### PR TITLE
PEAD screener: stabilization + tracker + backtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ help:
 	@echo "  make behavioral-cases Predefined case studies + serve"
 	@echo ""
 	@echo "$(GREEN)PEAD Screener:$(RESET)"
-	@echo "  make pead           Full PEAD pipeline (update caps + earnings + screen + HTML)"
+	@echo "  make pead           Full pipeline (caps + earnings + attention + screen + track + stats)"
 	@echo "  make pead-test      Run PEAD unit tests"
-	@echo "  make pead-screen    Screen only (from cached earnings, no fetch)"
+	@echo "  make pead-screen    Screen from cache (still tracks + resolves by default)"
 	@echo ""
 	@echo "$(GREEN)Other:$(RESET)"
 	@echo "  make diagrams       Generate architecture diagrams"
@@ -415,26 +415,24 @@ tp-universe-quick:
 # PEAD Earnings Drift Screener
 # ═══════════════════════════════════════════════════════════════
 
-# Full pipeline: update market caps → fetch earnings → screen → HTML report
+# Full pipeline: caps → earnings → attention → screen → track → resolve → stats → HTML
 pead:
 	@echo "$(BOLD)PEAD Earnings Drift Screen — Full Pipeline$(RESET)"
 	@echo ""
-	@echo "$(BOLD)Step 1/3: Updating market caps...$(RESET)"
+	@echo "$(BOLD)Step 1/2: Updating market caps...$(RESET)"
 	$(PYTHON) -m src.runners.signal_runner --update-market-caps \
 		--universe config/universe.yaml
 	@echo ""
-	@echo "$(BOLD)Step 2/3: Fetching earnings from FMP...$(RESET)"
-	$(PYTHON) -m src.runners.pead_runner --update-earnings \
-		--universe config/universe.yaml
-	@echo ""
-	@echo "$(BOLD)Step 3/3: Running PEAD screen...$(RESET)"
-	$(PYTHON) -m src.runners.pead_runner --screen \
+	@echo "$(BOLD)Step 2/2: Full PEAD run (earnings + attention + screen + track + stats)...$(RESET)"
+	$(PYTHON) -m src.runners.pead_runner --full \
+		--universe config/universe.yaml \
 		--html-output out/pead/pead.html
 	@echo ""
 	@echo "$(GREEN)✓ Candidates: out/pead/data/pead_candidates.json$(RESET)"
+	@echo "$(GREEN)✓ Tracker:    data/cache/pead_tracker.json$(RESET)"
 	@echo "$(GREEN)✓ HTML report: out/pead/pead.html$(RESET)"
 
-# Screen from cached earnings (no FMP fetch — fast)
+# Screen from cached earnings (no FMP fetch — still tracks + resolves by default)
 pead-screen:
 	@echo "$(BOLD)PEAD Screen (from cache)...$(RESET)"
 	$(PYTHON) -m src.runners.pead_runner --screen \

--- a/config/pead_screener.yaml
+++ b/config/pead_screener.yaml
@@ -37,3 +37,15 @@ liquidity_tiers:
 quality_thresholds:
   strong: 70
   moderate: 45
+
+multi_quarter_sue:
+  enabled: true
+  decay_lambda: 0.75
+  min_quarters: 6
+  max_bonus: 10.0
+  max_penalty: -5.0
+
+attention_filter:
+  enabled: false
+  low_bonus: 5.0
+  high_penalty: -5.0

--- a/config/strategy/pead.yaml
+++ b/config/strategy/pead.yaml
@@ -1,0 +1,32 @@
+name: pead
+tier: "TIER 2"
+module_path: "src.domain.strategy.signals.pead"
+class_name: "PeadSignalGenerator"
+
+# PEAD (Post-Earnings Announcement Drift) screener as a backtestable strategy.
+#
+# Unlike price-based strategies, entries come from earnings events.
+# Pass earnings_data via params (list of dicts with report_date, sue_score, etc.)
+# or let the generator load from earnings cache automatically.
+#
+# vectorbt_compatible: true (long-only, target/stop/timeout exits)
+
+params:
+  # SUE filter thresholds
+  min_sue: 2.0
+  min_gap_pct: 0.02
+  min_volume_ratio: 2.0
+
+  # Exit parameters
+  profit_target_pct: 0.06
+  stop_loss_pct: -0.05
+  max_hold_bars: 25
+
+  # Entry timing
+  entry_delay_bars: 2
+
+  # Quality weighting (confidence-based sizing)
+  use_quality_sizing: true
+  min_quality_for_entry: 0.0
+
+history: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest-asyncio>=0.21.0",  # Async test support
     "hypothesis>=6.100.0",     # Property-based testing
     "mypy>=1.7.0",             # Static type checking
+    "types-requests>=2.31.0",  # Type stubs for requests
     "black>=23.12.0",          # Code formatting
     "isort>=5.13.0",           # Import sorting
     "flake8>=6.1.0",           # Linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+pead = [
+    "pytrends>=4.9.0",            # Google Trends for PEAD attention filter
+]
+
 dev = [
     "pytest>=7.4.0",           # Testing framework
     "pytest-cov>=4.1.0",       # Coverage reporting

--- a/src/domain/screeners/pead/__init__.py
+++ b/src/domain/screeners/pead/__init__.py
@@ -1,20 +1,35 @@
 """PEAD (Post-Earnings Announcement Drift) screener domain."""
 
+from .config import PEADConfig
 from .models import (
     EarningsSurprise,
     LiquidityTier,
     PEADCandidate,
     PEADScreenResult,
 )
-from .scorer import classify_quality, score_pead_quality
+from .scorer import (
+    apply_attention_modifier,
+    apply_multi_quarter_modifier,
+    classify_quality,
+    score_pead_quality,
+)
 from .screener import PEADScreener
+from .sue import compute_multi_quarter_sue, compute_sue
+from .tracker import TrackedCandidate, TrackerStats
 
 __all__ = [
     "EarningsSurprise",
     "LiquidityTier",
     "PEADCandidate",
+    "PEADConfig",
     "PEADScreenResult",
     "PEADScreener",
+    "apply_attention_modifier",
+    "apply_multi_quarter_modifier",
     "classify_quality",
+    "compute_multi_quarter_sue",
+    "compute_sue",
     "score_pead_quality",
+    "TrackedCandidate",
+    "TrackerStats",
 ]

--- a/src/domain/screeners/pead/config.py
+++ b/src/domain/screeners/pead/config.py
@@ -1,0 +1,138 @@
+"""Typed configuration for PEAD screener.
+
+All screener configuration is validated at load time via dataclasses.
+Typos or missing keys raise immediately, not silently no-op at runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class PEADFilters:
+    """Filter thresholds for the screening pipeline."""
+
+    min_sue: float = 2.0
+    min_earnings_day_gap: float = 0.02
+    min_volume_ratio: float = 2.0
+    max_entry_delay_trading_days: int = 5
+    max_forward_pe: float = 40.0
+    exclude_at_52w_high: bool = True
+    exclude_analyst_downgrade_days: int = 3
+    require_revenue_beat: bool = False
+
+
+@dataclass
+class PEADTradeParams:
+    """Default trade parameters for candidates."""
+
+    default_profit_target: float = 0.06
+    default_stop_loss: float = -0.05
+    default_max_hold_trading_days: int = 25
+    trailing_stop_atr_multiplier: float = 2.0
+    trailing_stop_activation_pct: float = 0.03
+
+
+@dataclass
+class PEADRegimeRules:
+    """Regime-dependent position sizing rules."""
+
+    r0_position_size_factor: float = 1.0
+    r1_position_size_factor: float = 0.5
+    r2_block_entirely: bool = True
+
+
+@dataclass
+class PEADLiquidityTiers:
+    """Market cap thresholds and slippage estimates."""
+
+    large_cap_min_market_cap: float = 50_000_000_000
+    mid_cap_min_market_cap: float = 2_000_000_000
+    large_cap_slippage_bps: int = 10
+    mid_cap_slippage_bps: int = 25
+    small_cap_slippage_bps: int = 50
+
+
+@dataclass
+class PEADQualityThresholds:
+    """Score thresholds for quality classification."""
+
+    strong: float = 70.0
+    moderate: float = 45.0
+
+
+@dataclass
+class MultiQuarterSueConfig:
+    """Configuration for multi-quarter SUE enhancement."""
+
+    enabled: bool = True
+    decay_lambda: float = 0.75
+    min_quarters: int = 6
+    max_bonus: float = 10.0
+    max_penalty: float = -5.0
+
+
+@dataclass
+class AttentionFilterConfig:
+    """Configuration for Google Trends attention filter."""
+
+    enabled: bool = False
+    low_bonus: float = 5.0
+    high_penalty: float = -5.0
+
+
+@dataclass
+class PEADConfig:
+    """Complete PEAD screener configuration.
+
+    Validates all keys at load time. Any typo or missing section raises
+    immediately instead of silently using wrong defaults.
+    """
+
+    filters: PEADFilters = field(default_factory=PEADFilters)
+    trade_params: PEADTradeParams = field(default_factory=PEADTradeParams)
+    regime_rules: PEADRegimeRules = field(default_factory=PEADRegimeRules)
+    liquidity_tiers: PEADLiquidityTiers = field(default_factory=PEADLiquidityTiers)
+    quality_thresholds: PEADQualityThresholds = field(default_factory=PEADQualityThresholds)
+    multi_quarter_sue: MultiQuarterSueConfig = field(default_factory=MultiQuarterSueConfig)
+    attention_filter: AttentionFilterConfig = field(default_factory=AttentionFilterConfig)
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> PEADConfig:
+        """Load and validate config from YAML file."""
+        with open(path) as f:
+            raw = yaml.safe_load(f) or {}
+        return cls.from_dict(raw)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> PEADConfig:
+        """Build typed config from raw dict, using defaults for missing keys."""
+        return cls(
+            filters=_build_dataclass(PEADFilters, raw.get("filters", {})),
+            trade_params=_build_dataclass(PEADTradeParams, raw.get("trade_params", {})),
+            regime_rules=_build_dataclass(PEADRegimeRules, raw.get("regime_rules", {})),
+            liquidity_tiers=_build_dataclass(PEADLiquidityTiers, raw.get("liquidity_tiers", {})),
+            quality_thresholds=_build_dataclass(
+                PEADQualityThresholds, raw.get("quality_thresholds", {})
+            ),
+            multi_quarter_sue=_build_dataclass(
+                MultiQuarterSueConfig, raw.get("multi_quarter_sue", {})
+            ),
+            attention_filter=_build_dataclass(
+                AttentionFilterConfig, raw.get("attention_filter", {})
+            ),
+        )
+
+
+def _build_dataclass(cls: type, data: dict[str, Any]) -> Any:
+    """Build a dataclass from dict, ignoring unknown keys."""
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(cls)}
+    filtered = {k: v for k, v in (data or {}).items() if k in field_names}
+    return cls(**filtered)

--- a/src/domain/screeners/pead/models.py
+++ b/src/domain/screeners/pead/models.py
@@ -36,6 +36,7 @@ class EarningsSurprise:
     analyst_downgrade: bool
     liquidity_tier: LiquidityTier
     forward_pe: float | None = None
+    multi_quarter_sue: float | None = None
 
 
 @dataclass

--- a/src/domain/screeners/pead/sue.py
+++ b/src/domain/screeners/pead/sue.py
@@ -1,0 +1,91 @@
+"""SUE (Standardized Unexpected Earnings) computation.
+
+Single-quarter SUE normalizes the current earnings surprise by historical
+surprise volatility. Multi-quarter SUE captures the trajectory of past
+surprises using exponential decay weighting.
+"""
+
+from __future__ import annotations
+
+import statistics
+
+
+def compute_sue(
+    actual_eps: float,
+    consensus_eps: float,
+    historical_surprises: list[float],
+) -> float:
+    """Compute Standardized Unexpected Earnings (SUE).
+
+    When >= 4 quarters of historical surprise data:
+        SUE = raw_surprise / stdev(historical_surprises)
+    Fallback (< 4 quarters):
+        SUE = raw_surprise / (|consensus| * 0.05 + 0.01)
+
+    Args:
+        actual_eps: Actual reported EPS.
+        consensus_eps: Analyst consensus EPS estimate.
+        historical_surprises: List of past (actual - consensus) values.
+            Must already exclude current quarter (see Phase 0.3).
+
+    Returns:
+        SUE score (positive = beat, negative = miss).
+    """
+    raw = actual_eps - consensus_eps
+
+    if len(historical_surprises) >= 4:
+        std = statistics.stdev(historical_surprises)
+        if std > 0:
+            return raw / std
+        # Zero std means all identical — use fallback
+    # Fallback: proxy scaling
+    denom = abs(consensus_eps) * 0.05 + 0.01
+    return raw / denom
+
+
+def compute_multi_quarter_sue(
+    historical_surprises: list[float],
+    decay_lambda: float = 0.75,
+    min_quarters: int = 6,
+) -> float | None:
+    """Weighted multi-quarter SUE using exponential decay.
+
+    Captures the trajectory of past surprises. Does NOT include the
+    current quarter (that's the single-Q SUE). Uses historical_surprises
+    which already exclude current quarter (Phase 0.3).
+
+    Formula:
+        weighted_mean = sum(w_i * s_i) / sum(w_i)
+        where w_i = decay_lambda ^ i, s_i = surprise[i] (most recent first)
+
+    Args:
+        historical_surprises: Past (actual - consensus) values, most recent first.
+        decay_lambda: Decay factor per quarter (0.75 = 25% decay each quarter).
+        min_quarters: Minimum quarters required. Returns None if fewer.
+
+    Returns:
+        Multi-quarter SUE score, or None if insufficient data.
+    """
+    if len(historical_surprises) < min_quarters:
+        return None
+
+    total_weight = 0.0
+    weighted_sum = 0.0
+    for i, surprise in enumerate(historical_surprises):
+        weight = decay_lambda**i
+        weighted_sum += weight * surprise
+        total_weight += weight
+
+    if total_weight == 0:
+        return None
+
+    weighted_mean = weighted_sum / total_weight
+
+    # Normalize by stdev of historical surprises for scale-invariance
+    if len(historical_surprises) >= 4:
+        std = statistics.stdev(historical_surprises)
+        if std > 0:
+            return weighted_mean / std
+
+    # Fallback: return raw weighted mean (unnormalized)
+    return weighted_mean

--- a/src/domain/screeners/pead/tracker.py
+++ b/src/domain/screeners/pead/tracker.py
@@ -1,0 +1,115 @@
+"""PEAD tracker domain models.
+
+Tracks PEAD candidates over time and resolves outcomes using OHLC first-touch logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+
+@dataclass
+class TrackedCandidate:
+    """A PEAD candidate being tracked to resolution."""
+
+    symbol: str
+    entry_date: date
+    entry_price: float
+    profit_target_pct: float
+    stop_loss_pct: float
+    max_hold_days: int
+    quality_score: float
+    quality_label: str
+    sue_score: float
+    multi_quarter_sue: float | None
+    regime: str
+    # Outcome (filled on resolution)
+    exit_date: date | None = None
+    exit_price: float | None = None
+    exit_reason: str | None = None  # "profit_target" | "stop_loss" | "timeout"
+    pnl_pct: float | None = None
+    status: str = "open"  # "open" | "won" | "lost" | "timeout"
+
+    @property
+    def target_price(self) -> float:
+        """Absolute price for profit target."""
+        return self.entry_price * (1 + self.profit_target_pct)
+
+    @property
+    def stop_price(self) -> float:
+        """Absolute price for stop loss."""
+        return self.entry_price * (1 + self.stop_loss_pct)
+
+    def to_dict(self) -> dict:
+        """Serialize to JSON-compatible dict."""
+        return {
+            "symbol": self.symbol,
+            "entry_date": self.entry_date.isoformat(),
+            "entry_price": self.entry_price,
+            "profit_target_pct": self.profit_target_pct,
+            "stop_loss_pct": self.stop_loss_pct,
+            "max_hold_days": self.max_hold_days,
+            "quality_score": self.quality_score,
+            "quality_label": self.quality_label,
+            "sue_score": self.sue_score,
+            "multi_quarter_sue": self.multi_quarter_sue,
+            "regime": self.regime,
+            "exit_date": self.exit_date.isoformat() if self.exit_date else None,
+            "exit_price": self.exit_price,
+            "exit_reason": self.exit_reason,
+            "pnl_pct": self.pnl_pct,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> TrackedCandidate:
+        """Deserialize from dict."""
+        return cls(
+            symbol=d["symbol"],
+            entry_date=date.fromisoformat(d["entry_date"]),
+            entry_price=d["entry_price"],
+            profit_target_pct=d["profit_target_pct"],
+            stop_loss_pct=d["stop_loss_pct"],
+            max_hold_days=d["max_hold_days"],
+            quality_score=d["quality_score"],
+            quality_label=d["quality_label"],
+            sue_score=d["sue_score"],
+            multi_quarter_sue=d.get("multi_quarter_sue"),
+            regime=d["regime"],
+            exit_date=date.fromisoformat(d["exit_date"]) if d.get("exit_date") else None,
+            exit_price=d.get("exit_price"),
+            exit_reason=d.get("exit_reason"),
+            pnl_pct=d.get("pnl_pct"),
+            status=d.get("status", "open"),
+        )
+
+
+@dataclass
+class TrackerStats:
+    """Aggregate performance statistics."""
+
+    total: int = 0
+    open: int = 0
+    won: int = 0
+    lost: int = 0
+    timeout: int = 0
+    win_rate: float | None = None
+    avg_pnl_pct: float | None = None
+    avg_hold_days: float | None = None
+    by_quality: dict[str, dict] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "total": self.total,
+            "open": self.open,
+            "won": self.won,
+            "lost": self.lost,
+            "timeout": self.timeout,
+            "win_rate": round(self.win_rate, 4) if self.win_rate is not None else None,
+            "avg_pnl_pct": round(self.avg_pnl_pct, 4) if self.avg_pnl_pct is not None else None,
+            "avg_hold_days": (
+                round(self.avg_hold_days, 1) if self.avg_hold_days is not None else None
+            ),
+            "by_quality": self.by_quality,
+        }

--- a/src/domain/strategy/manifest.yaml
+++ b/src/domain/strategy/manifest.yaml
@@ -95,3 +95,9 @@ strategies:
     apex_only: true
     validation:
       validated_by_apex: false
+
+  pead:
+    strategy: null  # Screener-only - no event-driven playbook
+    signals: src.domain.strategy.signals.pead:PeadSignalGenerator
+    validation:
+      validated_by_apex: false

--- a/src/domain/strategy/signals/pead.py
+++ b/src/domain/strategy/signals/pead.py
@@ -1,0 +1,232 @@
+"""PEAD (Post-Earnings Announcement Drift) SignalGenerator for VectorBT.
+
+Unlike price-based signal generators, PEAD entries are triggered by
+earnings surprise events, not OHLCV price patterns. The generator
+receives earnings data via ``params["earnings_data"]`` — a list of dicts
+with ``report_date``, ``sue_score``, ``gap_pct``, ``volume_ratio``,
+``revenue_beat``, and ``quality_score`` fields.
+
+Look-ahead prevention:
+    Only earnings with ``report_date < bar_date`` generate signals.
+    Entry is delayed by ``entry_delay_bars`` (default 2) after report.
+
+Exit logic (first-touch, vectorized forward scan):
+    1. Profit target: close >= entry_price * (1 + profit_target_pct)
+    2. Stop loss: close <= entry_price * (1 + stop_loss_pct)
+    3. Timeout: bars_held >= max_hold_bars → exit at close
+
+Intentional difference from live screener:
+    - Live screener uses intraday OHLC for first-touch (high/low).
+    - VectorBT backtest uses daily close for simplicity and consistency
+      with how VectorBT prices exits. This slightly understates wins
+      (misses intraday target touches) but is conservative.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from ..param_loader import get_strategy_params
+
+_DEFAULTS = get_strategy_params("pead")
+
+
+class PeadSignalGenerator:
+    """Vectorized PEAD signal generation for VectorBT backtesting.
+
+    Earnings-event-driven entries with target/stop/timeout exits.
+
+    Required ``params["earnings_data"]``:
+        List of dicts, each with at minimum::
+
+            {
+                "report_date": "2024-01-25",  # ISO date string or date object
+                "sue_score": 3.5,
+                "gap_pct": 0.04,
+                "volume_ratio": 2.8,
+                "revenue_beat": True,
+                "quality_score": 72.0,  # 0-100, optional for sizing
+            }
+    """
+
+    @property
+    def warmup_bars(self) -> int:
+        """No indicator warmup needed — entries from external events."""
+        return 0
+
+    def generate(
+        self,
+        data: pd.DataFrame,
+        params: dict[str, Any],
+        secondary_data: Optional[Dict[str, pd.DataFrame]] = None,
+    ) -> Tuple[pd.Series, pd.Series]:
+        """Generate PEAD entry/exit signals from OHLCV + earnings data.
+
+        Args:
+            data: OHLCV DataFrame with DatetimeIndex.
+            params: Strategy parameters. Must include ``earnings_data`` key.
+            secondary_data: Not used.
+
+        Returns:
+            (entries, exits) boolean Series aligned to data.index.
+        """
+        effective = {**_DEFAULTS, **params}
+
+        # Extract parameters
+        min_sue = float(effective.get("min_sue", 2.0))
+        min_gap = float(effective.get("min_gap_pct", 0.02))
+        min_vol = float(effective.get("min_volume_ratio", 2.0))
+        target_pct = float(effective.get("profit_target_pct", 0.06))
+        stop_pct = float(effective.get("stop_loss_pct", -0.05))
+        max_hold = int(effective.get("max_hold_bars", 25))
+        delay = int(effective.get("entry_delay_bars", 2))
+        use_sizing = bool(effective.get("use_quality_sizing", True))
+        min_quality = float(effective.get("min_quality_for_entry", 0.0))
+
+        # Parse earnings data
+        earnings_data: list[dict[str, Any]] = effective.get("earnings_data", [])
+
+        n = len(data)
+        close = data["close"].values.astype(np.float64)
+        bar_dates = _extract_dates(data.index)
+
+        # Build entry map: bar_index -> quality_score for qualified earnings
+        entry_map = self._build_entry_map(
+            earnings_data, bar_dates, delay, min_sue, min_gap, min_vol, min_quality
+        )
+
+        # Forward scan: generate entries and exits
+        entries_arr = np.zeros(n, dtype=bool)
+        exits_arr = np.zeros(n, dtype=bool)
+        sizing_arr = np.ones(n, dtype=np.float64)
+
+        in_position = False
+        entry_price = 0.0
+        bars_held = 0
+
+        for i in range(n):
+            if in_position:
+                bars_held += 1
+                pnl_pct = (close[i] - entry_price) / entry_price
+
+                # Check exits (priority: stop > target > timeout)
+                if pnl_pct <= stop_pct:
+                    exits_arr[i] = True
+                    in_position = False
+                elif pnl_pct >= target_pct:
+                    exits_arr[i] = True
+                    in_position = False
+                elif bars_held >= max_hold:
+                    exits_arr[i] = True
+                    in_position = False
+            else:
+                # Check for entry
+                if i in entry_map:
+                    entries_arr[i] = True
+                    in_position = True
+                    entry_price = close[i]
+                    bars_held = 0
+                    if use_sizing:
+                        sizing_arr[i] = entry_map[i] / 100.0  # Normalize 0-100 → 0-1
+
+        entries = pd.Series(entries_arr, index=data.index, dtype=bool)
+        exits = pd.Series(exits_arr, index=data.index, dtype=bool)
+
+        if use_sizing:
+            self.entry_sizes = pd.Series(np.clip(sizing_arr, 0.1, 1.0), index=data.index)
+
+        return entries, exits
+
+    # ── Internal ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _build_entry_map(
+        earnings_data: list[dict[str, Any]],
+        bar_dates: list[date],
+        delay: int,
+        min_sue: float,
+        min_gap: float,
+        min_vol: float,
+        min_quality: float,
+    ) -> dict[int, float]:
+        """Map qualifying earnings events to bar indices.
+
+        For each earning:
+            1. Parse report_date
+            2. Apply filters (SUE, gap, volume, quality)
+            3. Find bar_index = first bar that is >= (report_date + delay trading days)
+            4. Look-ahead prevention: only report_date < bar_date
+
+        Returns:
+            {bar_index: quality_score} for each qualifying entry.
+        """
+        if not earnings_data or not bar_dates:
+            return {}
+
+        # Sort bar_dates for binary search
+        entry_map: dict[int, float] = {}
+
+        for earning in earnings_data:
+            # Parse report date
+            rdate = earning.get("report_date")
+            if rdate is None:
+                continue
+            if isinstance(rdate, str):
+                rdate = date.fromisoformat(rdate)
+
+            # Apply filters
+            sue = float(earning.get("sue_score", 0.0))
+            gap = float(earning.get("gap_pct", 0.0))
+            vol = float(earning.get("volume_ratio", 0.0))
+            quality = float(earning.get("quality_score", 50.0))
+
+            if sue < min_sue or gap < min_gap or vol < min_vol:
+                continue
+            if quality < min_quality:
+                continue
+
+            # Find entry bar: first bar >= report_date + delay days
+            # This is approximate — uses calendar days, not trading days
+            # (trading day arithmetic would require NYSE calendar import
+            # which is avoided in the signal generator for portability)
+            target_idx = _find_entry_bar(bar_dates, rdate, delay)
+            if target_idx is not None and target_idx not in entry_map:
+                entry_map[target_idx] = quality
+
+        return entry_map
+
+
+def _extract_dates(index: pd.DatetimeIndex) -> list[date]:
+    """Convert DatetimeIndex to list of date objects."""
+    return [d.date() if hasattr(d, "date") else d for d in index]
+
+
+def _find_entry_bar(bar_dates: list[date], report_date: date, delay: int) -> int | None:
+    """Find first bar index that is at least ``delay`` bars after report_date.
+
+    Look-ahead safe: the entry bar is always strictly after the report date,
+    and at least ``delay`` trading bars later.
+
+    Returns:
+        Bar index, or None if report_date is outside the data range.
+    """
+    # Find the first bar after report_date
+    first_after = None
+    for i, d in enumerate(bar_dates):
+        if d > report_date:
+            first_after = i
+            break
+
+    if first_after is None:
+        return None
+
+    # Advance by delay bars (these are trading bars since OHLCV only has trading days)
+    target = first_after + delay - 1
+    if target >= len(bar_dates):
+        return None
+
+    return target

--- a/src/infrastructure/adapters/earnings/attention_adapter.py
+++ b/src/infrastructure/adapters/earnings/attention_adapter.py
@@ -1,0 +1,216 @@
+"""Google Trends attention adapter for PEAD screener.
+
+Measures retail attention for earnings symbols using Google Trends data.
+Low-attention stocks show stronger post-earnings drift (under-reaction).
+High-attention stocks revert faster (efficient market pricing).
+
+Requires optional ``pytrends`` dependency.  When unavailable or rate-limited,
+returns ``None`` for attention — screening continues unblocked.
+
+Company name lookup prevents ticker-symbol ambiguity (CAT, AI, META).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yfinance as yf
+
+from src.utils.logging_setup import get_logger
+
+logger = get_logger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+DEFAULT_CACHE_PATH = PROJECT_ROOT / "data" / "cache" / "attention.json"
+
+# Classification thresholds (relative Google Trends interest 0-100)
+_LOW_THRESHOLD = 25
+_HIGH_THRESHOLD = 65
+
+
+class AttentionAdapter:
+    """Fetches and classifies Google Trends attention for symbols.
+
+    Caches results to ``data/cache/attention.json`` keyed by
+    ``{symbol}_{report_date}`` to avoid redundant API calls.
+
+    If ``pytrends`` is not installed, all methods return None gracefully.
+    """
+
+    def __init__(self, cache_path: Path | None = None) -> None:
+        self._cache_path = cache_path or DEFAULT_CACHE_PATH
+        self._cache: dict[str, Any] | None = None
+        self._pytrends_available = self._check_pytrends()
+
+    @staticmethod
+    def _check_pytrends() -> bool:
+        try:
+            import pytrends  # type: ignore[import-not-found]  # noqa: F401
+
+            return True
+        except ImportError:
+            logger.info("pytrends not installed — attention filter disabled")
+            return False
+
+    # ── Cache ────────────────────────────────────────────────────────────
+
+    def _load_cache(self) -> dict[str, Any]:
+        if self._cache is not None:
+            return self._cache
+
+        if self._cache_path.exists():
+            try:
+                self._cache = json.loads(self._cache_path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"Attention cache load error: {e}")
+                self._cache = {}
+        else:
+            self._cache = {}
+
+        return self._cache
+
+    def _save_cache(self) -> None:
+        cache = self._load_cache()
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache_path.write_text(json.dumps(cache, indent=2))
+
+    # ── Public API ───────────────────────────────────────────────────────
+
+    def get_attention_level(self, symbol: str, report_date: date) -> str | None:
+        """Get attention level for a symbol around its earnings report.
+
+        Returns:
+            "low" / "medium" / "high" / None (if data unavailable).
+        """
+        cache_key = f"{symbol}_{report_date.isoformat()}"
+        cache = self._load_cache()
+
+        if cache_key in cache:
+            level: str | None = cache[cache_key].get("level")
+            return level
+
+        if not self._pytrends_available:
+            return None
+
+        score = self._fetch_attention_score(symbol)
+        if score is None:
+            return None
+
+        level = self._classify(score)
+        cache[cache_key] = {"score": score, "level": level}
+        self._save_cache()
+
+        return level
+
+    def update_attention_batch(
+        self,
+        symbols_dates: list[tuple[str, date]],
+        delay_seconds: float = 2.0,
+    ) -> int:
+        """Pre-fetch attention data for a batch of (symbol, report_date) pairs.
+
+        Rate-limits requests to avoid 429 errors. Skips cached entries.
+
+        Returns:
+            Count of newly fetched attention scores.
+        """
+        if not self._pytrends_available:
+            logger.info("pytrends not installed — skipping attention batch")
+            return 0
+
+        cache = self._load_cache()
+        fetched = 0
+
+        for symbol, rdate in symbols_dates:
+            cache_key = f"{symbol}_{rdate.isoformat()}"
+            if cache_key in cache:
+                continue
+
+            score = self._fetch_attention_score(symbol)
+            if score is not None:
+                level = self._classify(score)
+                cache[cache_key] = {"score": score, "level": level}
+                fetched += 1
+                logger.info(f"Attention: {symbol} → {level} (score={score})")
+            else:
+                logger.warning(f"Attention: {symbol} → unavailable")
+
+            # Rate limit
+            if delay_seconds > 0:
+                time.sleep(delay_seconds)
+
+        if fetched > 0:
+            self._save_cache()
+
+        return fetched
+
+    # ── Internal ─────────────────────────────────────────────────────────
+
+    def _fetch_attention_score(self, symbol: str) -> int | None:
+        """Fetch Google Trends interest score for a symbol.
+
+        Uses ``"{company_name} stock"`` as search query to avoid
+        ticker-symbol ambiguity (CAT, AI, META).
+
+        Returns:
+            Peak interest score (0-100) in the last 7 days, or None.
+        """
+        query = self._build_search_query(symbol)
+        if query is None:
+            return None
+
+        try:
+            from pytrends.request import TrendReq  # type: ignore[import-not-found]
+
+            pytrends = TrendReq(hl="en-US", tz=300)
+            pytrends.build_payload([query], timeframe="now 7-d")
+            interest = pytrends.interest_over_time()
+
+            if interest.empty or query not in interest.columns:
+                return None
+
+            return int(interest[query].max())
+
+        except Exception as e:
+            logger.warning(f"Google Trends error for {symbol}: {e}")
+            return None
+
+    def _build_search_query(self, symbol: str) -> str | None:
+        """Build unambiguous Google Trends query.
+
+        Strategy: use "{company_name} stock" as primary query.
+        Fallback: "{symbol} stock earnings" if company name unavailable.
+
+        Examples:
+            AAPL -> "Apple stock"
+            CAT  -> "Caterpillar stock"
+            META -> "Meta Platforms stock"
+            AI   -> "C3.ai stock"
+        """
+        try:
+            ticker = yf.Ticker(symbol)
+            info = ticker.info
+            name = info.get("shortName") or info.get("longName")
+            if name:
+                # Strip common suffixes like "Inc.", "Corp.", "Ltd."
+                for suffix in [", Inc.", " Inc.", " Corp.", " Ltd.", " LLC"]:
+                    name = name.replace(suffix, "")
+                return f"{name.strip()} stock"
+        except Exception as e:
+            logger.debug(f"yfinance company name lookup failed for {symbol}: {e}")
+
+        # Fallback — less precise but still disambiguated
+        return f"{symbol} stock earnings"
+
+    @staticmethod
+    def _classify(score: int) -> str:
+        """Classify attention score into low/medium/high."""
+        if score <= _LOW_THRESHOLD:
+            return "low"
+        if score >= _HIGH_THRESHOLD:
+            return "high"
+        return "medium"

--- a/src/infrastructure/reporting/email_pead_renderer.py
+++ b/src/infrastructure/reporting/email_pead_renderer.py
@@ -71,8 +71,11 @@ def render_pead_email_text(
             slip = c.get("estimated_slippage_bps", 0)
             gap_held = "Y" if c.get("gap_held") else "N"
 
+            mq_sue = c.get("multi_quarter_sue")
+            mq_str = f" MQ:{mq_sue:.1f}" if mq_sue is not None else ""
+
             lines.append(f"#{i} {c['symbol']} [{tier}]")
-            lines.append(f"   SUE:{sue:.1f} Gap:{gap:+.1f}% Vol:{vol:.1f}x")
+            lines.append(f"   SUE:{sue:.1f}{mq_str} Gap:{gap:+.1f}% Vol:{vol:.1f}x")
             lines.append(f"   Quality: {score:.0f} {label}  Rev: {rev}")
             lines.append(f"   Gap Held: {gap_held}")
             lines.append(f"   Target: +{target:.1f}%  Stop: {stop:.1f}%")

--- a/src/infrastructure/reporting/pead/builder.py
+++ b/src/infrastructure/reporting/pead/builder.py
@@ -52,6 +52,11 @@ class PEADReportBuilder:
                     "consensus_eps": c.surprise.consensus_eps,
                     "surprise_pct": round(c.surprise.surprise_pct, 2),
                     "sue_score": round(c.surprise.sue_score, 2),
+                    "multi_quarter_sue": (
+                        round(c.surprise.multi_quarter_sue, 2)
+                        if c.surprise.multi_quarter_sue is not None
+                        else None
+                    ),
                     "earnings_day_gap": round(c.surprise.earnings_day_gap, 4),
                     "earnings_day_return": round(c.surprise.earnings_day_return, 4),
                     "earnings_day_volume_ratio": round(c.surprise.earnings_day_volume_ratio, 2),

--- a/src/services/pead_tracker_service.py
+++ b/src/services/pead_tracker_service.py
@@ -1,0 +1,266 @@
+"""PEAD tracker service — persists candidates and resolves outcomes.
+
+Uses OHLC first-touch logic to determine if profit target, stop loss,
+or max hold timeout was hit first.
+
+Cache file: data/cache/pead_tracker.json
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import pandas_market_calendars as mcal
+import yfinance as yf
+
+from src.domain.screeners.pead.models import PEADCandidate
+from src.domain.screeners.pead.tracker import TrackedCandidate, TrackerStats
+from src.utils.logging_setup import get_logger
+
+logger = get_logger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_TRACKER_PATH = PROJECT_ROOT / "data" / "cache" / "pead_tracker.json"
+
+_NYSE = mcal.get_calendar("NYSE")
+
+
+class PEADTrackerService:
+    """Manages PEAD candidate tracking and outcome resolution."""
+
+    def __init__(self, tracker_path: Path | None = None) -> None:
+        self._path = tracker_path or DEFAULT_TRACKER_PATH
+        self._candidates: list[TrackedCandidate] | None = None
+
+    # ── Persistence ────────────────────────────────────────────────────
+
+    def _load(self) -> list[TrackedCandidate]:
+        if self._candidates is not None:
+            return self._candidates
+
+        if not self._path.exists():
+            self._candidates = []
+            return self._candidates
+
+        try:
+            data = json.loads(self._path.read_text())
+            self._candidates = [TrackedCandidate.from_dict(d) for d in data.get("candidates", [])]
+            logger.info(f"Loaded {len(self._candidates)} tracked candidates")
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"Failed to load tracker: {e}")
+            self._candidates = []
+
+        return self._candidates
+
+    def _save(self) -> None:
+        candidates = self._load()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": "1.0",
+            "candidates": [c.to_dict() for c in candidates],
+        }
+        self._path.write_text(json.dumps(payload, indent=2))
+        logger.info(f"Saved {len(candidates)} tracked candidates")
+
+    # ── Public API ─────────────────────────────────────────────────────
+
+    def add_candidates(self, candidates: list[PEADCandidate]) -> int:
+        """Add new candidates for tracking. Dedup by (symbol, entry_date).
+
+        Returns count of newly added candidates.
+        """
+        existing = self._load()
+        existing_keys = {(c.symbol, c.entry_date) for c in existing}
+
+        added = 0
+        for c in candidates:
+            key = (c.symbol, c.entry_date)
+            if key in existing_keys:
+                continue
+
+            tracked = TrackedCandidate(
+                symbol=c.symbol,
+                entry_date=c.entry_date,
+                entry_price=c.entry_price,
+                profit_target_pct=c.profit_target_pct,
+                stop_loss_pct=c.stop_loss_pct,
+                max_hold_days=c.max_hold_days,
+                quality_score=c.quality_score,
+                quality_label=c.quality_label,
+                sue_score=c.surprise.sue_score,
+                multi_quarter_sue=c.surprise.multi_quarter_sue,
+                regime=c.regime,
+            )
+            existing.append(tracked)
+            existing_keys.add(key)
+            added += 1
+
+        if added > 0:
+            self._save()
+            logger.info(f"Added {added} new candidates to tracker")
+
+        return added
+
+    def update_outcomes(self) -> int:
+        """Resolve open candidates via OHLC first-touch. Returns count resolved."""
+        candidates = self._load()
+        open_candidates = [c for c in candidates if c.status == "open"]
+
+        if not open_candidates:
+            logger.info("No open candidates to resolve")
+            return 0
+
+        resolved = 0
+        for candidate in open_candidates:
+            result = self._resolve_candidate(candidate)
+            if result:
+                resolved += 1
+
+        if resolved > 0:
+            self._save()
+
+        logger.info(f"Resolved {resolved}/{len(open_candidates)} open candidates")
+        return resolved
+
+    def get_stats(self) -> TrackerStats:
+        """Compute aggregate performance statistics."""
+        candidates = self._load()
+
+        if not candidates:
+            return TrackerStats()
+
+        resolved = [c for c in candidates if c.status != "open"]
+        won = [c for c in resolved if c.status == "won"]
+        lost = [c for c in resolved if c.status == "lost"]
+        timeout = [c for c in resolved if c.status == "timeout"]
+        open_count = len(candidates) - len(resolved)
+
+        win_rate = len(won) / len(resolved) if resolved else None
+        avg_pnl = (
+            sum(c.pnl_pct for c in resolved if c.pnl_pct is not None) / len(resolved)
+            if resolved
+            else None
+        )
+
+        # Average hold days
+        hold_days_list = []
+        for c in resolved:
+            if c.exit_date and c.entry_date:
+                hold_days_list.append((c.exit_date - c.entry_date).days)
+        avg_hold = sum(hold_days_list) / len(hold_days_list) if hold_days_list else None
+
+        # By quality tier
+        by_quality: dict[str, dict[str, Any]] = {}
+        for label in ["STRONG", "MODERATE", "MARGINAL"]:
+            tier_resolved = [c for c in resolved if c.quality_label == label]
+            tier_won = [c for c in tier_resolved if c.status == "won"]
+            if tier_resolved:
+                tier_pnls = [c.pnl_pct for c in tier_resolved if c.pnl_pct is not None]
+                by_quality[label] = {
+                    "total": len(tier_resolved),
+                    "win_rate": round(len(tier_won) / len(tier_resolved), 4),
+                    "avg_pnl_pct": (
+                        round(sum(tier_pnls) / len(tier_pnls), 4) if tier_pnls else None
+                    ),
+                }
+
+        return TrackerStats(
+            total=len(candidates),
+            open=open_count,
+            won=len(won),
+            lost=len(lost),
+            timeout=len(timeout),
+            win_rate=win_rate,
+            avg_pnl_pct=avg_pnl,
+            avg_hold_days=avg_hold,
+            by_quality=by_quality,
+        )
+
+    def get_all_candidates(self) -> list[TrackedCandidate]:
+        """Return all tracked candidates."""
+        return list(self._load())
+
+    # ── OHLC First-Touch Resolution ────────────────────────────────────
+
+    def _resolve_candidate(self, candidate: TrackedCandidate) -> bool:
+        """Resolve a single open candidate using daily OHLC first-touch logic.
+
+        For each trading day from entry_date to today:
+            1. Check if day's LOW <= stop_loss price → LOST
+            2. Check if day's HIGH >= profit_target price → WON
+            3. If both triggered on same bar: stop wins (conservative)
+            4. If trading_days >= max_hold_days → TIMEOUT (use closing price)
+
+        Returns True if candidate was resolved, False if data unavailable.
+        """
+        target_price = candidate.target_price
+        stop_price = candidate.stop_price
+        today = date.today()
+
+        # Fetch OHLC data from entry date to today
+        start = candidate.entry_date
+        end = today + timedelta(days=1)
+
+        try:
+            ticker = yf.Ticker(candidate.symbol)
+            hist = ticker.history(start=start.isoformat(), end=end.isoformat())
+        except Exception as e:
+            logger.warning(f"yfinance error for {candidate.symbol}: {e}")
+            return False
+
+        if hist.empty:
+            return False
+
+        # Count trading days for max hold check
+        trading_day_count = 0
+
+        for _, row in hist.iterrows():
+            trading_day_count += 1
+            day_date = row.name.date() if hasattr(row.name, "date") else row.name
+            day_low = float(row["Low"])
+            day_high = float(row["High"])
+            day_close = float(row["Close"])
+
+            stop_hit = day_low <= stop_price
+            target_hit = day_high >= target_price
+
+            # Same-bar: stop wins (conservative)
+            if stop_hit and target_hit:
+                candidate.exit_date = day_date
+                candidate.exit_price = stop_price
+                candidate.exit_reason = "stop_loss"
+                candidate.pnl_pct = candidate.stop_loss_pct
+                candidate.status = "lost"
+                return True
+
+            if stop_hit:
+                candidate.exit_date = day_date
+                candidate.exit_price = stop_price
+                candidate.exit_reason = "stop_loss"
+                candidate.pnl_pct = candidate.stop_loss_pct
+                candidate.status = "lost"
+                return True
+
+            if target_hit:
+                candidate.exit_date = day_date
+                candidate.exit_price = target_price
+                candidate.exit_reason = "profit_target"
+                candidate.pnl_pct = candidate.profit_target_pct
+                candidate.status = "won"
+                return True
+
+            # Max hold timeout
+            if trading_day_count >= candidate.max_hold_days:
+                pnl = (day_close - candidate.entry_price) / candidate.entry_price
+                candidate.exit_date = day_date
+                candidate.exit_price = day_close
+                candidate.exit_reason = "timeout"
+                candidate.pnl_pct = round(pnl, 6)
+                candidate.status = "timeout"
+                return True
+
+        # Not enough days elapsed yet — candidate stays open
+        return False

--- a/tests/unit/screeners/test_attention_adapter.py
+++ b/tests/unit/screeners/test_attention_adapter.py
@@ -1,0 +1,154 @@
+"""Unit tests for PEAD attention adapter (Google Trends)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.infrastructure.adapters.earnings.attention_adapter import AttentionAdapter
+
+
+class TestQueryBuilding:
+    @patch("src.infrastructure.adapters.earnings.attention_adapter.yf")
+    def test_build_query_with_company_name(self, mock_yf: MagicMock) -> None:
+        """Uses '{company_name} stock' when yfinance returns a name."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"shortName": "Apple Inc."}
+        mock_yf.Ticker.return_value = mock_ticker
+
+        adapter = AttentionAdapter()
+        query = adapter._build_search_query("AAPL")
+        assert query == "Apple stock"
+
+    @patch("src.infrastructure.adapters.earnings.attention_adapter.yf")
+    def test_build_query_strips_corp_suffix(self, mock_yf: MagicMock) -> None:
+        """Strips Inc., Corp., Ltd. suffixes."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"shortName": "Caterpillar Inc."}
+        mock_yf.Ticker.return_value = mock_ticker
+
+        adapter = AttentionAdapter()
+        query = adapter._build_search_query("CAT")
+        assert query == "Caterpillar stock"
+
+    @patch("src.infrastructure.adapters.earnings.attention_adapter.yf")
+    def test_build_query_fallback(self, mock_yf: MagicMock) -> None:
+        """Falls back to '{symbol} stock earnings' when name unavailable."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}
+        mock_yf.Ticker.return_value = mock_ticker
+
+        adapter = AttentionAdapter()
+        query = adapter._build_search_query("XYZ")
+        assert query == "XYZ stock earnings"
+
+    @patch("src.infrastructure.adapters.earnings.attention_adapter.yf")
+    def test_build_query_exception_fallback(self, mock_yf: MagicMock) -> None:
+        """Falls back gracefully when yfinance raises."""
+        mock_yf.Ticker.side_effect = Exception("network error")
+
+        adapter = AttentionAdapter()
+        query = adapter._build_search_query("FAIL")
+        assert query == "FAIL stock earnings"
+
+
+class TestClassification:
+    def test_low_attention(self) -> None:
+        assert AttentionAdapter._classify(10) == "low"
+        assert AttentionAdapter._classify(25) == "low"
+
+    def test_medium_attention(self) -> None:
+        assert AttentionAdapter._classify(26) == "medium"
+        assert AttentionAdapter._classify(50) == "medium"
+        assert AttentionAdapter._classify(64) == "medium"
+
+    def test_high_attention(self) -> None:
+        assert AttentionAdapter._classify(65) == "high"
+        assert AttentionAdapter._classify(100) == "high"
+
+
+class TestCaching:
+    def test_cache_hit_returns_level(self) -> None:
+        """Cached entries are returned without API calls."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        cache = {"AAPL_2025-01-27": {"score": 80, "level": "high"}}
+        path.write_text(json.dumps(cache))
+
+        adapter = AttentionAdapter(cache_path=path)
+        level = adapter.get_attention_level("AAPL", date(2025, 1, 27))
+        assert level == "high"
+
+        path.unlink(missing_ok=True)
+
+    def test_cache_miss_without_pytrends_returns_none(self) -> None:
+        """When pytrends is unavailable, uncached entries return None."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        adapter = AttentionAdapter(cache_path=path)
+        adapter._pytrends_available = False
+
+        level = adapter.get_attention_level("AAPL", date(2025, 1, 27))
+        assert level is None
+
+        path.unlink(missing_ok=True)
+
+
+class TestBatchUpdate:
+    def test_batch_skips_when_no_pytrends(self) -> None:
+        """Batch update returns 0 when pytrends unavailable."""
+        adapter = AttentionAdapter()
+        adapter._pytrends_available = False
+
+        count = adapter.update_attention_batch([("AAPL", date(2025, 1, 27))])
+        assert count == 0
+
+    def test_batch_skips_cached(self) -> None:
+        """Already-cached entries are not re-fetched."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        cache = {"AAPL_2025-01-27": {"score": 80, "level": "high"}}
+        path.write_text(json.dumps(cache))
+
+        adapter = AttentionAdapter(cache_path=path)
+        adapter._pytrends_available = True
+
+        # Mock _fetch_attention_score to track calls
+        adapter._fetch_attention_score = MagicMock(return_value=None)  # type: ignore[assignment]
+
+        adapter.update_attention_batch([("AAPL", date(2025, 1, 27))], delay_seconds=0)
+        adapter._fetch_attention_score.assert_not_called()  # type: ignore[attr-defined]
+
+        path.unlink(missing_ok=True)
+
+
+class TestAttentionModifierIntegration:
+    def test_apply_attention_modifier_low_bonus(self) -> None:
+        from src.domain.screeners.pead.scorer import apply_attention_modifier
+
+        result = apply_attention_modifier(50.0, "low", low_bonus=5.0)
+        assert result == 55.0
+
+    def test_apply_attention_modifier_high_penalty(self) -> None:
+        from src.domain.screeners.pead.scorer import apply_attention_modifier
+
+        result = apply_attention_modifier(50.0, "high", high_penalty=-5.0)
+        assert result == 45.0
+
+    def test_apply_attention_modifier_medium_no_change(self) -> None:
+        from src.domain.screeners.pead.scorer import apply_attention_modifier
+
+        result = apply_attention_modifier(50.0, "medium")
+        assert result == 50.0
+
+    def test_apply_attention_modifier_none_no_change(self) -> None:
+        from src.domain.screeners.pead.scorer import apply_attention_modifier
+
+        result = apply_attention_modifier(50.0, None)
+        assert result == 50.0

--- a/tests/unit/screeners/test_fmp_merge.py
+++ b/tests/unit/screeners/test_fmp_merge.py
@@ -1,0 +1,167 @@
+"""Tests for FMP earnings merge logic — BMO/AMC alignment and SUE leakage fixes."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from src.infrastructure.adapters.earnings.fmp_earnings import FMPEarningsAdapter
+
+
+def _make_calendar_entry(
+    symbol: str = "AAPL",
+    report_date: str = "2025-01-27",
+    actual_eps: float = 2.50,
+    estimated_eps: float = 2.00,
+    report_time: str = "bmo",
+) -> dict:
+    return {
+        "symbol": symbol,
+        "date": report_date,
+        "time": report_time,
+        "epsActual": actual_eps,
+        "epsEstimated": estimated_eps,
+        "revenueActual": 100_000,
+        "revenueEstimated": 95_000,
+    }
+
+
+def _make_history(
+    quarters: list[tuple[str, float, float]],
+) -> list[dict]:
+    """Build history list: [(date, actual, est), ...]"""
+    return [{"date": d, "epsActual": a, "epsEstimated": e} for d, a, e in quarters]
+
+
+_EMPTY_GRADES: list[dict] = []
+_DEFAULT_PRICE = {
+    "prior_close": 100.0,
+    "open": 105.0,
+    "close": 106.0,
+    "volume": 5_000_000,
+    "avg_20d_volume": 2_000_000,
+    "high_52w": 110.0,
+    "current_price": 106.0,
+    "forward_pe": 25.0,
+}
+
+
+class TestBmoAmcAlignment:
+    def test_bmo_stores_report_time(self) -> None:
+        """BMO report_time is stored in merged dict."""
+        entry = _make_calendar_entry(report_time="bmo")
+        merged = FMPEarningsAdapter._merge_earning_data(
+            entry,
+            [],
+            _EMPTY_GRADES,
+            _DEFAULT_PRICE,
+            date(2025, 1, 27),
+            report_time="bmo",
+        )
+        assert merged["report_time"] == "bmo"
+
+    def test_amc_stores_report_time(self) -> None:
+        """AMC report_time is stored in merged dict."""
+        entry = _make_calendar_entry(report_time="amc")
+        merged = FMPEarningsAdapter._merge_earning_data(
+            entry,
+            [],
+            _EMPTY_GRADES,
+            _DEFAULT_PRICE,
+            date(2025, 1, 27),
+            report_time="amc",
+        )
+        assert merged["report_time"] == "amc"
+
+    def test_missing_time_defaults_bmo(self) -> None:
+        """When time field is None, default is bmo."""
+        entry = _make_calendar_entry()
+        entry["time"] = None
+        # The default in _merge_earning_data is "bmo"
+        merged = FMPEarningsAdapter._merge_earning_data(
+            entry,
+            [],
+            _EMPTY_GRADES,
+            _DEFAULT_PRICE,
+            date(2025, 1, 27),
+        )
+        assert merged["report_time"] == "bmo"
+
+
+class TestSueLeakageFix:
+    def test_sue_excludes_current_quarter(self) -> None:
+        """Current quarter is excluded from historical_surprises."""
+        # History includes current quarter (2025-01-27) and 7 past quarters
+        history = _make_history(
+            [
+                ("2025-01-27", 2.50, 2.00),  # Current quarter — should be excluded
+                ("2024-10-25", 2.20, 2.10),
+                ("2024-07-26", 2.10, 2.00),
+                ("2024-04-26", 1.90, 1.80),
+                ("2024-01-26", 1.80, 1.70),
+                ("2023-10-27", 1.70, 1.60),
+                ("2023-07-28", 1.60, 1.50),
+                ("2023-04-28", 1.50, 1.40),
+            ]
+        )
+        entry = _make_calendar_entry(report_date="2025-01-27")
+        merged = FMPEarningsAdapter._merge_earning_data(
+            entry,
+            history,
+            _EMPTY_GRADES,
+            _DEFAULT_PRICE,
+            date(2025, 1, 27),
+        )
+        surprises = merged["historical_surprises"]
+        # Current quarter surprise = 2.50 - 2.00 = 0.50 — should NOT be present
+        assert 0.50 not in surprises
+        # Should have 7 past quarters
+        assert len(surprises) == 7
+
+    def test_sue_history_sorted_descending(self) -> None:
+        """History is sorted most-recent-first regardless of input order."""
+        # Intentionally unsorted input
+        history = _make_history(
+            [
+                ("2023-04-28", 1.50, 1.40),  # oldest
+                ("2024-10-25", 2.20, 2.10),  # 2nd most recent
+                ("2024-01-26", 1.80, 1.70),
+                ("2024-07-26", 2.10, 2.00),
+                ("2023-10-27", 1.70, 1.60),
+                ("2024-04-26", 1.90, 1.80),
+            ]
+        )
+        entry = _make_calendar_entry(report_date="2025-01-27")
+        merged = FMPEarningsAdapter._merge_earning_data(
+            entry,
+            history,
+            _EMPTY_GRADES,
+            _DEFAULT_PRICE,
+            date(2025, 1, 27),
+        )
+        surprises = merged["historical_surprises"]
+        # Most recent surprise (2024-10-25: 2.20-2.10=0.10) should be first
+        assert abs(surprises[0] - 0.10) < 0.001
+        # Oldest (2023-04-28: 1.50-1.40=0.10) should be last
+        assert abs(surprises[-1] - 0.10) < 0.001
+
+    def test_sue_12q_history(self) -> None:
+        """With 12+ quarters available, takes first 12 after excluding current."""
+        history = _make_history(
+            [
+                ("2025-01-27", 2.50, 2.00),  # Current — excluded
+                *[
+                    (f"20{24 - i // 4}-{['01', '04', '07', '10'][i % 4]}-15", 1.0 + i * 0.01, 1.0)
+                    for i in range(14)
+                ],
+            ]
+        )
+        entry = _make_calendar_entry(report_date="2025-01-27")
+        merged = FMPEarningsAdapter._merge_earning_data(
+            entry,
+            history,
+            _EMPTY_GRADES,
+            _DEFAULT_PRICE,
+            date(2025, 1, 27),
+        )
+        # Should have at most 12 quarters (sliced from past_history[:12])
+        assert len(merged["historical_surprises"]) <= 12

--- a/tests/unit/screeners/test_pead_tracker.py
+++ b/tests/unit/screeners/test_pead_tracker.py
@@ -1,0 +1,344 @@
+"""Unit tests for PEAD tracker service — OHLC first-touch resolution."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from src.domain.screeners.pead.tracker import TrackedCandidate, TrackerStats
+from src.services.pead_tracker_service import PEADTrackerService
+
+
+def _make_tracked(
+    symbol: str = "AAPL",
+    entry_date: date = date(2025, 1, 29),
+    entry_price: float = 200.0,
+    profit_target_pct: float = 0.06,
+    stop_loss_pct: float = -0.05,
+    max_hold_days: int = 25,
+    quality_score: float = 75.0,
+    quality_label: str = "STRONG",
+    sue_score: float = 4.5,
+    regime: str = "R0",
+) -> TrackedCandidate:
+    return TrackedCandidate(
+        symbol=symbol,
+        entry_date=entry_date,
+        entry_price=entry_price,
+        profit_target_pct=profit_target_pct,
+        stop_loss_pct=stop_loss_pct,
+        max_hold_days=max_hold_days,
+        quality_score=quality_score,
+        quality_label=quality_label,
+        sue_score=sue_score,
+        multi_quarter_sue=None,
+        regime=regime,
+    )
+
+
+def _make_ohlc_df(rows: list[tuple[str, float, float, float, float]]) -> pd.DataFrame:
+    """Build yfinance-style OHLC DataFrame: [(date, open, high, low, close), ...]"""
+    dates = pd.to_datetime([r[0] for r in rows])
+    data = {
+        "Open": [r[1] for r in rows],
+        "High": [r[2] for r in rows],
+        "Low": [r[3] for r in rows],
+        "Close": [r[4] for r in rows],
+        "Volume": [1_000_000] * len(rows),
+    }
+    return pd.DataFrame(data, index=dates)
+
+
+class TestTrackedCandidate:
+    def test_target_price(self) -> None:
+        c = _make_tracked(entry_price=100.0, profit_target_pct=0.06)
+        assert c.target_price == 106.0
+
+    def test_stop_price(self) -> None:
+        c = _make_tracked(entry_price=100.0, stop_loss_pct=-0.05)
+        assert c.stop_price == 95.0
+
+    def test_round_trip_serialization(self) -> None:
+        c = _make_tracked()
+        d = c.to_dict()
+        c2 = TrackedCandidate.from_dict(d)
+        assert c2.symbol == c.symbol
+        assert c2.entry_date == c.entry_date
+        assert c2.entry_price == c.entry_price
+        assert c2.status == "open"
+
+
+class TestTrackerPersistence:
+    def test_add_and_load(self) -> None:
+        """Add candidates, save, reload, verify persistence."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        c = _make_tracked()
+
+        # Manually add via internal API
+        tracker._load()
+        tracker._candidates = [c]
+        tracker._save()
+
+        # Reload
+        tracker2 = PEADTrackerService(tracker_path=path)
+        loaded = tracker2._load()
+        assert len(loaded) == 1
+        assert loaded[0].symbol == "AAPL"
+
+        path.unlink(missing_ok=True)
+
+    def test_dedup_by_symbol_date(self) -> None:
+        """No duplicate tracking for same (symbol, entry_date)."""
+        from src.domain.screeners.pead.models import (
+            EarningsSurprise,
+            LiquidityTier,
+            PEADCandidate,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+
+        surprise = EarningsSurprise(
+            symbol="AAPL",
+            report_date=date(2025, 1, 27),
+            actual_eps=2.5,
+            consensus_eps=2.0,
+            surprise_pct=25.0,
+            sue_score=4.5,
+            earnings_day_return=0.06,
+            earnings_day_gap=0.05,
+            earnings_day_volume_ratio=3.0,
+            revenue_beat=True,
+            at_52w_high=False,
+            analyst_downgrade=False,
+            liquidity_tier=LiquidityTier.LARGE_CAP,
+        )
+        candidate = PEADCandidate(
+            symbol="AAPL",
+            surprise=surprise,
+            entry_date=date(2025, 1, 29),
+            entry_price=200.0,
+            profit_target_pct=0.06,
+            stop_loss_pct=-0.05,
+            trailing_stop_atr=2.0,
+            trailing_activation_pct=0.03,
+            max_hold_days=25,
+            position_size_factor=1.0,
+            quality_score=75.0,
+            quality_label="STRONG",
+            regime="R0",
+            gap_held=True,
+            estimated_slippage_bps=10,
+        )
+
+        # Add twice
+        added1 = tracker.add_candidates([candidate])
+        added2 = tracker.add_candidates([candidate])
+        assert added1 == 1
+        assert added2 == 0  # Duplicate
+
+        path.unlink(missing_ok=True)
+
+
+class TestFirstTouchResolution:
+    @patch("src.services.pead_tracker_service.yf")
+    def test_first_touch_stop_hit(self, mock_yf: MagicMock) -> None:
+        """Stop loss hit before target."""
+        candidate = _make_tracked(entry_price=100.0, profit_target_pct=0.06, stop_loss_pct=-0.05)
+        # Day 1: price drops to 94 (below stop of 95)
+        hist = _make_ohlc_df(
+            [
+                ("2025-01-29", 100.0, 101.0, 94.0, 96.0),
+            ]
+        )
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = hist
+        mock_yf.Ticker.return_value = mock_ticker
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        tracker._candidates = [candidate]
+
+        result = tracker._resolve_candidate(candidate)
+        assert result is True
+        assert candidate.status == "lost"
+        assert candidate.exit_reason == "stop_loss"
+        assert candidate.pnl_pct == -0.05
+
+        path.unlink(missing_ok=True)
+
+    @patch("src.services.pead_tracker_service.yf")
+    def test_first_touch_target_hit(self, mock_yf: MagicMock) -> None:
+        """Profit target hit before stop."""
+        candidate = _make_tracked(entry_price=100.0, profit_target_pct=0.06, stop_loss_pct=-0.05)
+        # Day 1: price rises to 107 (above target of 106)
+        hist = _make_ohlc_df(
+            [
+                ("2025-01-29", 100.0, 107.0, 99.0, 106.0),
+            ]
+        )
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = hist
+        mock_yf.Ticker.return_value = mock_ticker
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        tracker._candidates = [candidate]
+
+        result = tracker._resolve_candidate(candidate)
+        assert result is True
+        assert candidate.status == "won"
+        assert candidate.exit_reason == "profit_target"
+        assert candidate.pnl_pct == 0.06
+
+        path.unlink(missing_ok=True)
+
+    @patch("src.services.pead_tracker_service.yf")
+    def test_same_bar_stop_wins(self, mock_yf: MagicMock) -> None:
+        """Both stop and target triggered on same bar — stop wins (conservative)."""
+        candidate = _make_tracked(entry_price=100.0, profit_target_pct=0.06, stop_loss_pct=-0.05)
+        # Extreme volatility: low=94 (stop hit), high=107 (target hit)
+        hist = _make_ohlc_df(
+            [
+                ("2025-01-29", 100.0, 107.0, 94.0, 102.0),
+            ]
+        )
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = hist
+        mock_yf.Ticker.return_value = mock_ticker
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        tracker._candidates = [candidate]
+
+        result = tracker._resolve_candidate(candidate)
+        assert result is True
+        assert candidate.status == "lost"
+        assert candidate.exit_reason == "stop_loss"
+
+        path.unlink(missing_ok=True)
+
+    @patch("src.services.pead_tracker_service.yf")
+    def test_timeout_at_max_hold(self, mock_yf: MagicMock) -> None:
+        """Neither target nor stop hit within max_hold_days — timeout."""
+        candidate = _make_tracked(
+            entry_price=100.0, profit_target_pct=0.06, stop_loss_pct=-0.05, max_hold_days=3
+        )
+        # 3 days of sideways action — neither triggered
+        hist = _make_ohlc_df(
+            [
+                ("2025-01-29", 100.0, 103.0, 97.0, 101.0),
+                ("2025-01-30", 101.0, 104.0, 98.0, 102.0),
+                ("2025-01-31", 102.0, 104.0, 98.0, 103.0),
+            ]
+        )
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = hist
+        mock_yf.Ticker.return_value = mock_ticker
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        tracker._candidates = [candidate]
+
+        result = tracker._resolve_candidate(candidate)
+        assert result is True
+        assert candidate.status == "timeout"
+        assert candidate.exit_reason == "timeout"
+        assert candidate.pnl_pct is not None
+        assert abs(candidate.pnl_pct - 0.03) < 0.001  # (103-100)/100
+
+        path.unlink(missing_ok=True)
+
+    @patch("src.services.pead_tracker_service.yf")
+    def test_ohlc_data_unavailable(self, mock_yf: MagicMock) -> None:
+        """Candidate stays open when OHLC data unavailable."""
+        candidate = _make_tracked()
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = pd.DataFrame()  # Empty
+        mock_yf.Ticker.return_value = mock_ticker
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        tracker._candidates = [candidate]
+
+        result = tracker._resolve_candidate(candidate)
+        assert result is False
+        assert candidate.status == "open"
+
+        path.unlink(missing_ok=True)
+
+
+class TestTrackerStats:
+    def test_stats_with_zero_resolved(self) -> None:
+        """Empty tracker returns zero stats."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        stats = tracker.get_stats()
+        assert stats.total == 0
+        assert stats.win_rate is None
+        assert stats.avg_pnl_pct is None
+
+        path.unlink(missing_ok=True)
+
+    def test_stats_with_mixed_outcomes(self) -> None:
+        """Stats computed correctly with mixed won/lost/timeout."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+
+        tracker = PEADTrackerService(tracker_path=path)
+        candidates = [
+            _make_tracked(symbol="WIN1", quality_label="STRONG"),
+            _make_tracked(symbol="WIN2", quality_label="STRONG"),
+            _make_tracked(symbol="LOSE", quality_label="MODERATE"),
+            _make_tracked(symbol="OPEN", quality_label="MARGINAL"),
+        ]
+        # Resolve manually
+        candidates[0].status = "won"
+        candidates[0].pnl_pct = 0.06
+        candidates[0].exit_date = date(2025, 2, 10)
+        candidates[1].status = "won"
+        candidates[1].pnl_pct = 0.06
+        candidates[1].exit_date = date(2025, 2, 12)
+        candidates[2].status = "lost"
+        candidates[2].pnl_pct = -0.05
+        candidates[2].exit_date = date(2025, 2, 5)
+
+        tracker._candidates = candidates
+        stats = tracker.get_stats()
+
+        assert stats.total == 4
+        assert stats.open == 1
+        assert stats.won == 2
+        assert stats.lost == 1
+        assert stats.timeout == 0
+        # Win rate = 2/3 resolved
+        assert stats.win_rate is not None
+        assert abs(stats.win_rate - 2 / 3) < 0.01
+        # Avg P&L = (0.06 + 0.06 - 0.05) / 3
+        assert stats.avg_pnl_pct is not None
+        expected_pnl = (0.06 + 0.06 - 0.05) / 3
+        assert abs(stats.avg_pnl_pct - expected_pnl) < 0.001
+
+        path.unlink(missing_ok=True)

--- a/tests/unit/screeners/test_sue.py
+++ b/tests/unit/screeners/test_sue.py
@@ -1,0 +1,110 @@
+"""Unit tests for SUE computation and multi-quarter SUE."""
+
+from __future__ import annotations
+
+from src.domain.screeners.pead.sue import compute_multi_quarter_sue, compute_sue
+
+# ═══════════════════════════════════════════════════════════════════════
+# Single-Quarter SUE
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestComputeSue:
+    def test_sue_with_history(self) -> None:
+        """SUE = raw_surprise / stdev(history) when >= 4 quarters."""
+        history = [0.10, -0.05, 0.15, 0.20, -0.10, 0.05, 0.08, -0.03]
+        sue = compute_sue(2.50, 2.00, history)
+        # raw = 0.50, stdev ≈ 0.104
+        assert sue > 4.0, f"Expected SUE > 4.0, got {sue:.2f}"
+
+    def test_sue_no_history(self) -> None:
+        """Fallback when < 4 quarters: raw / (|consensus| * 0.05 + 0.01)."""
+        sue = compute_sue(2.50, 2.00, [0.1, 0.2])
+        # raw = 0.50, denom = 2.0 * 0.05 + 0.01 = 0.11
+        expected = 0.50 / 0.11
+        assert abs(sue - expected) < 0.01
+
+    def test_sue_zero_std(self) -> None:
+        """When all historical surprises are identical, use fallback."""
+        sue = compute_sue(2.50, 2.00, [0.1, 0.1, 0.1, 0.1])
+        # std=0, fallback to proxy
+        assert sue > 0
+
+    def test_sue_excludes_current_quarter(self) -> None:
+        """Verify that history should not contain current quarter data.
+
+        This test documents the contract: callers must pre-filter history
+        to exclude the current quarter before calling compute_sue.
+        The FMP adapter does this in _merge_earning_data (Phase 0.3 fix).
+        """
+        # Same data with/without current quarter produces different SUE
+        # because stdev changes when the outlier is included
+        history_with_leak = [0.50, 0.10, -0.05, 0.15, 0.20]  # 0.50 = current Q
+        history_clean = [0.10, -0.05, 0.15, 0.20]  # current Q excluded
+        sue_leak = compute_sue(2.50, 2.00, history_with_leak)
+        sue_clean = compute_sue(2.50, 2.00, history_clean)
+        # The leaky version has different stdev, producing different SUE
+        assert sue_leak != sue_clean
+
+    def test_sue_history_order(self) -> None:
+        """SUE computation uses stdev which is order-invariant, so any order works."""
+        history_asc = [-0.10, -0.05, 0.05, 0.10, 0.15, 0.20]
+        history_desc = [0.20, 0.15, 0.10, 0.05, -0.05, -0.10]
+        sue_asc = compute_sue(2.50, 2.00, history_asc)
+        sue_desc = compute_sue(2.50, 2.00, history_desc)
+        assert abs(sue_asc - sue_desc) < 0.001
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Multi-Quarter SUE
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestMultiQuarterSue:
+    def test_decay_weighting(self) -> None:
+        """Exponential decay gives more weight to recent quarters."""
+        # All positive: more recent = higher weight
+        history = [0.20, 0.15, 0.10, 0.05, 0.02, 0.01]
+        mq = compute_multi_quarter_sue(history, decay_lambda=0.75, min_quarters=6)
+        assert mq is not None
+        assert mq > 0  # All positive surprises → positive multi-Q
+
+    def test_returns_none_when_insufficient(self) -> None:
+        """Returns None when fewer than min_quarters."""
+        mq = compute_multi_quarter_sue([0.1, 0.2, 0.3], min_quarters=6)
+        assert mq is None
+
+    def test_empty_list(self) -> None:
+        """Empty list returns None."""
+        mq = compute_multi_quarter_sue([], min_quarters=1)
+        assert mq is None
+
+    def test_deteriorating_trajectory(self) -> None:
+        """Deteriorating trajectory (positive → negative) yields negative multi-Q."""
+        # Recent quarters are negative, older were positive
+        history = [-0.20, -0.15, -0.10, 0.05, 0.10, 0.15]
+        mq = compute_multi_quarter_sue(history, decay_lambda=0.75, min_quarters=6)
+        assert mq is not None
+        assert mq < 0
+
+    def test_decay_lambda_effect(self) -> None:
+        """Higher decay_lambda means more weight on older quarters."""
+        history = [0.30, -0.05, -0.05, -0.05, -0.05, -0.05]
+        # With high decay (0.9): older negative quarters matter more → lower score
+        mq_high = compute_multi_quarter_sue(history, decay_lambda=0.9, min_quarters=6)
+        # With low decay (0.5): recent positive dominates → higher score
+        mq_low = compute_multi_quarter_sue(history, decay_lambda=0.5, min_quarters=6)
+        assert mq_high is not None and mq_low is not None
+        # Low decay should give higher score (more weight to the positive recent Q)
+        assert mq_low > mq_high
+
+    def test_hand_computed(self) -> None:
+        """Hand-computed expected value for 6 quarters with lambda=0.75."""
+        history = [0.10, 0.10, 0.10, 0.10, 0.10, 0.10]
+        # All identical = 0.10
+        # weights: 1, 0.75, 0.5625, 0.421875, 0.316406, 0.237305
+        # weighted_mean = 0.10 (all same) / 1 = 0.10
+        # stdev of identical = 0, so fallback returns raw weighted_mean
+        mq = compute_multi_quarter_sue(history, decay_lambda=0.75, min_quarters=6)
+        assert mq is not None
+        assert abs(mq - 0.10) < 0.001

--- a/tests/unit/strategy/signals/test_pead_signal_generator.py
+++ b/tests/unit/strategy/signals/test_pead_signal_generator.py
@@ -1,0 +1,260 @@
+"""Unit tests for PEAD signal generator (VectorBT integration)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.domain.strategy.signals.pead import PeadSignalGenerator, _find_entry_bar
+
+
+def _make_ohlcv(start: str = "2024-01-02", periods: int = 60, base: float = 100.0) -> pd.DataFrame:
+    """Build synthetic daily OHLCV DataFrame."""
+    dates = pd.bdate_range(start=start, periods=periods)
+    rng = np.random.default_rng(42)
+    close = base + np.cumsum(rng.normal(0, 0.5, periods))
+    return pd.DataFrame(
+        {
+            "open": close - rng.uniform(0, 1, periods),
+            "high": close + rng.uniform(0, 2, periods),
+            "low": close - rng.uniform(0, 2, periods),
+            "close": close,
+            "volume": rng.integers(500_000, 2_000_000, periods),
+        },
+        index=dates,
+    )
+
+
+def _make_earnings(
+    report_date: str = "2024-01-10",
+    sue: float = 3.5,
+    gap: float = 0.04,
+    vol: float = 2.8,
+    quality: float = 72.0,
+) -> dict:
+    return {
+        "report_date": report_date,
+        "sue_score": sue,
+        "gap_pct": gap,
+        "volume_ratio": vol,
+        "revenue_beat": True,
+        "quality_score": quality,
+    }
+
+
+class TestPeadSignalGenerator:
+    def test_entry_on_correct_bar(self) -> None:
+        """Entry appears after report_date + delay bars."""
+        data = _make_ohlcv(start="2024-01-02", periods=30)
+        earnings = [_make_earnings(report_date="2024-01-10")]
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings})
+
+        # Should have exactly 1 entry
+        assert entries.sum() == 1
+
+        # Entry bar must be after 2024-01-10
+        entry_date = entries[entries].index[0].date()
+        assert entry_date > date(2024, 1, 10)
+
+    def test_no_lookahead(self) -> None:
+        """No entry signal before or on report_date."""
+        data = _make_ohlcv(start="2024-01-02", periods=30)
+        earnings = [_make_earnings(report_date="2024-01-10")]
+
+        gen = PeadSignalGenerator()
+        entries, _ = gen.generate(data, {"earnings_data": earnings})
+
+        # All entries must be after report_date
+        for ts in entries[entries].index:
+            assert ts.date() > date(2024, 1, 10)
+
+    def test_exit_at_target(self) -> None:
+        """Position exits when close reaches profit target."""
+        # Create data that rises steadily to hit 6% target
+        dates = pd.bdate_range("2024-01-02", periods=30)
+        close = np.concatenate(
+            [
+                np.full(8, 100.0),  # Flat before report
+                np.full(2, 100.0),  # Delay bars
+                np.linspace(100, 108, 20),  # Rising to +8%
+            ]
+        )
+        data = pd.DataFrame(
+            {
+                "open": close,
+                "high": close + 0.5,
+                "low": close - 0.5,
+                "close": close,
+                "volume": 1_000_000,
+            },
+            index=dates,
+        )
+        earnings = [_make_earnings(report_date="2024-01-10")]
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings})
+
+        assert entries.sum() >= 1
+        assert exits.sum() >= 1  # Should exit at target
+
+    def test_exit_at_stop(self) -> None:
+        """Position exits when close hits stop loss."""
+        dates = pd.bdate_range("2024-01-02", periods=30)
+        close = np.concatenate(
+            [
+                np.full(8, 100.0),
+                np.full(2, 100.0),
+                np.linspace(100, 93, 20),  # Dropping to -7%
+            ]
+        )
+        data = pd.DataFrame(
+            {
+                "open": close,
+                "high": close + 0.5,
+                "low": close - 0.5,
+                "close": close,
+                "volume": 1_000_000,
+            },
+            index=dates,
+        )
+        earnings = [_make_earnings(report_date="2024-01-10")]
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings})
+
+        assert entries.sum() >= 1
+        assert exits.sum() >= 1  # Should exit at stop
+
+    def test_exit_at_timeout(self) -> None:
+        """Position exits after max_hold_bars if neither target nor stop hit."""
+        dates = pd.bdate_range("2024-01-02", periods=50)
+        # Flat price — neither target nor stop triggers
+        close = np.full(50, 100.0)
+        data = pd.DataFrame(
+            {
+                "open": close,
+                "high": close + 0.5,
+                "low": close - 0.5,
+                "close": close,
+                "volume": 1_000_000,
+            },
+            index=dates,
+        )
+        earnings = [_make_earnings(report_date="2024-01-10")]
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings, "max_hold_bars": 10})
+
+        assert entries.sum() == 1
+        assert exits.sum() == 1  # Timeout exit
+
+    def test_sue_filter(self) -> None:
+        """Earnings below min_sue are filtered out."""
+        data = _make_ohlcv(start="2024-01-02", periods=30)
+        earnings = [_make_earnings(sue=1.0)]  # Below default min_sue=2.0
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings})
+
+        assert entries.sum() == 0  # Filtered out
+
+    def test_gap_filter(self) -> None:
+        """Earnings below min_gap_pct are filtered out."""
+        data = _make_ohlcv(start="2024-01-02", periods=30)
+        earnings = [_make_earnings(gap=0.01)]  # Below default min_gap_pct=0.02
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings})
+
+        assert entries.sum() == 0
+
+    def test_volume_filter(self) -> None:
+        """Earnings below min_volume_ratio are filtered out."""
+        data = _make_ohlcv(start="2024-01-02", periods=30)
+        earnings = [_make_earnings(vol=1.5)]  # Below default min_volume_ratio=2.0
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings})
+
+        assert entries.sum() == 0
+
+    def test_no_earnings_data(self) -> None:
+        """No entries when earnings_data is empty or missing."""
+        data = _make_ohlcv()
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {})
+
+        assert entries.sum() == 0
+        assert exits.sum() == 0
+
+    def test_quality_sizing(self) -> None:
+        """Quality score drives position sizing when use_quality_sizing=True."""
+        data = _make_ohlcv(start="2024-01-02", periods=30)
+        earnings = [_make_earnings(quality=80.0)]
+
+        gen = PeadSignalGenerator()
+        gen.generate(data, {"earnings_data": earnings, "use_quality_sizing": True})
+
+        assert hasattr(gen, "entry_sizes")
+        # Quality 80 → 0.80 sizing (clamped to [0.1, 1.0])
+        entry_idx = gen.entry_sizes[gen.entry_sizes < 1.0].index
+        assert len(entry_idx) > 0
+
+    def test_multiple_earnings(self) -> None:
+        """Multiple earnings events produce multiple entries (if not overlapping)."""
+        data = _make_ohlcv(start="2024-01-02", periods=120)
+        earnings = [
+            _make_earnings(report_date="2024-01-15"),
+            _make_earnings(report_date="2024-04-15"),
+        ]
+
+        gen = PeadSignalGenerator()
+        entries, exits = gen.generate(data, {"earnings_data": earnings, "max_hold_bars": 10})
+
+        # Both should produce entries (sufficiently spaced)
+        assert entries.sum() == 2
+
+    def test_report_after_data_range_ignored(self) -> None:
+        """Earnings after the data range produce no entries."""
+        data = _make_ohlcv(start="2024-01-02", periods=20)
+        earnings = [_make_earnings(report_date="2025-06-01")]
+
+        gen = PeadSignalGenerator()
+        entries, _ = gen.generate(data, {"earnings_data": earnings})
+
+        assert entries.sum() == 0
+
+    def test_warmup_bars_zero(self) -> None:
+        """PEAD needs no indicator warmup."""
+        gen = PeadSignalGenerator()
+        assert gen.warmup_bars == 0
+
+
+class TestFindEntryBar:
+    def test_basic_delay(self) -> None:
+        bar_dates = [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4), date(2024, 1, 5)]
+        # report on Jan 2, delay=2 → first bar after report is Jan 3 (idx 1), + 1 delay = idx 2
+        idx = _find_entry_bar(bar_dates, date(2024, 1, 2), delay=2)
+        assert idx == 2
+
+    def test_report_before_data(self) -> None:
+        bar_dates = [date(2024, 1, 10), date(2024, 1, 11)]
+        idx = _find_entry_bar(bar_dates, date(2024, 1, 5), delay=2)
+        assert idx == 1  # First bar after report + 1 delay
+
+    def test_report_after_data(self) -> None:
+        bar_dates = [date(2024, 1, 2), date(2024, 1, 3)]
+        idx = _find_entry_bar(bar_dates, date(2024, 6, 1), delay=2)
+        assert idx is None
+
+    def test_delay_exceeds_remaining(self) -> None:
+        bar_dates = [date(2024, 1, 2), date(2024, 1, 3)]
+        # report on Jan 2, delay=5 → not enough bars
+        idx = _find_entry_bar(bar_dates, date(2024, 1, 2), delay=5)
+        assert idx is None


### PR DESCRIPTION
## Summary

- **Phase 0 — Stabilization**: Fix 3 correctness bugs (regime fail-closed, BMO/AMC session alignment, SUE history leakage) + typed config dataclass + file splits
- **Phase 1 — Multi-Quarter SUE**: Exponential decay weighting of historical surprise trajectory as additive quality modifier
- **Phase 2 — Historical Tracker**: OHLC first-touch exit resolution, JSON persistence, win rate / avg P&L / quality tier stats
- **Phase 3 — Attention Filter**: Google Trends adapter with company name disambiguation, graceful degradation without pytrends
- **Phase 4 — VectorBT Backtest**: Event-driven signal generator for historical backtesting with look-ahead prevention

CLI defaults: tracker + attention run automatically on every `--screen` or `--full`. `make pead` does the full pipeline in one command.

## Test plan

- [x] 107 unit tests passing (screener filters, SUE, tracker first-touch, attention, signal generator)
- [x] mypy clean on all PEAD files
- [x] black + isort formatted
- [ ] Run `make pead` end-to-end with live FMP data
- [ ] Verify HTML report renders tracker section after accumulating candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)