### PR TITLE
Bidirectional strategy audit -> create a SOP for create a strategy

### DIFF
--- a/config/backtest/playbook/regime_flex.yaml
+++ b/config/backtest/playbook/regime_flex.yaml
@@ -1,0 +1,86 @@
+# RegimeFlex Strategy - Regime-Based Exposure Scaling
+#
+# Tier 2 strategy: Adjusts portfolio gross exposure based on market regime.
+# Portfolio-mode: requires regime context, NOT vectorbt-compatible.
+#
+# Run with:
+#   python -m src.backtest.runner --strategy regime_flex --symbols AAPL NVDA MSFT --start 2022-01-01 --end 2025-06-30
+#   python -m src.backtest.runner --spec config/backtest/playbook/regime_flex.yaml
+
+name: "RegimeFlex_Backtest"
+description: "Regime-based gross exposure scaling with dwell/cooldown filters"
+strategy: "regime_flex"
+
+parameters:
+  # Frozen structural params (use YAML defaults)
+  min_dwell_bars:
+    type: fixed
+    value: 10
+  switch_cooldown_bars:
+    type: fixed
+    value: 15
+  # Optimizable params (matches strategy_objective.py _build_param_space)
+  r0_gross_pct:
+    type: range
+    min: 0.7
+    max: 1.0
+    step: 0.1
+  r1_gross_pct:
+    type: range
+    min: 0.2
+    max: 0.7
+    step: 0.1
+  r3_gross_pct:
+    type: range
+    min: 0.1
+    max: 0.5
+    step: 0.1
+  ramp_bars:
+    type: range
+    min: 3
+    max: 20
+    step: 1
+
+universe:
+  type: static
+  symbols:
+    - AAPL
+    - NVDA
+    - MSFT
+    - AMZN
+    - GOOGL
+
+temporal:
+  primary_method: walk_forward
+  train_days: 504
+  test_days: 126
+  folds: 4
+  purge_days: 5
+  embargo_days: 2
+  start_date: "2020-01-01"
+  end_date: "2025-06-30"
+
+optimization:
+  method: bayesian
+  metric: sharpe
+  direction: maximize
+  n_trials: 50
+  constraints:
+    - metric: p10_sharpe
+      operator: ">="
+      value: 0.0
+    - metric: median_max_dd
+      operator: "<="
+      value: 0.30
+
+profiles:
+  default:
+    name: tier_a
+    version: v1
+    slippage_bps: 5.0
+    commission_per_share: 0.005
+    fill_model: close
+
+reproducibility:
+  random_seed: 42
+  data_version: "apex_2025.01"

--- a/config/backtest/playbook/sector_pulse.yaml
+++ b/config/backtest/playbook/sector_pulse.yaml
@@ -1,0 +1,84 @@
+# SectorPulse Strategy - Sector Rotation with Regime Gating
+#
+# Tier 2 strategy: Cross-sectional sector rotation.
+# Portfolio-mode: trades all symbols at once, NOT vectorbt-compatible.
+#
+# Run with:
+#   python -m src.backtest.runner --strategy sector_pulse --symbols AAPL NVDA MSFT --start 2022-01-01 --end 2025-06-30
+#   python -m src.backtest.runner --spec config/backtest/playbook/sector_pulse.yaml
+
+name: "SectorPulse_Backtest"
+description: "Cross-sectional sector rotation with multi-horizon scoring and regime gating"
+strategy: "sector_pulse"
+
+parameters:
+  # All params optimizable (matches strategy_objective.py _build_param_space)
+  top_n_sectors:
+    type: range
+    min: 2
+    max: 5
+    step: 1
+  confidence_threshold:
+    type: range
+    min: 0.005
+    max: 0.10
+    step: 0.005
+  drift_threshold_pct:
+    type: range
+    min: 0.03
+    max: 0.15
+    step: 0.01
+  max_turnover_pct:
+    type: range
+    min: 0.15
+    max: 0.50
+    step: 0.05
+  risk_per_sector_pct:
+    type: range
+    min: 0.05
+    max: 0.20
+    step: 0.05
+
+universe:
+  type: static
+  symbols:
+    - AAPL
+    - NVDA
+    - MSFT
+    - AMZN
+    - GOOGL
+
+temporal:
+  primary_method: walk_forward
+  train_days: 504
+  test_days: 126
+  folds: 4
+  purge_days: 5
+  embargo_days: 2
+  start_date: "2020-01-01"
+  end_date: "2025-06-30"
+
+optimization:
+  method: bayesian
+  metric: sharpe
+  direction: maximize
+  n_trials: 50
+  constraints:
+    - metric: p10_sharpe
+      operator: ">="
+      value: 0.0
+    - metric: median_max_dd
+      operator: "<="
+      value: 0.35
+
+profiles:
+  default:
+    name: tier_a
+    version: v1
+    slippage_bps: 5.0
+    commission_per_share: 0.005
+    fill_model: close
+
+reproducibility:
+  random_seed: 42
+  data_version: "apex_2025.01"

--- a/config/backtest/playbook/trend_pulse.yaml
+++ b/config/backtest/playbook/trend_pulse.yaml
@@ -1,0 +1,109 @@
+# TrendPulse Strategy - ZigZag + DualMACD Confluence Trend Following
+#
+# Tier 1 strategy: Buy confirmed uptrends with multi-indicator confluence.
+# Uses ZigZag swing detection + DualMACD momentum + ADX chop filter.
+#
+# Run with:
+#   python -m src.backtest.runner --strategy trend_pulse --symbols AAPL NVDA MSFT --start 2022-01-01 --end 2025-06-30
+#   python -m src.backtest.runner --spec config/backtest/playbook/trend_pulse.yaml
+
+name: "TrendPulse_Backtest"
+description: "ZigZag + DualMACD confluence trend following with regime gating"
+strategy: "trend_pulse"
+
+parameters:
+  # Frozen structural params (use YAML defaults)
+  cooldown_bars:
+    type: fixed
+    value: 5
+  risk_per_trade_pct:
+    type: fixed
+    value: 0.05
+  # Optimizable params (matches strategy_objective.py _build_param_space)
+  zig_threshold_pct:
+    type: range
+    min: 1.5
+    max: 5.0
+    step: 0.5
+  trend_strength_moderate:
+    type: range
+    min: 0.10
+    max: 0.30
+    step: 0.05
+  min_confidence:
+    type: range
+    min: 0.2
+    max: 0.6
+    step: 0.05
+  hard_stop_pct:
+    type: range
+    min: 0.10
+    max: 0.20
+    step: 0.02
+  atr_stop_mult:
+    type: range
+    min: 3.0
+    max: 6.0
+    step: 0.5
+  exit_bearish_bars:
+    type: range
+    min: 2
+    max: 5
+    step: 1
+  adx_entry_min:
+    type: range
+    min: 10
+    max: 25
+    step: 5
+
+secondary_timeframes: [1W]
+
+universe:
+  type: static
+  symbols:
+    - AAPL
+    - NVDA
+    - MSFT
+    - AMZN
+    - GOOGL
+
+temporal:
+  primary_method: walk_forward
+  train_days: 504
+  test_days: 126
+  folds: 4
+  purge_days: 5
+  embargo_days: 2
+  start_date: "2020-01-01"
+  end_date: "2025-06-30"
+
+optimization:
+  method: bayesian
+  metric: sharpe
+  direction: maximize
+  n_trials: 50
+  constraints:
+    - metric: p10_sharpe
+      operator: ">="
+      value: 0.0
+    - metric: median_max_dd
+      operator: "<="
+      value: 0.20
+
+profiles:
+  default:
+    name: tier_a
+    version: v1
+    slippage_bps: 5.0
+    commission_per_share: 0.005
+    fill_model: close
+  conservative:
+    name: tier_b
+    version: v1
+    slippage_bps: 15.0
+    commission_per_share: 0.005
+    fill_model: next_open
+
+reproducibility:
+  random_seed: 42
+  data_version: "apex_2025.01"

--- a/config/strategy/ma_cross.yaml
+++ b/config/strategy/ma_cross.yaml
@@ -1,0 +1,18 @@
+name: ma_cross
+tier: "LEGACY"
+module_path: "src.domain.strategy.signals.ma_cross"
+class_name: "MACrossSignalGenerator"
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  short_window: 10
+  long_window: 50
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      short_window: 10
+      long_window: 50
+    reason: "Pre-architecture strategy with hardcoded defaults"

--- a/config/strategy/momentum_breakout.yaml
+++ b/config/strategy/momentum_breakout.yaml
@@ -1,0 +1,18 @@
+name: momentum_breakout
+tier: "LEGACY"
+module_path: "src.domain.strategy.signals.momentum_breakout"
+class_name: "MomentumBreakoutSignalGenerator"
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  lookback_days: 20
+  momentum_threshold: 0.0
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      lookback_days: 20
+      momentum_threshold: 0.0
+    reason: "Pre-architecture strategy with hardcoded defaults"

--- a/config/strategy/mtf_rsi_trend.yaml
+++ b/config/strategy/mtf_rsi_trend.yaml
@@ -1,0 +1,24 @@
+name: mtf_rsi_trend
+tier: "LEGACY"
+module_path: "src.domain.strategy.signals.mtf_rsi_trend"
+class_name: "MTFRsiTrendSignalGenerator"
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  trend_rsi_period: 14
+  entry_rsi_period: 14
+  trend_threshold: 50
+  entry_oversold: 30
+  entry_overbought: 70
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      trend_rsi_period: 14
+      entry_rsi_period: 14
+      trend_threshold: 50
+      entry_oversold: 30
+      entry_overbought: 70
+    reason: "Pre-architecture strategy with hardcoded defaults"

--- a/config/strategy/pairs_trading.yaml
+++ b/config/strategy/pairs_trading.yaml
@@ -1,0 +1,20 @@
+name: pairs_trading
+tier: "LEGACY"
+module_path: "src.domain.strategy.signals.pairs_trading"
+class_name: "PairsTradingSignalGenerator"
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  lookback: 20
+  entry_zscore: 2.0
+  exit_zscore: 0.5
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      lookback: 20
+      entry_zscore: 2.0
+      exit_zscore: 0.5
+    reason: "Pre-architecture strategy with hardcoded defaults"

--- a/config/strategy/regime_flex.yaml
+++ b/config/strategy/regime_flex.yaml
@@ -2,6 +2,7 @@ name: regime_flex
 tier: "TIER 2"
 module_path: "src.domain.strategy.playbook.regime_flex"
 class_name: "RegimeFlexStrategy"
+vectorbt_compatible: false  # Portfolio-mode: requires regime context across symbols
 
 # Current best parameters — used by all runners, playbooks, signal generators
 params:

--- a/config/strategy/rsi_mean_reversion.yaml
+++ b/config/strategy/rsi_mean_reversion.yaml
@@ -1,0 +1,20 @@
+name: rsi_mean_reversion
+tier: "LEGACY"
+module_path: "src.domain.strategy.signals.rsi_mean_reversion"
+class_name: "RSIMeanReversionSignalGenerator"
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  rsi_period: 14
+  rsi_oversold: 30
+  rsi_overbought: 70
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      rsi_period: 14
+      rsi_oversold: 30
+      rsi_overbought: 70
+    reason: "Pre-architecture strategy with hardcoded defaults"

--- a/config/strategy/scheduled_rebalance.yaml
+++ b/config/strategy/scheduled_rebalance.yaml
@@ -1,0 +1,19 @@
+name: scheduled_rebalance
+tier: "DEMO"
+module_path: "src.domain.strategy.playbook.scheduled_rebalance"
+class_name: "ScheduledRebalanceStrategy"
+vectorbt_compatible: false  # Demo strategy: uses scheduler/clock, not vectorizable
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  rebalance_threshold: 0.05
+  total_capital: 100000
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      rebalance_threshold: 0.05
+      total_capital: 100000
+    reason: "Demo strategy for scheduler/clock abstraction"

--- a/config/strategy/sector_pulse.yaml
+++ b/config/strategy/sector_pulse.yaml
@@ -2,8 +2,7 @@ name: sector_pulse
 tier: "TIER 2"
 module_path: "src.domain.strategy.playbook.sector_pulse"
 class_name: "SectorPulseStrategy"
-
-# Current best parameters — used by all runners, playbooks, signal generators
+vectorbt_compatible: false  # Cross-sectional portfolio mode: can't vectorize per-symbol
 execution_mode: portfolio  # Runs with all symbols at once (cross-sectional)
 
 params:

--- a/config/strategy/ta_metrics.yaml
+++ b/config/strategy/ta_metrics.yaml
@@ -1,0 +1,32 @@
+name: ta_metrics
+tier: "LEGACY"
+module_path: "src.domain.strategy.signals.ta_metrics"
+class_name: "TAMetricsSignalGenerator"
+
+# Current best parameters — used by all runners, playbooks, signal generators
+params:
+  sma_fast: 20
+  sma_slow: 50
+  rsi_period: 14
+  rsi_oversold: 30
+  rsi_overbought: 70
+  macd_fast: 12
+  macd_slow: 26
+  macd_signal: 9
+  min_score: 3
+
+history:
+  - version: "v1.0-initial"
+    date: "2025-01-01"
+    source: "Original hardcoded defaults"
+    params:
+      sma_fast: 20
+      sma_slow: 50
+      rsi_period: 14
+      rsi_oversold: 30
+      rsi_overbought: 70
+      macd_fast: 12
+      macd_slow: 26
+      macd_signal: 9
+      min_score: 3
+    reason: "Pre-architecture strategy with hardcoded defaults"

--- a/src/backtest/optimization/strategy_objective.py
+++ b/src/backtest/optimization/strategy_objective.py
@@ -64,7 +64,7 @@ FROZEN_PARAMS: Dict[str, Set[str]] = {
     "squeeze_play": {"bb_period", "bb_std", "kc_multiplier"},
     "trend_pulse": {"risk_per_trade_pct", "cooldown_bars"},
     "pulse_dip": set(),
-    "regime_flex": set(),
+    "regime_flex": {"min_dwell_bars", "switch_cooldown_bars"},
     "sector_pulse": set(),
 }
 

--- a/src/domain/strategy/signals/ma_cross.py
+++ b/src/domain/strategy/signals/ma_cross.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from ..param_loader import get_strategy_params
 from .indicators import sma
+
+_DEFAULTS = get_strategy_params("ma_cross")
 
 
 class MACrossSignalGenerator:
@@ -49,9 +52,10 @@ class MACrossSignalGenerator:
         """
         close = data["close"]
 
+        effective = {**_DEFAULTS, **params}
         # Support both new and legacy param names
-        short_window = params.get("short_window", params.get("fast_period", 10))
-        long_window = params.get("long_window", params.get("slow_period", 50))
+        short_window = effective.get("short_window", effective.get("fast_period", 10))
+        long_window = effective.get("long_window", effective.get("slow_period", 50))
 
         # Calculate MAs using TA-Lib
         fast_ma = sma(close, int(short_window))

--- a/src/domain/strategy/signals/momentum_breakout.py
+++ b/src/domain/strategy/signals/momentum_breakout.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from ..param_loader import get_strategy_params
 from .indicators import momentum
+
+_DEFAULTS = get_strategy_params("momentum_breakout")
 
 
 class MomentumBreakoutSignalGenerator:
@@ -46,8 +49,9 @@ class MomentumBreakoutSignalGenerator:
         """
         close = data["close"]
 
-        lookback = int(params.get("lookback_days", 20))
-        threshold = float(params.get("momentum_threshold", 0.0))
+        effective = {**_DEFAULTS, **params}
+        lookback = int(effective.get("lookback_days", 20))
+        threshold = float(effective.get("momentum_threshold", 0.0))
 
         # Calculate momentum using TA-Lib
         mom = momentum(close, lookback)

--- a/src/domain/strategy/signals/mtf_rsi_trend.py
+++ b/src/domain/strategy/signals/mtf_rsi_trend.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from ..param_loader import get_strategy_params
 from .indicators import rsi
+
+_DEFAULTS = get_strategy_params("mtf_rsi_trend")
 
 
 class MTFRsiTrendSignalGenerator:
@@ -109,11 +112,12 @@ class MTFRsiTrendSignalGenerator:
         index = close.index
 
         # Extract parameters
-        trend_period = int(params.get("trend_rsi_period", 14))
-        entry_period = int(params.get("entry_rsi_period", 14))
-        trend_threshold = float(params.get("trend_threshold", 50))
-        oversold = float(params.get("entry_oversold", 30))
-        overbought = float(params.get("entry_overbought", 70))
+        effective = {**_DEFAULTS, **params}
+        trend_period = int(effective.get("trend_rsi_period", 14))
+        entry_period = int(effective.get("entry_rsi_period", 14))
+        trend_threshold = float(effective.get("trend_threshold", 50))
+        oversold = float(effective.get("entry_oversold", 30))
+        overbought = float(effective.get("entry_overbought", 70))
 
         # Calculate primary timeframe RSI for trend
         primary_rsi = rsi(close, trend_period)

--- a/src/domain/strategy/signals/pairs_trading.py
+++ b/src/domain/strategy/signals/pairs_trading.py
@@ -7,7 +7,10 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from ..param_loader import get_strategy_params
 from .indicators import sma
+
+_DEFAULTS = get_strategy_params("pairs_trading")
 
 
 class PairsTradingSignalGenerator:
@@ -78,9 +81,10 @@ class PairsTradingSignalGenerator:
         close_b = data["close_b"]
         index = close_a.index
 
-        lookback = int(params.get("lookback", 20))
-        entry_zscore = float(params.get("entry_zscore", 2.0))
-        exit_zscore = float(params.get("exit_zscore", 0.5))
+        effective = {**_DEFAULTS, **params}
+        lookback = int(effective.get("lookback", 20))
+        entry_zscore = float(effective.get("entry_zscore", 2.0))
+        exit_zscore = float(effective.get("exit_zscore", 0.5))
 
         # Calculate spread as ratio
         spread = close_a / close_b

--- a/src/domain/strategy/signals/rsi_mean_reversion.py
+++ b/src/domain/strategy/signals/rsi_mean_reversion.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from ..param_loader import get_strategy_params
 from .indicators import rsi
+
+_DEFAULTS = get_strategy_params("rsi_mean_reversion")
 
 
 class RSIMeanReversionSignalGenerator:
@@ -48,10 +51,11 @@ class RSIMeanReversionSignalGenerator:
         """
         close = data["close"]
 
+        effective = {**_DEFAULTS, **params}
         # Support both prefixed and non-prefixed param names for compatibility
-        period = int(params.get("rsi_period", 14))
-        oversold = float(params.get("rsi_oversold", params.get("oversold", 30)))
-        overbought = float(params.get("rsi_overbought", params.get("overbought", 70)))
+        period = int(effective.get("rsi_period", 14))
+        oversold = float(effective.get("rsi_oversold", effective.get("oversold", 30)))
+        overbought = float(effective.get("rsi_overbought", effective.get("overbought", 70)))
 
         # Calculate RSI using TA-Lib
         rsi_values = rsi(close, period)

--- a/src/domain/strategy/signals/ta_metrics.py
+++ b/src/domain/strategy/signals/ta_metrics.py
@@ -7,7 +7,10 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from ..param_loader import get_strategy_params
 from .indicators import macd, rsi, sma
+
+_DEFAULTS = get_strategy_params("ta_metrics")
 
 
 class TAMetricsSignalGenerator:
@@ -59,15 +62,16 @@ class TAMetricsSignalGenerator:
         index = close.index
 
         # Extract parameters
-        sma_fast_period = int(params.get("sma_fast", 20))
-        sma_slow_period = int(params.get("sma_slow", 50))
-        rsi_period = int(params.get("rsi_period", 14))
-        rsi_oversold = float(params.get("rsi_oversold", 30))
-        rsi_overbought = float(params.get("rsi_overbought", 70))
-        macd_fast = int(params.get("macd_fast", 12))
-        macd_slow = int(params.get("macd_slow", 26))
-        macd_signal_period = int(params.get("macd_signal", 9))
-        min_score = float(params.get("min_score", 3))
+        effective = {**_DEFAULTS, **params}
+        sma_fast_period = int(effective.get("sma_fast", 20))
+        sma_slow_period = int(effective.get("sma_slow", 50))
+        rsi_period = int(effective.get("rsi_period", 14))
+        rsi_oversold = float(effective.get("rsi_oversold", 30))
+        rsi_overbought = float(effective.get("rsi_overbought", 70))
+        macd_fast = int(effective.get("macd_fast", 12))
+        macd_slow = int(effective.get("macd_slow", 26))
+        macd_signal_period = int(effective.get("macd_signal", 9))
+        min_score = float(effective.get("min_score", 3))
 
         # Calculate indicators using TA-Lib wrappers
         sma_fast_series = sma(close, sma_fast_period)


### PR DESCRIPTION
:AML configs, _DEFAULTS wiring, rich Opuna history

  Direction 1 (code gaps):
  - Add YAML configs for 7 legacy/demo strategies (ma_cross, momentum_breakout, rsi_mean_reversion, mtf_rsi_trend, pairs_trading, ta_metrics, scheduled_rebalance)
  - Wire all 6 legacy signal generators to _DEFAULTS = get_strategy_params() pattern
  - Mark portfolio strategies as vectorbt_compatible: false (regime_flex, sector_pulse)
  - Add min_dwell_bars/switch_cooldown_bars to RegimeFlex FROZEN_PARAMS
  - Create missing backtest YAML specs (trend_pulse, regime_flex, sector_pulse)

  Direction 2 (rich optimization history):
  - update_strategy_params() now accepts source, reason, results, changes kwargs
  - optimize_runner passes best trial metrics (Sharpe, return, drawdown, trades, win rate, calmar, composite score) and auto-generated change diffs to history
  - YAML history entries become full audit trail of optimization runs

  13 strategies now discoverable via param_loader (was 6). 1644 tests pass.