### PR TITLE
Summary — Regime × Dual-MACD Interaction Upgrade

### DIFF
--- a/config/regime_weights.yaml
+++ b/config/regime_weights.yaml
@@ -1,11 +1,9 @@
-generated_at: '2026-01-28T00:42:14.838794'
+generated_at: '2026-01-29T00:00:00.000000'
 method: logistic_regression
-version: '1.0'
+version: '2.0'
 weights:
-  breadth: 0.14264950840414745
-  macd_momentum: 0.03694472914625503
-  macd_trend: 0.10736625808312346
-  momentum: 0.3266440758464334
-  trend: 0.13292827862154674
-  trend_short: 0.07387579439294535
-  volatility: 0.17959135550554853
+  breadth: 0.20
+  momentum: 0.35
+  trend: 0.13
+  trend_short: 0.10
+  volatility: 0.22

--- a/config/signals/rules.yaml
+++ b/config/signals/rules.yaml
@@ -56,102 +56,54 @@ momentum_rules:
       line_b: signal
     message_template: "{symbol} MACD bearish crossover"
 
-  # Dual MACD rules (overlapping 55/89 and 13/21)
-  dual_macd_trend_confirm_bullish:
+  # Dual MACD v1.0 rules (tactical dip/rally detection)
+  dual_macd_dip_buy:
     indicator: dual_macd
     direction: buy
-    strength: 75
+    strength: 80
     priority: high
     condition_type: state_change
     condition_config:
-      field: signal_type
-      from: [null]
-      to: [trend_confirmation_bullish]
-    message_template: "{symbol} DualMACD: Trend confirmed bullish (both histograms positive)"
+      field: tactical_signal
+      from: [NONE]
+      to: [DIP_BUY]
+    message_template: "{symbol} DualMACD: Dip buy (slow bullish, fast pulling back and turning)"
 
-  dual_macd_trend_confirm_bearish:
+  dual_macd_rally_sell:
     indicator: dual_macd
     direction: sell
-    strength: 75
+    strength: 80
     priority: high
     condition_type: state_change
     condition_config:
-      field: signal_type
-      from: [null]
-      to: [trend_confirmation_bearish]
-    message_template: "{symbol} DualMACD: Trend confirmed bearish (both histograms negative)"
+      field: tactical_signal
+      from: [NONE]
+      to: [RALLY_SELL]
+    message_template: "{symbol} DualMACD: Rally sell (slow bearish, fast bouncing and fading)"
 
-  dual_macd_momentum_entry_bullish:
+  dual_macd_trend_deteriorating:
     indicator: dual_macd
-    direction: buy
+    direction: alert
     strength: 70
     priority: high
     condition_type: state_change
     condition_config:
-      field: signal_type
-      from: [null]
-      to: [bullish_momentum_entry]
-    message_template: "{symbol} DualMACD: Bullish entry (short histogram up, long trend intact)"
+      field: trend_state
+      from: [BULLISH]
+      to: [DETERIORATING]
+    message_template: "{symbol} DualMACD: Trend deteriorating (slow histogram positive but falling)"
 
-  dual_macd_momentum_entry_bearish:
+  dual_macd_trend_improving:
     indicator: dual_macd
-    direction: sell
+    direction: alert
     strength: 70
     priority: high
     condition_type: state_change
     condition_config:
-      field: signal_type
-      from: [null]
-      to: [bearish_momentum_entry]
-    message_template: "{symbol} DualMACD: Bearish entry (short histogram down, long trend intact)"
-
-  dual_macd_divergence_bullish_warning:
-    indicator: dual_macd
-    direction: alert
-    strength: 65
-    priority: medium
-    condition_type: state_change
-    condition_config:
-      field: signal_type
-      from: [null]
-      to: [momentum_divergence_bullish_warning]
-    message_template: "{symbol} DualMACD: Bullish divergence warning (short positive, long negative)"
-
-  dual_macd_divergence_bearish_warning:
-    indicator: dual_macd
-    direction: alert
-    strength: 65
-    priority: medium
-    condition_type: state_change
-    condition_config:
-      field: signal_type
-      from: [null]
-      to: [momentum_divergence_bearish_warning]
-    message_template: "{symbol} DualMACD: Bearish divergence warning (short negative, long positive)"
-
-  dual_macd_overbought_in_uptrend:
-    indicator: dual_macd
-    direction: alert
-    strength: 60
-    priority: medium
-    condition_type: state_change
-    condition_config:
-      field: signal_type
-      from: [null]
-      to: [overbought_in_uptrend]
-    message_template: "{symbol} DualMACD: Overbought within uptrend (short stretched vs long)"
-
-  dual_macd_oversold_in_downtrend:
-    indicator: dual_macd
-    direction: alert
-    strength: 60
-    priority: medium
-    condition_type: state_change
-    condition_config:
-      field: signal_type
-      from: [null]
-      to: [oversold_in_downtrend]
-    message_template: "{symbol} DualMACD: Oversold within downtrend (short stretched vs long)"
+      field: trend_state
+      from: [BEARISH]
+      to: [IMPROVING]
+    message_template: "{symbol} DualMACD: Trend improving (slow histogram negative but rising)"
 
 # Trend rules
 trend_rules:

--- a/src/domain/signals/indicators/regime/regime_detector.py
+++ b/src/domain/signals/indicators/regime/regime_detector.py
@@ -360,8 +360,6 @@ class RegimeDetectorIndicator(IndicatorBase):
                 "composite_score": scored["score"].values,
                 "composite_trend": scored["trend"].values,
                 "composite_trend_short": scored["trend_short"].values,
-                "composite_macd_trend": scored["macd_trend"].values,
-                "composite_macd_momentum": scored["macd_momentum"].values,
                 "composite_momentum": scored["momentum"].values,
                 "composite_volatility": scored["volatility"].values,
                 "composite_breadth": scored["breadth"].values,
@@ -579,16 +577,6 @@ class RegimeDetectorIndicator(IndicatorBase):
                 "composite_trend_short": (
                     self._safe_float(current.get("composite_trend_short"))
                     if pd.notna(current.get("composite_trend_short"))
-                    else None
-                ),
-                "composite_macd_trend": (
-                    self._safe_float(current.get("composite_macd_trend"))
-                    if pd.notna(current.get("composite_macd_trend"))
-                    else None
-                ),
-                "composite_macd_momentum": (
-                    self._safe_float(current.get("composite_macd_momentum"))
-                    if pd.notna(current.get("composite_macd_momentum"))
                     else None
                 ),
                 "composite_momentum": (
@@ -1382,8 +1370,6 @@ class RegimeDetectorIndicator(IndicatorBase):
                 {
                     "trend": flat_state.get("composite_trend"),
                     "trend_short": flat_state.get("composite_trend_short"),
-                    "macd_trend": flat_state.get("composite_macd_trend"),
-                    "macd_momentum": flat_state.get("composite_macd_momentum"),
                     "momentum": flat_state.get("composite_momentum"),
                     "volatility": flat_state.get("composite_volatility"),
                     "breadth": flat_state.get("composite_breadth"),

--- a/src/domain/signals/indicators/regime/train_weights.py
+++ b/src/domain/signals/indicators/regime/train_weights.py
@@ -195,12 +195,10 @@ def train_and_validate(
     # Learn weights
     logger.info(f"Learning weights using {method}...")
     learner = WeightLearner(method=method)
-    # All 7 Phase 5 factors (must match CompositeWeights)
+    # All 5 Phase 5 factors (must match CompositeWeights)
     factor_cols = [
         "trend",
         "trend_short",
-        "macd_trend",
-        "macd_momentum",
         "momentum",
         "volatility",
         "breadth",

--- a/src/domain/signals/indicators/regime/weight_learner.py
+++ b/src/domain/signals/indicators/regime/weight_learner.py
@@ -202,15 +202,13 @@ class WeightLearner:
         # Build weights dict
         weights_dict = dict(zip(X.columns, norm_weights))
 
-        # Fill missing with default (all 7 Phase 5 factors)
+        # Fill missing with default (all 5 Phase 5 factors)
         default_weights = {
-            "trend": 0.10,
-            "trend_short": 0.08,
-            "macd_trend": 0.12,
-            "macd_momentum": 0.10,
-            "momentum": 0.28,
-            "volatility": 0.17,
-            "breadth": 0.15,
+            "trend": 0.13,
+            "trend_short": 0.10,
+            "momentum": 0.35,
+            "volatility": 0.22,
+            "breadth": 0.20,
         }
         for k in default_weights:
             if k not in weights_dict:
@@ -270,15 +268,13 @@ class WeightLearner:
 
         weights_dict = dict(zip(X.columns, result.x))
 
-        # Fill missing with all 7 Phase 5 factors
+        # Fill missing with all 5 Phase 5 factors
         default_weights = {
-            "trend": 0.10,
-            "trend_short": 0.08,
-            "macd_trend": 0.12,
-            "macd_momentum": 0.10,
-            "momentum": 0.28,
-            "volatility": 0.17,
-            "breadth": 0.15,
+            "trend": 0.13,
+            "trend_short": 0.10,
+            "momentum": 0.35,
+            "volatility": 0.22,
+            "breadth": 0.20,
         }
         for k in default_weights:
             if k not in weights_dict:

--- a/src/infrastructure/reporting/package/data_aggregator.py
+++ b/src/infrastructure/reporting/package/data_aggregator.py
@@ -80,7 +80,7 @@ def df_to_chart_data(df: pd.DataFrame) -> Dict[str, Any]:
         elif ind_name == "rsi":
             chart_data["rsi"][col] = values
         elif ind_name == "dual" and col.startswith("dual_macd"):
-            # DualMACD indicator (dual_macd_long_histogram, dual_macd_short_histogram, etc.)
+            # DualMACD indicator (dual_macd_slow_histogram, dual_macd_fast_histogram, etc.)
             chart_data["dual_macd"][col] = values
         elif ind_name == "macd":
             chart_data["macd"][col] = values

--- a/src/infrastructure/reporting/package/html_assets.py
+++ b/src/infrastructure/reporting/package/html_assets.py
@@ -138,6 +138,17 @@ def build_index_html(
         </div>
 
         <div class="section">
+            <h2 class="section-header" onclick="toggleSection('dual-macd-history-content')">
+                <span class="toggle-icon">&#9660;</span> DualMACD
+            </h2>
+            <div id="dual-macd-history-content" class="section-content">
+                <div id="dual-macd-history-table">
+                    <div style="color: #94a3b8; padding: 16px;">Loading DualMACD state...</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="section">
             <h2 class="section-header" onclick="toggleSection('regime-content')">
                 <span class="toggle-icon">&#9660;</span> Regime Analysis
             </h2>

--- a/src/infrastructure/reporting/regime/components.py
+++ b/src/infrastructure/reporting/regime/components.py
@@ -17,20 +17,16 @@ from .utils import get_score_gradient_color
 
 # Factor weights (must match composite_scorer.py)
 FACTOR_WEIGHTS = {
-    "trend": 0.10,
-    "trend_short": 0.08,
-    "macd_trend": 0.12,
-    "macd_momentum": 0.10,
-    "momentum": 0.28,
-    "volatility": 0.17,
-    "breadth": 0.15,
+    "trend": 0.13,
+    "trend_short": 0.10,
+    "momentum": 0.35,
+    "volatility": 0.22,
+    "breadth": 0.20,
 }
 
 FACTOR_INFO = [
     ("trend", "📈", "Trend (Long)"),
     ("trend_short", "🔥", "Trend (Short)"),
-    ("macd_trend", "📊", "MACD Trend"),
-    ("macd_momentum", "⚡", "MACD Momentum"),
     ("momentum", "🚀", "Momentum"),
     ("volatility", "📉", "Volatility"),
     ("breadth", "🌐", "Breadth"),
@@ -252,8 +248,6 @@ def _render_momentum_tile(factors: Dict[str, Optional[float]], theme: str) -> st
     muted = "#94a3b8" if theme == "dark" else "#64748b"
     border = "#334155" if theme == "dark" else "#e2e8f0"
 
-    macd_t = (factors.get("macd_trend", 0) or 0) * 100
-    macd_m = (factors.get("macd_momentum", 0) or 0) * 100
     rsi = (factors.get("momentum", 0) or 0) * 100
 
     return f"""
@@ -267,14 +261,6 @@ def _render_momentum_tile(factors: Dict[str, Optional[float]], theme: str) -> st
             🚀 MOMENTUM
         </div>
         <div style="font-size: 11px; color: {muted};">
-            <div style="margin-bottom: 6px;">
-                <strong style="color: {text};">MACD Trend ({macd_t:.0f})</strong><br>
-                <code style="font-size: 10px;">EMA55-EMA89 hist</code> → pctl
-            </div>
-            <div style="margin-bottom: 6px;">
-                <strong style="color: {text};">MACD Mom ({macd_m:.0f})</strong><br>
-                <code style="font-size: 10px;">EMA13-EMA21 hist</code> → pctl
-            </div>
             <div>
                 <strong style="color: {text};">RSI ({rsi:.0f})</strong><br>
                 <code style="font-size: 10px;">RSI(14)</code> → pctl (63d)

--- a/src/infrastructure/reporting/regime/header.py
+++ b/src/infrastructure/reporting/regime/header.py
@@ -187,20 +187,6 @@ def _render_component_breakdown(
             "formula": "(EMA₁₀ - EMA₂₀) / EMA₂₀ → percentile rank",
             "interpretation": "Higher = recent momentum acceleration",
         },
-        "macd_trend": {
-            "label": "MACD Trend",
-            "icon": "📉",
-            "description": "Long MACD (55/89) histogram, percentile ranked",
-            "formula": "(EMA₅₅ - EMA₈₉) - Signal₉ → percentile rank",
-            "interpretation": "Higher = stronger trend direction",
-        },
-        "macd_momentum": {
-            "label": "MACD Momentum",
-            "icon": "⚡",
-            "description": "Short MACD (13/21) histogram, percentile ranked",
-            "formula": "(EMA₁₃ - EMA₂₁) - Signal₉ → percentile rank",
-            "interpretation": "Higher = momentum timing within trend",
-        },
         "momentum": {
             "label": "RSI Momentum",
             "icon": "💪",
@@ -228,8 +214,6 @@ def _render_component_breakdown(
     for factor_key in [
         "trend",
         "trend_short",
-        "macd_trend",
-        "macd_momentum",
         "momentum",
         "volatility",
         "breadth",
@@ -318,7 +302,7 @@ def _render_component_breakdown(
     <div style="margin-top: 12px; padding: 10px; background: {border_color}; border-radius: 6px;">
         <div style="font-size: 11px; color: {muted_color}; margin-bottom: 4px;">COMPOSITE FORMULA</div>
         <code style="font-size: 10px; color: {text_color};">
-            Score = 0.10×Trend + 0.08×TrendShort + 0.12×MACDTrend + 0.10×MACDMom + 0.28×RSI + 0.17×(1-Vol) + 0.15×Breadth
+            Score = 0.13×Trend + 0.10×TrendShort + 0.35×RSI + 0.22×(1-Vol) + 0.20×Breadth
         </code>
         <div style="font-size: 11px; color: {muted_color}; margin-top: 8px;">
             • Score ≥70 → R0 (Healthy) | Score 30-70 → R1 (Choppy) | Score ≤30 → R2 (Risk-Off)
@@ -404,13 +388,11 @@ def generate_composite_score_html(regime_output: RegimeOutput, theme: str = "dar
     component_html = ""
     if composite_factors:
         weights = {
-            "trend": 0.10,
-            "trend_short": 0.08,
-            "macd_trend": 0.12,
-            "macd_momentum": 0.10,
-            "momentum": 0.28,
-            "volatility": 0.17,
-            "breadth": 0.15,
+            "trend": 0.13,
+            "trend_short": 0.10,
+            "momentum": 0.35,
+            "volatility": 0.22,
+            "breadth": 0.20,
         }
         component_html = _render_component_breakdown(
             composite_factors, weights, composite_score, theme
@@ -478,7 +460,7 @@ def generate_composite_score_html(regime_output: RegimeOutput, theme: str = "dar
                     {score_label}
                 </div>
                 <div style="font-size: 12px; color: {muted_color}; margin-top: 4px;">
-                    Based on 7 calibrated factors
+                    Based on 5 calibrated factors
                 </div>
             </div>
         </div>

--- a/src/infrastructure/reporting/signal_report/dual_macd_section.py
+++ b/src/infrastructure/reporting/signal_report/dual_macd_section.py
@@ -1,0 +1,238 @@
+"""
+DualMACD Historical State Section - Collapsible table for signal verification.
+
+Renders a per-symbol, per-timeframe table showing the last N bars of DualMACD state:
+  Date | H_slow | H_fast | ΔH_slow | ΔH_fast | Trend State | Tactical | Mom.Bal | Conf
+
+Row color coding:
+  - DIP_BUY rows: green-10% background
+  - RALLY_SELL rows: red-10% background
+  - DETERIORATING trend: amber cell
+  - IMPROVING trend: teal cell
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+
+from src.domain.signals.indicators.momentum.dual_macd import DualMACDIndicator
+
+
+def compute_dual_macd_history(
+    data: Dict[Tuple[str, str], pd.DataFrame],
+    last_n_bars: int = 60,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Compute DualMACD state for each (symbol, timeframe) pair.
+
+    Args:
+        data: Dict mapping (symbol, timeframe) to OHLCV+indicator DataFrame
+        last_n_bars: Number of most recent bars to include
+
+    Returns:
+        Dict mapping "{symbol}_{timeframe}" to list of state dicts (newest first)
+    """
+    indicator = DualMACDIndicator()
+    params = indicator.default_params
+    history: Dict[str, List[Dict[str, Any]]] = {}
+
+    for (symbol, timeframe), df in data.items():
+        if len(df) < indicator.warmup_periods:
+            continue
+
+        # Calculate indicator on close prices
+        close_df = df[["close"]].copy()
+        result = indicator.calculate(close_df, params)
+
+        if result.empty:
+            continue
+
+        # Extract last N bars of state
+        start_idx = max(0, len(result) - last_n_bars)
+        rows: List[Dict[str, Any]] = []
+
+        for i in range(start_idx, len(result)):
+            current = result.iloc[i]
+            previous = result.iloc[i - 1] if i > 0 else None
+            state = indicator._get_state(current, previous, params)
+
+            # Add timestamp
+            ts = result.index[i]
+            date_str = ts.strftime("%Y-%m-%d %H:%M") if hasattr(ts, "strftime") else str(ts)
+
+            rows.append(
+                {
+                    "date": date_str,
+                    **state,
+                }
+            )
+
+        # Reverse so newest is first
+        rows.reverse()
+
+        key = f"{symbol}_{timeframe}"
+        history[key] = rows
+
+    return history
+
+
+def render_dual_macd_history_html(
+    history: Dict[str, List[Dict[str, Any]]],
+    theme: str = "dark",
+) -> str:
+    """
+    Render DualMACD historical state as a collapsible HTML section.
+
+    Each (symbol, timeframe) pair gets a sub-section filtered by JavaScript
+    based on the active symbol/timeframe selection.
+
+    Args:
+        history: Dict from compute_dual_macd_history()
+        theme: Color theme
+
+    Returns:
+        HTML string for the DualMACD history section
+    """
+    if not history:
+        return ""
+
+    # Theme colors
+    bg = "#0f172a" if theme == "dark" else "#ffffff"
+    text = "#e2e8f0" if theme == "dark" else "#1e293b"
+    muted = "#94a3b8" if theme == "dark" else "#64748b"
+    border = "#334155" if theme == "dark" else "#e2e8f0"
+    header_bg = "#1e293b" if theme == "dark" else "#f1f5f9"
+
+    # Row background colors for tactical signals
+    row_colors = {
+        "DIP_BUY": "rgba(16, 185, 129, 0.10)",
+        "RALLY_SELL": "rgba(239, 68, 68, 0.10)",
+        "NONE": "transparent",
+    }
+
+    # Trend state cell colors
+    trend_colors = {
+        "BULLISH": "#10b981",
+        "BEARISH": "#ef4444",
+        "DETERIORATING": "#f59e0b",
+        "IMPROVING": "#06b6d4",
+    }
+
+    # Build tables for each symbol_timeframe
+    tables_html = []
+    for key, rows in sorted(history.items()):
+        if not rows:
+            continue
+
+        # Parse symbol_timeframe
+        parts = key.rsplit("_", 1)
+        symbol = parts[0] if len(parts) == 2 else key
+        timeframe = parts[1] if len(parts) == 2 else ""
+
+        body_rows = []
+        for row in rows:
+            tactical = row.get("tactical_signal", "NONE")
+            trend = row.get("trend_state", "BEARISH")
+            row_bg = row_colors.get(tactical, "transparent")
+            trend_color = trend_colors.get(trend, muted)
+            confidence = row.get("confidence", 0.0)
+
+            # Format tactical signal with color
+            if tactical == "DIP_BUY":
+                tactical_html = f'<span style="color: #10b981; font-weight: 600;">DIP_BUY</span>'
+            elif tactical == "RALLY_SELL":
+                tactical_html = f'<span style="color: #ef4444; font-weight: 600;">RALLY_SELL</span>'
+            else:
+                tactical_html = f'<span style="color: {muted};">—</span>'
+
+            # Confidence bar
+            conf_pct = int(confidence * 100)
+            conf_color = "#10b981" if conf_pct >= 50 else "#f59e0b" if conf_pct >= 25 else muted
+            conf_html = (
+                f'<div style="display:flex;align-items:center;gap:4px;">'
+                f'<div style="width:40px;height:6px;background:{border};border-radius:3px;overflow:hidden;">'
+                f'<div style="width:{conf_pct}%;height:100%;background:{conf_color};"></div>'
+                f"</div>"
+                f'<span style="font-size:10px;">{conf_pct}</span>'
+                f"</div>"
+            )
+
+            body_rows.append(f"""
+                <tr style="background:{row_bg};border-bottom:1px solid {border};">
+                    <td style="padding:4px 8px;font-size:11px;white-space:nowrap;">{row['date']}</td>
+                    <td style="padding:4px 6px;text-align:right;font-family:monospace;font-size:11px;">
+                        {row['slow_histogram']:+.3f}
+                    </td>
+                    <td style="padding:4px 6px;text-align:right;font-family:monospace;font-size:11px;">
+                        {row['fast_histogram']:+.3f}
+                    </td>
+                    <td style="padding:4px 6px;text-align:right;font-family:monospace;font-size:11px;">
+                        {row['slow_hist_delta']:+.3f}
+                    </td>
+                    <td style="padding:4px 6px;text-align:right;font-family:monospace;font-size:11px;">
+                        {row['fast_hist_delta']:+.3f}
+                    </td>
+                    <td style="padding:4px 6px;color:{trend_color};font-weight:500;font-size:11px;">
+                        {trend}
+                    </td>
+                    <td style="padding:4px 6px;font-size:11px;">{tactical_html}</td>
+                    <td style="padding:4px 6px;font-size:11px;color:{muted};">
+                        {row.get('momentum_balance', '—')}
+                    </td>
+                    <td style="padding:4px 6px;font-size:11px;">{conf_html}</td>
+                </tr>
+            """)
+
+        table_html = f"""
+        <div class="dual-macd-table" data-symbol="{symbol}" data-timeframe="{timeframe}"
+             style="display:none;">
+            <div style="overflow-x:auto;">
+                <table style="width:100%;border-collapse:collapse;color:{text};font-size:12px;">
+                    <thead>
+                        <tr style="background:{header_bg};border-bottom:2px solid {border};">
+                            <th style="padding:6px 8px;text-align:left;font-size:11px;color:{muted};">Date</th>
+                            <th style="padding:6px 6px;text-align:right;font-size:11px;color:{muted};">H_slow</th>
+                            <th style="padding:6px 6px;text-align:right;font-size:11px;color:{muted};">H_fast</th>
+                            <th style="padding:6px 6px;text-align:right;font-size:11px;color:{muted};">\u0394H_slow</th>
+                            <th style="padding:6px 6px;text-align:right;font-size:11px;color:{muted};">\u0394H_fast</th>
+                            <th style="padding:6px 6px;text-align:left;font-size:11px;color:{muted};">Trend</th>
+                            <th style="padding:6px 6px;text-align:left;font-size:11px;color:{muted};">Tactical</th>
+                            <th style="padding:6px 6px;text-align:left;font-size:11px;color:{muted};">Mom.Bal</th>
+                            <th style="padding:6px 6px;text-align:left;font-size:11px;color:{muted};">Conf</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {''.join(body_rows)}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        """
+        tables_html.append(table_html)
+
+    return f"""
+    <div class="dual-macd-history-section">
+        <h2 class="section-header" onclick="toggleSection('dual-macd-history-content')">
+            <span class="toggle-icon">\u25b6</span> DualMACD Historical State
+        </h2>
+        <div id="dual-macd-history-content" class="section-content collapsed">
+            <div style="
+                background: {bg};
+                border: 1px solid {border};
+                border-radius: 8px;
+                padding: 16px;
+            ">
+                <div style="font-size:12px;color:{muted};margin-bottom:12px;">
+                    Last 60 bars \u00b7 Newest first \u00b7
+                    <span style="display:inline-block;width:10px;height:10px;background:rgba(16,185,129,0.10);border:1px solid #10b981;border-radius:2px;vertical-align:middle;"></span> DIP_BUY
+                    <span style="display:inline-block;width:10px;height:10px;background:rgba(239,68,68,0.10);border:1px solid #ef4444;border-radius:2px;vertical-align:middle;margin-left:8px;"></span> RALLY_SELL
+                </div>
+                <div id="dual-macd-tables-container">
+                    {''.join(tables_html)}
+                </div>
+            </div>
+        </div>
+    </div>
+    """

--- a/src/infrastructure/reporting/signal_report/plotly_scripts.py
+++ b/src/infrastructure/reporting/signal_report/plotly_scripts.py
@@ -75,6 +75,20 @@ function updateChart() {{
     updateSignalHistoryTable();
     updateConfluencePanel();
     updateRegimeSection();
+    updateDualMACDHistory();
+}}
+
+function updateDualMACDHistory() {{
+    // Hide all DualMACD tables
+    const tables = document.querySelectorAll('.dual-macd-table');
+    tables.forEach(t => {{ t.style.display = 'none'; }});
+
+    // Show matching symbol + timeframe
+    tables.forEach(t => {{
+        if (t.dataset.symbol === currentSymbol && t.dataset.timeframe === currentTimeframe) {{
+            t.style.display = 'block';
+        }}
+    }});
 }}
 
 function updateRegimeSection() {{
@@ -174,39 +188,39 @@ function renderMainChart(data) {{
 
     // Row 3: MACD subplot (DualMACD if available, else standard MACD)
     const hasDualMACD = data.dual_macd && (
-        hasData(data.dual_macd['dual_macd_long_histogram']) ||
-        hasData(data.dual_macd['dual_macd_short_histogram'])
+        hasData(data.dual_macd['dual_macd_slow_histogram']) ||
+        hasData(data.dual_macd['dual_macd_fast_histogram'])
     );
 
     if (hasDualMACD) {{
-        // DualMACD: Overlay long (55/89) and short (13/21) histograms
-        const longHist = data.dual_macd['dual_macd_long_histogram'];
-        const shortHist = data.dual_macd['dual_macd_short_histogram'];
+        // DualMACD: Overlay slow (55/89) and fast (13/21) histograms
+        const slowHist = data.dual_macd['dual_macd_slow_histogram'];
+        const fastHist = data.dual_macd['dual_macd_fast_histogram'];
 
-        // Long MACD histogram (trend direction) - wider bars, more transparent
-        if (hasData(longHist)) {{
-            const longColors = longHist.map(v => v >= 0 ? 'rgba(16, 185, 129, 0.4)' : 'rgba(239, 68, 68, 0.4)');
+        // Slow MACD histogram (structural trend) - wider bars, more transparent
+        if (hasData(slowHist)) {{
+            const slowColors = slowHist.map(v => v >= 0 ? 'rgba(16, 185, 129, 0.4)' : 'rgba(239, 68, 68, 0.4)');
             traces.push({{
                 type: 'bar',
                 x: xValues,
-                y: longHist,
-                name: 'Long MACD (55/89)',
-                marker: {{ color: longColors }},
+                y: slowHist,
+                name: 'Slow MACD (55/89)',
+                marker: {{ color: slowColors }},
                 xaxis: 'x',
                 yaxis: 'y3',
                 width: isIntraday ? 0.8 : 86400000 * 0.8,
             }});
         }}
 
-        // Short MACD histogram (momentum timing) - narrower bars, more opaque
-        if (hasData(shortHist)) {{
-            const shortColors = shortHist.map(v => v >= 0 ? 'rgba(59, 130, 246, 0.8)' : 'rgba(249, 115, 22, 0.8)');
+        // Fast MACD histogram (tactical timing) - narrower bars, more opaque
+        if (hasData(fastHist)) {{
+            const fastColors = fastHist.map(v => v >= 0 ? 'rgba(59, 130, 246, 0.8)' : 'rgba(249, 115, 22, 0.8)');
             traces.push({{
                 type: 'bar',
                 x: xValues,
-                y: shortHist,
-                name: 'Short MACD (13/21)',
-                marker: {{ color: shortColors }},
+                y: fastHist,
+                name: 'Fast MACD (13/21)',
+                marker: {{ color: fastColors }},
                 xaxis: 'x',
                 yaxis: 'y3',
                 width: isIntraday ? 0.4 : 86400000 * 0.4,
@@ -788,5 +802,6 @@ document.addEventListener('DOMContentLoaded', () => {{
     updateSignalHistoryTable();
     updateConfluencePanel();
     updateRegimeSection();
+    updateDualMACDHistory();
 }});
 """

--- a/src/infrastructure/reporting/signal_report/regime_renderer.py
+++ b/src/infrastructure/reporting/signal_report/regime_renderer.py
@@ -156,16 +156,6 @@ def compute_regime_outputs(
                     if pd.notna(last_row.get("composite_volatility"))
                     else None
                 ),
-                "composite_macd_trend": (
-                    float(last_row.get("composite_macd_trend", 0.5))
-                    if pd.notna(last_row.get("composite_macd_trend"))
-                    else None
-                ),
-                "composite_macd_momentum": (
-                    float(last_row.get("composite_macd_momentum", 0.5))
-                    if pd.notna(last_row.get("composite_macd_momentum"))
-                    else None
-                ),
             }
 
             # Compute full regime output with hysteresis

--- a/tests/unit/signals/test_dual_macd.py
+++ b/tests/unit/signals/test_dual_macd.py
@@ -1,0 +1,271 @@
+"""
+Tests for DualMACD v1.0 indicator.
+
+Covers:
+1. Contract: output contains all required state keys
+2. Logic: Synthetic series triggering DIP_BUY and RALLY_SELL
+3. Isolation: CompositeScore payload has zero macd_ keys
+4. No-lookahead: Rolling percentile uses only past window
+5. Behavioral consistency: DETERIORATING trend state
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def dual_macd_indicator():
+    """Get DualMACD indicator instance."""
+    from src.domain.signals.indicators.momentum.dual_macd import DualMACDIndicator
+
+    return DualMACDIndicator()
+
+
+@pytest.fixture
+def long_ohlcv_data() -> pd.DataFrame:
+    """Generate 300-bar OHLCV data for full warmup."""
+    np.random.seed(42)
+    n = 300
+    dates = pd.date_range("2024-01-01", periods=n, freq="1h")
+    base_price = 100.0
+    returns = np.random.randn(n) * 0.01
+    close = base_price * np.exp(np.cumsum(returns))
+    high = close * (1 + np.abs(np.random.randn(n) * 0.005))
+    low = close * (1 - np.abs(np.random.randn(n) * 0.005))
+    volume = np.random.randint(1000, 10000, n).astype(float)
+
+    return pd.DataFrame(
+        {"open": (high + low) / 2, "high": high, "low": low, "close": close, "volume": volume},
+        index=dates,
+    )
+
+
+class TestDualMACDContract:
+    """Output contains all required keys from spec."""
+
+    def test_state_keys_present(
+        self, dual_macd_indicator: Any, long_ohlcv_data: pd.DataFrame
+    ) -> None:
+        """State dict must contain all 8 required keys."""
+        result = dual_macd_indicator.calculate(
+            long_ohlcv_data[["close"]], dual_macd_indicator.default_params
+        )
+        current = result.iloc[-1]
+        previous = result.iloc[-2]
+        state = dual_macd_indicator._get_state(
+            current, previous, dual_macd_indicator.default_params
+        )
+
+        required_keys = {
+            "slow_histogram",
+            "fast_histogram",
+            "slow_hist_delta",
+            "fast_hist_delta",
+            "trend_state",
+            "tactical_signal",
+            "momentum_balance",
+            "confidence",
+        }
+        assert required_keys == set(
+            state.keys()
+        ), f"Missing keys: {required_keys - set(state.keys())}"
+
+    def test_no_none_values_in_state(
+        self, dual_macd_indicator: Any, long_ohlcv_data: pd.DataFrame
+    ) -> None:
+        """No state values should be None after warmup."""
+        result = dual_macd_indicator.calculate(
+            long_ohlcv_data[["close"]], dual_macd_indicator.default_params
+        )
+        current = result.iloc[-1]
+        previous = result.iloc[-2]
+        state = dual_macd_indicator._get_state(
+            current, previous, dual_macd_indicator.default_params
+        )
+
+        for key, value in state.items():
+            assert value is not None, f"State[{key}] is None"
+
+    def test_trend_state_enum_values(
+        self, dual_macd_indicator: Any, long_ohlcv_data: pd.DataFrame
+    ) -> None:
+        """trend_state must be one of the 4 valid values."""
+        result = dual_macd_indicator.calculate(
+            long_ohlcv_data[["close"]], dual_macd_indicator.default_params
+        )
+        current = result.iloc[-1]
+        state = dual_macd_indicator._get_state(current, None, dual_macd_indicator.default_params)
+        valid = {"BULLISH", "BEARISH", "IMPROVING", "DETERIORATING"}
+        assert state["trend_state"] in valid
+
+    def test_tactical_signal_enum_values(
+        self, dual_macd_indicator: Any, long_ohlcv_data: pd.DataFrame
+    ) -> None:
+        """tactical_signal must be one of 3 valid values."""
+        result = dual_macd_indicator.calculate(
+            long_ohlcv_data[["close"]], dual_macd_indicator.default_params
+        )
+        current = result.iloc[-1]
+        state = dual_macd_indicator._get_state(current, None, dual_macd_indicator.default_params)
+        valid = {"DIP_BUY", "RALLY_SELL", "NONE"}
+        assert state["tactical_signal"] in valid
+
+    def test_confidence_range(
+        self, dual_macd_indicator: Any, long_ohlcv_data: pd.DataFrame
+    ) -> None:
+        """Confidence must be in [0, 1]."""
+        result = dual_macd_indicator.calculate(
+            long_ohlcv_data[["close"]], dual_macd_indicator.default_params
+        )
+        current = result.iloc[-1]
+        state = dual_macd_indicator._get_state(current, None, dual_macd_indicator.default_params)
+        assert 0.0 <= state["confidence"] <= 1.0
+
+
+class TestDualMACDLogic:
+    """Synthetic series triggering specific signals."""
+
+    def test_dip_buy_conditions(self, dual_macd_indicator: Any) -> None:
+        """DIP_BUY fires when H_slow>0, H_fast<0, |ΔH_fast|>|ΔH_slow|, ΔH_fast>=0."""
+        # Directly construct a row satisfying DIP_BUY conditions
+        row = pd.Series(
+            {
+                "slow_histogram": 5.0,  # H_slow > 0
+                "fast_histogram": -2.0,  # H_fast < 0
+                "slow_hist_delta": 0.1,  # small ΔH_slow
+                "fast_hist_delta": 0.5,  # |0.5| > |0.1| and >= 0
+                "fast_hist_delta2": 0.3,  # positive curvature
+                "slow_hist_norm": 0.5,
+                "fast_hist_norm": 0.5,
+            }
+        )
+        state = dual_macd_indicator._get_state(row, None, dual_macd_indicator.default_params)
+        assert state["tactical_signal"] == "DIP_BUY"
+        assert state["confidence"] > 0.0
+
+    def test_rally_sell_conditions(self, dual_macd_indicator: Any) -> None:
+        """RALLY_SELL fires when H_slow<0, H_fast>0, |ΔH_fast|>|ΔH_slow|, ΔH_fast<=0."""
+        row = pd.Series(
+            {
+                "slow_histogram": -5.0,  # H_slow < 0
+                "fast_histogram": 2.0,  # H_fast > 0
+                "slow_hist_delta": -0.1,  # small ΔH_slow
+                "fast_hist_delta": -0.5,  # |0.5| > |0.1| and <= 0
+                "fast_hist_delta2": -0.3,  # negative curvature
+                "slow_hist_norm": 0.5,
+                "fast_hist_norm": 0.5,
+            }
+        )
+        state = dual_macd_indicator._get_state(row, None, dual_macd_indicator.default_params)
+        assert state["tactical_signal"] == "RALLY_SELL"
+        assert state["confidence"] > 0.0
+
+    def test_deteriorating_state(self, dual_macd_indicator: Any) -> None:
+        """DETERIORATING fires when H_slow>0 and ΔH_slow<0."""
+        row = pd.Series(
+            {
+                "slow_histogram": 3.0,  # H_slow > 0
+                "fast_histogram": -1.0,
+                "slow_hist_delta": -0.5,  # ΔH_slow < 0 → deteriorating
+                "fast_hist_delta": 0.0,
+                "fast_hist_delta2": 0.0,
+                "slow_hist_norm": 0.5,
+                "fast_hist_norm": 0.5,
+            }
+        )
+        state = dual_macd_indicator._get_state(row, None, dual_macd_indicator.default_params)
+        assert state["trend_state"] == "DETERIORATING"
+
+    def test_improving_state(self, dual_macd_indicator: Any) -> None:
+        """IMPROVING fires when H_slow<0 and ΔH_slow>0."""
+        row = pd.Series(
+            {
+                "slow_histogram": -3.0,
+                "fast_histogram": 1.0,
+                "slow_hist_delta": 0.5,  # ΔH_slow > 0 → improving
+                "fast_hist_delta": 0.0,
+                "fast_hist_delta2": 0.0,
+                "slow_hist_norm": 0.5,
+                "fast_hist_norm": 0.5,
+            }
+        )
+        state = dual_macd_indicator._get_state(row, None, dual_macd_indicator.default_params)
+        assert state["trend_state"] == "IMPROVING"
+
+
+class TestCompositeScoreIsolation:
+    """CompositeScore should have zero macd_ keys."""
+
+    def test_no_macd_in_composite_weights(self) -> None:
+        """CompositeWeights should not contain macd fields."""
+        from src.domain.signals.indicators.regime.composite_scorer import CompositeWeights
+
+        w = CompositeWeights()
+        d = w.to_dict()
+        macd_keys = [k for k in d if "macd" in k]
+        assert macd_keys == [], f"Found macd keys in CompositeWeights: {macd_keys}"
+
+    def test_no_macd_in_normalized_factors(self) -> None:
+        """NormalizedFactors should not have macd fields."""
+        import dataclasses
+
+        from src.domain.signals.indicators.regime.factor_normalizer import NormalizedFactors
+
+        field_names = [f.name for f in dataclasses.fields(NormalizedFactors)]
+        macd_fields = [f for f in field_names if "macd" in f]
+        assert macd_fields == [], f"Found macd fields in NormalizedFactors: {macd_fields}"
+
+    def test_composite_score_output_no_macd(self) -> None:
+        """score_and_classify output should have no macd_ columns."""
+        from src.domain.signals.indicators.regime.composite_scorer import CompositeRegimeScorer
+
+        np.random.seed(42)
+        n = 300
+        close = 100 + np.cumsum(np.random.randn(n) * 0.5)
+        high = close + np.abs(np.random.randn(n))
+        low = close - np.abs(np.random.randn(n))
+        volume = np.random.randint(1000, 10000, n).astype(float)
+        df = pd.DataFrame(
+            {"open": close, "high": high, "low": low, "close": close, "volume": volume},
+            index=pd.date_range("2024-01-01", periods=n, freq="1d"),
+        )
+
+        scorer = CompositeRegimeScorer()
+        result = scorer.score_and_classify(df)
+        macd_cols = [c for c in result.columns if "macd" in c]
+        assert macd_cols == [], f"Found macd columns in output: {macd_cols}"
+
+
+class TestNoLookahead:
+    """Rolling percentile uses only past window."""
+
+    def test_rolling_percentile_causal(self, dual_macd_indicator: Any) -> None:
+        """Modifying future data should not change past percentile values."""
+        n = 300
+        close_a = 100 + np.cumsum(np.random.RandomState(42).randn(n) * 0.5)
+        close_b = close_a.copy()
+        close_b[250:] = close_b[250:] + 50  # Spike future data
+
+        dates = pd.date_range("2024-01-01", periods=n, freq="1h")
+        df_a = pd.DataFrame({"close": close_a}, index=dates)
+        df_b = pd.DataFrame({"close": close_b}, index=dates)
+
+        result_a = dual_macd_indicator.calculate(df_a, dual_macd_indicator.default_params)
+        result_b = dual_macd_indicator.calculate(df_b, dual_macd_indicator.default_params)
+
+        # Check that slow_hist_norm values before bar 250 are identical
+        norm_a = result_a["slow_hist_norm"].iloc[:250].dropna()
+        norm_b = result_b["slow_hist_norm"].iloc[:250].dropna()
+        if len(norm_a) > 0:
+            np.testing.assert_array_equal(norm_a.values, norm_b.values)
+
+
+class TestWarmup:
+    """Warmup period is correct."""
+
+    def test_warmup_value(self, dual_macd_indicator: Any) -> None:
+        """Warmup should be 255 = max(89, 252) + 3."""
+        assert dual_macd_indicator.warmup_periods == 255


### PR DESCRIPTION
⸻

Summary — Regime × Dual-MACD Interaction Upgrade

What changed
	1.	Dual-MACD is removed from the Composite Score •	No longer contributes to regime scoring or weights. •	Composite regime remains driven by: •	Trend (long / short) •	Momentum (RSI only, now dominant) •	Volatility •	Breadth •	Dual-MACD is reclassified as a state & behavioral constraint system, not an alpha/scoring factor.
	2.	Dual-MACD is rewritten as a unified indicator •	Slow MACD (55, 89) defines trend backbone. •	Fast MACD (13, 21) defines intra-trend pullback / exhaustion. •	Outputs discrete, machine-readable states: •	trend_state: BULLISH | BEARISH | IMPROVING | DETERIORATING •	tactical_signal: DIP_BUY | RALLY_SELL | NONE •	momentum_balance: FAST_DOMINANT | SLOW_DOMINANT | BALANCED •	confidence •	No NaNs: every bar emits a valid state after warmup.
	3.	Regime × Dual-MACD interaction is formalized via a truth table •	Trading permissions are now explicitly gated by the combination of: •	Macro regime (R0 / R1 / R2) •	Dual-MACD structural + tactical states •	Dual-MACD can: •	Gate entries •	Downgrade effective trading permissions •	Block trend-following trades •	It never “adds confidence” to a regime; it only removes or constrains behavior.

⸻

New system behavior (high-level)
	•	R0 (Healthy)
	•	Trend-following is allowed only if trend_state != DETERIORATING.
	•	DIP_BUY is preferred over breakout chasing.
	•	When DETERIORATING, the system shifts from “attack” to defensive / pullback-only behavior.
	•	R1 (Choppy)
	•	Trend-following is disabled by default.
	•	Dual-MACD tactical signals (DIP_BUY, RALLY_SELL) become the primary tradable signals, with reduced size.
	•	Structural deterioration further reduces permissions.
	•	R2 (Risk-Off)
	•	New directional risk is blocked.
	•	Dual-MACD is used only for exit, reduction, or hedge management.
	•	IMPROVING signals are treated as early repair, not reversal entry.

⸻

Why this change
	•	Dual-MACD represents a relationship between trend and intra-trend structure, not an independent factor.
	•	Including it in the composite score:
	•	Double-counted momentum
	•	Over-amplified confidence near trend exhaustion
	•	Reframing it as a behavioral constraint:
	•	Prevents false confidence
	•	Enforces discipline during regime transitions
	•	Aligns with buy-side practice: good systems say “don’t trade” more often than “trade”

⸻

Net effect
	•	Composite regime remains stable and interpretable.
	•	Dual-MACD becomes the enforcer:
	•	Stops trend-chasing when structure deteriorates
	•	Allows selective pullback entries when conditions are favorable
	•	The system transitions from:
“How bullish is the market?”
to
“Given the regime, what am I allowed to do right now?”

⸻

If you want, I can also compress this into:
	•	a single commit message, or
	•	a PR description with risk/rollback section, or
	•	a one-page architecture diagram caption.