### PR TITLE
Fix logging to write to files and add timezone support

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -192,6 +192,7 @@ class ConfigManager:
                 backup_count=logging_raw.get("backup_count", 7),  # Keep 7 backups
                 when=logging_raw.get("when", "midnight"),  # Rotate at midnight
                 interval=logging_raw.get("interval", 1),  # Every 1 day
+                timezone=logging_raw.get("timezone", "local"),  # Default to local time
             )
 
             return AppConfig(

--- a/config/models.py
+++ b/config/models.py
@@ -92,6 +92,7 @@ class LoggingConfig:
     backup_count: int  # Number of backup files to keep
     when: str  # For time-based rotation: "midnight", "H" (hourly), "D" (daily), "W0" (Monday)
     interval: int  # Interval for time-based rotation
+    timezone: str  # Timezone for log timestamps (e.g., "America/New_York", "UTC", or "local")
 
 
 @dataclass

--- a/config/risk_config.yaml
+++ b/config/risk_config.yaml
@@ -178,6 +178,7 @@ logging:
   level: INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
   json: true  # Output structured JSON logs
   file: ./data/logs/live_risk.log
+  timezone: "America/New_York"  # Timezone for log timestamps ("local", "UTC", or IANA timezone like "America/New_York")
 
 # Position reconciliation settings
 reconciliation:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,23 @@
 """Utility modules."""
 
+from .logging_setup import (
+    setup_category_logging,
+    setup_logging,
+    flush_all_loggers,
+    reset_session_run_number,
+    set_log_timezone,
+    get_log_timezone,
+    get_current_timestamp,
+)
 from .structured_logger import StructuredLogger
-from .logging_setup import setup_category_logging, setup_logging
 
-__all__ = ["StructuredLogger", "setup_category_logging", "setup_logging"]
+__all__ = [
+    "StructuredLogger",
+    "setup_category_logging",
+    "setup_logging",
+    "flush_all_loggers",
+    "reset_session_run_number",
+    "set_log_timezone",
+    "get_log_timezone",
+    "get_current_timestamp",
+]

--- a/src/utils/structured_logger.py
+++ b/src/utils/structured_logger.py
@@ -5,14 +5,16 @@ Provides structured logging with:
 - JSON output format
 - Log categories (SYSTEM, RISK, TRADING, DATA, ALERT)
 - Standard schema for log entries
+- Configurable timezone support (via logging_setup.set_log_timezone)
 """
 
 from __future__ import annotations
 import json
 import logging
 from typing import Dict, Any
-from datetime import datetime
 from enum import Enum
+
+from .logging_setup import get_current_timestamp
 
 
 class LogCategory(Enum):
@@ -64,7 +66,7 @@ class StructuredLogger:
             data: Optional additional data dict.
         """
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": get_current_timestamp(),
             "level": level.upper(),
             "category": category.value,
             "message": message,


### PR DESCRIPTION
- Create new log file with incremental run number on each program start (e.g., live_risk_dev_sys_2025-11-28_1.log, _2.log, _3.log)
- Add configurable timezone for log timestamps (local, UTC, or IANA timezone)
- Add flush_all_loggers() to ensure logs are written on shutdown
- Add set_log_timezone() and get_current_timestamp() utilities
- Update config to support logging.timezone setting (default: America/New_York)

