### PR TITLE
Fix momentum report

### DIFF
--- a/.github/workflows/momentum-screen.yml
+++ b/.github/workflows/momentum-screen.yml
@@ -1,4 +1,15 @@
-name: Momentum Screener
+name: "Daily: Momentum Screener"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Quantitative momentum screen: 12-1 momentum + FIP composite ranking.
+#
+# Pipeline:
+#   Step 1: Fetch regime data from gh-pages (for regime-gated sizing)
+#   Step 2: Update universe + OHLCV from FMP/yfinance
+#   Step 3: Screen + email (runner handles email via shared email_sender)
+#
+# Email sent by Python runner (not workflow action) — works locally too.
+# ═══════════════════════════════════════════════════════════════════════════
 
 on:
   schedule:
@@ -6,27 +17,107 @@ on:
     - cron: '30 21 * * 1-5'
   workflow_dispatch:
 
+concurrency:
+  group: momentum-screen
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: '3.13'
+  CACHE_VERSION: v1
+
 jobs:
   screen:
+    name: Momentum Screen
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-
+
+      - name: Cache TA-Lib
+        id: cache-talib
+        uses: actions/cache@v5
+        with:
+          path: ~/ta-lib-install
+          key: talib-0.6.4-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install TA-Lib
+        run: |
+          if [ -d "$HOME/ta-lib-install/lib" ]; then
+            echo "Restoring TA-Lib from cache..."
+            sudo cp -r $HOME/ta-lib-install/lib/* /usr/lib/
+            sudo cp -r $HOME/ta-lib-install/include/* /usr/include/
+            sudo ldconfig
+          else
+            echo "Building TA-Lib 0.6.4 from source..."
+            sudo apt-get update && sudo apt-get install -y wget build-essential
+            wget https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz
+            tar -xzf ta-lib-0.6.4-src.tar.gz
+            cd ta-lib-0.6.4 && ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+            sudo ldconfig
+            mkdir -p $HOME/ta-lib-install/lib $HOME/ta-lib-install/include
+            cp -r /usr/lib/libta* $HOME/ta-lib-install/lib/ 2>/dev/null || true
+            cp -r /usr/include/ta-lib $HOME/ta-lib-install/include/ 2>/dev/null || true
+          fi
 
       - name: Install dependencies
-        run: pip install -e .
+        run: |
+          .venv/bin/python --version 2>/dev/null || uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e ".[dev,observability]"
+
+      # === PIPELINE ===
+
+      - name: Fetch regime data from gh-pages
+        continue-on-error: true
+        run: |
+          mkdir -p out/signals/data
+          git fetch origin gh-pages --depth=1 2>/dev/null || true
+          git show origin/gh-pages:data/summary.json > out/signals/data/summary.json 2>/dev/null || echo '{}' > out/signals/data/summary.json
+          echo "Regime data fetched ($(wc -c < out/signals/data/summary.json) bytes)"
 
       - name: Run momentum screener
+        run: |
+          source .venv/bin/activate
+          python -m src.runners.momentum_runner --update \
+            --html out/momentum/report.html \
+            --signals-dir out/signals
         env:
           FMP_API_KEY: ${{ secrets.FMP_API_KEY }}
-        run: python -m src.runners.momentum_runner --update --html out/momentum/report.html
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT || 587 }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          SIGNAL_REPORT_RECIPIENTS: ${{ secrets.SIGNAL_REPORT_RECIPIENTS }}
 
-      - uses: actions/upload-artifact@v6
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v6
         with:
           name: momentum-${{ github.run_id }}
           path: |
             out/momentum/data/momentum_watchlist.json
             out/momentum/report.html
+          if-no-files-found: warn
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ help:
 	@echo "  make pead-screen    Screen from cache (still tracks + resolves by default)"
 	@echo ""
 	@echo "$(GREEN)Momentum Screener:$(RESET)"
-	@echo "  make quantitative-moment          Screen from cache (alias: momentum)"
-	@echo "  make quantitative-moment-update   Fetch fresh data + screen"
+	@echo "  make quantitative-moment          Refresh + screen + email (alias: momentum)"
+	@echo "  make quantitative-moment-update   Same as above (refresh is now default)"
 	@echo "  make quantitative-moment-backtest Walk-forward backtest"
 	@echo "  make quantitative-moment-test     Run unit tests"
 	@echo ""
@@ -455,17 +455,14 @@ pead-test:
 # Momentum Screener
 # ═══════════════════════════════════════════════════════════════
 
-# Run momentum screen from cached data
+# Always-fresh: refresh universe + incremental OHLCV + screen
 momentum:
-	@echo "$(BOLD)Momentum Screen (from cache)...$(RESET)"
+	@echo "$(BOLD)Momentum Screen (refresh + screen)...$(RESET)"
 	$(PYTHON) -m src.runners.momentum_runner --html out/momentum/report.html
 	@echo "$(GREEN)✓ HTML report: out/momentum/report.html$(RESET)"
 
-# Fetch fresh data + screen
-momentum-update:
-	@echo "$(BOLD)Momentum Screen — Full Update...$(RESET)"
-	$(PYTHON) -m src.runners.momentum_runner --update --html out/momentum/report.html
-	@echo "$(GREEN)✓ HTML report: out/momentum/report.html$(RESET)"
+# Alias: momentum-update is now identical to momentum (refresh is default)
+momentum-update: momentum
 
 # Walk-forward backtest
 momentum-backtest:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ help:
 	@echo "$(GREEN)Momentum Screener:$(RESET)"
 	@echo "  make quantitative-moment          Refresh + screen + email (alias: momentum)"
 	@echo "  make quantitative-moment-update   Same as above (refresh is now default)"
-	@echo "  make quantitative-moment-backtest Walk-forward backtest"
+	@echo "  make quantitative-moment-backtest Walk-forward backtest + ablation + HTML"
 	@echo "  make quantitative-moment-test     Run unit tests"
 	@echo ""
 	@echo "$(GREEN)Other:$(RESET)"
@@ -464,11 +464,11 @@ momentum:
 # Alias: momentum-update is now identical to momentum (refresh is default)
 momentum-update: momentum
 
-# Walk-forward backtest
+# Walk-forward backtest + ablation + HTML report
 momentum-backtest:
-	@echo "$(BOLD)Momentum Backtest...$(RESET)"
-	$(PYTHON) -m src.runners.momentum_runner --backtest --html out/momentum/backtest.html
-	@echo "$(GREEN)✓ Backtest: out/momentum/backtest.html$(RESET)"
+	@echo "$(BOLD)Momentum Backtest + Ablation...$(RESET)"
+	$(PYTHON) -m src.runners.momentum_runner --backtest --no-refresh
+	@echo "$(GREEN)✓ Report: out/momentum/backtest.html$(RESET)"
 
 # Run momentum screener tests
 momentum-test:

--- a/config/momentum_screener.yaml
+++ b/config/momentum_screener.yaml
@@ -7,6 +7,7 @@ universe:
     enabled: true
     market_cap_min: 300_000_000       # $300M
     market_cap_max: 10_000_000_000    # $10B
+  fallback_max_symbols: 800           # company-screener fallback when 402
   source: "fmp"
   cache_path: "data/cache/index_constituents.json"
 
@@ -17,10 +18,11 @@ data_source:
 
 filters:
   min_market_cap: 500_000_000         # $500M
-  min_avg_daily_dollar_volume: 10_000_000
+  min_avg_daily_dollar_volume: 20_000_000   # $20M (thesis spec)
   min_price: 10.0
   # Turnover rate: live-only filter (not applied in backtest to avoid look-ahead)
   min_daily_turnover_rate: 0.002      # 0.2%, live screen only
+  earnings_blackout_days: 5           # exclude if reporting within N calendar days
 
 scoring:
   momentum_weight: 0.5

--- a/src/domain/screeners/momentum/compute.py
+++ b/src/domain/screeners/momentum/compute.py
@@ -51,14 +51,21 @@ def compute_fip(
     skip: int = 21,
     lookback: int = 252,
 ) -> float | None:
-    """Frog-In-Pan indicator over the momentum window.
+    """Frog-In-Pan smoothness proxy over the momentum window.
 
-    FIP = (# positive return days - # negative return days) / total days
-    in the momentum window (excluding the skip period).
+    Computes the fraction of positive-return days as a path-smoothness
+    proxy inspired by Da, Gurun & Warachka (2014).
 
-    High FIP (close to 1.0) means smooth, gradual appreciation.
-    Low FIP (close to -1.0) means smooth, gradual decline.
-    FIP near 0 means roughly equal up/down days.
+    Note: the original DGW paper defines Information Discreteness as
+    ``ID_i = sgn(PRET) * (%neg - %pos)`` (Eq. 1), where
+    %pos + %neg + %zero = 1.  Our FIP is a monotonic proxy (%pos/total)
+    that correlates with smooth appreciation but is NOT the paper's ID.
+    Higher FIP = smoother path = stronger momentum persistence signal.
+
+    FIP = 0.58 means 58% of trading days had positive returns.
+    High FIP (close to 1.0) = smooth, gradual appreciation.
+    Low FIP (close to 0.0) = mostly negative days.
+    FIP near 0.5 = roughly equal up/down days.
 
     Args:
         daily_closes: Array of daily closing prices, chronologically ordered.
@@ -66,7 +73,7 @@ def compute_fip(
         lookback: Total lookback trading days.
 
     Returns:
-        FIP value in [-1.0, 1.0], or None if insufficient data.
+        FIP value in [0.0, 1.0], or None if insufficient data.
     """
     required = lookback + skip
     if len(daily_closes) < required:
@@ -78,15 +85,12 @@ def compute_fip(
     # Daily returns within the window
     returns = np.diff(window) / window[:-1]
 
-    # Count positive and negative days (exclude zero-return days)
-    n_pos = int(np.sum(returns > 0))
-    n_neg = int(np.sum(returns < 0))
-    total = n_pos + n_neg
-
+    total = len(returns)
     if total == 0:
         return 0.0
 
-    return float((n_pos - n_neg) / total)
+    n_pos = int(np.sum(returns > 0))
+    return float(n_pos / total)
 
 
 def compute_adaptive_momentum(

--- a/src/domain/screeners/momentum/config.py
+++ b/src/domain/screeners/momentum/config.py
@@ -44,7 +44,7 @@ class MomentumFilters:
     min_avg_daily_dollar_volume: float = 20_000_000
     min_price: float = 10.0
     min_daily_turnover_rate: float = 0.002
-    earnings_blackout_days: int = 0  # calendar days, 0 = disabled
+    earnings_blackout_days: int = 5  # calendar days, 0 = disabled
 
 
 @dataclass

--- a/src/domain/screeners/momentum/config.py
+++ b/src/domain/screeners/momentum/config.py
@@ -22,6 +22,7 @@ class UniverseConfig:
     russell_proxy_enabled: bool = True
     russell_proxy_market_cap_min: float = 300_000_000
     russell_proxy_market_cap_max: float = 10_000_000_000
+    fallback_max_symbols: int = 800
     source: str = "fmp"
     cache_path: str = "data/cache/index_constituents.json"
 
@@ -40,9 +41,10 @@ class MomentumFilters:
     """Filter thresholds for the screening pipeline."""
 
     min_market_cap: float = 500_000_000
-    min_avg_daily_dollar_volume: float = 10_000_000
+    min_avg_daily_dollar_volume: float = 20_000_000
     min_price: float = 10.0
     min_daily_turnover_rate: float = 0.002
+    earnings_blackout_days: int = 0  # calendar days, 0 = disabled
 
 
 @dataclass
@@ -132,6 +134,7 @@ class MomentumConfig:
                 "russell_proxy_enabled": rp.get("enabled", True),
                 "russell_proxy_market_cap_min": rp.get("market_cap_min", 300_000_000),
                 "russell_proxy_market_cap_max": rp.get("market_cap_max", 10_000_000_000),
+                "fallback_max_symbols": universe_raw.get("fallback_max_symbols", 800),
             },
         )
 

--- a/src/domain/screeners/momentum/screener.py
+++ b/src/domain/screeners/momentum/screener.py
@@ -18,7 +18,7 @@ Filter pipeline (cheapest first):
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 import numpy as np
@@ -56,6 +56,7 @@ class MomentumScreener:
         *,
         is_backtest: bool = False,
         use_adaptive: bool = False,
+        earnings_dates: dict[str, date] | None = None,
     ) -> MomentumScreenResult:
         """Run the full screening pipeline.
 
@@ -64,8 +65,9 @@ class MomentumScreener:
             volume_data: Symbol -> array of daily volumes (chronological).
             regime: Current market regime ("R0", "R1", "R2", "R3").
             market_caps: Symbol -> market cap in USD.
-            is_backtest: If True, skip turnover filter (avoids look-ahead bias).
+            is_backtest: If True, skip turnover + earnings filter (avoids look-ahead bias).
             use_adaptive: If True, use adaptive momentum for stocks with < 12mo history.
+            earnings_dates: Symbol -> upcoming earnings date (for blackout filter).
 
         Returns:
             MomentumScreenResult with ranked candidates.
@@ -129,6 +131,19 @@ class MomentumScreener:
             # Price filter
             if len(closes) == 0 or closes[-1] < cfg.filters.min_price:
                 continue
+
+            # Earnings blackout filter (live-only, avoids look-ahead in backtest).
+            # Uses calendar days intentionally: simpler, more conservative than
+            # trading days, and avoids market-calendar dependency in domain layer.
+            if (
+                not is_backtest
+                and earnings_dates
+                and cfg.filters.earnings_blackout_days > 0
+                and symbol in earnings_dates
+            ):
+                days_to = (earnings_dates[symbol] - date.today()).days
+                if 0 <= days_to <= cfg.filters.earnings_blackout_days:
+                    continue
 
             # History length filter (relaxed for adaptive mode)
             if use_adaptive:

--- a/src/infrastructure/adapters/fmp/index_constituents.py
+++ b/src/infrastructure/adapters/fmp/index_constituents.py
@@ -99,6 +99,47 @@ class FMPIndexConstituentsAdapter:
         )
         return self._extract_symbols(data)
 
+    def fetch_us_stocks(self, cap_min: float = 500_000_000, max_symbols: int = 800) -> list[str]:
+        """Fetch large-cap US stocks via company-screener as universe fallback.
+
+        Used when constituent endpoints (sp500/nasdaq) return 402 on
+        FMP Starter plans.
+
+        Args:
+            cap_min: Minimum market cap in USD.
+            max_symbols: Maximum number of symbols to return.
+
+        Returns:
+            List of symbols sorted by market cap descending, capped at max_symbols.
+        """
+        data = self._fmp_get(
+            f"{_FMP_BASE}/stable/company-screener",
+            params={
+                "marketCapMoreThan": int(cap_min),
+                "country": "US",
+                "isActivelyTrading": True,
+                "limit": 5000,
+            },
+        )
+        if not isinstance(data, list):
+            return []
+
+        # Sort by market cap descending; coerce None/non-numeric to 0
+        items_with_cap: list[tuple[str, float]] = []
+        for item in data:
+            sym = item.get("symbol")
+            if not sym or not isinstance(sym, str):
+                continue
+            raw_cap = item.get("marketCap")
+            cap = float(raw_cap) if isinstance(raw_cap, (int, float)) else 0.0
+            items_with_cap.append((sym, cap))
+        items_with_cap.sort(key=lambda x: x[1], reverse=True)
+        symbols = [sym for sym, _ in items_with_cap[:max_symbols]]
+        logger.info(
+            f"US stocks screener: {len(data)} total, returning top {len(symbols)} by market cap"
+        )
+        return symbols
+
     def fetch_historical_sp500_changes(self) -> list[dict[str, Any]]:
         """Fetch historical S&P 500 additions and removals.
 
@@ -160,32 +201,56 @@ class FMPIndexConstituentsAdapter:
         russell_proxy: bool = True,
         cap_min: float = 300_000_000,
         cap_max: float = 10_000_000_000,
+        fallback_cap_min: float = 500_000_000,
+        fallback_max_symbols: int = 800,
     ) -> list[str]:
         """Fetch combined universe from multiple indices.
+
+        Falls back to company-screener if constituent endpoints return 402
+        (FMP Starter plan limitation).
 
         Args:
             indices: List of index names to include ("sp500", "nasdaq").
             russell_proxy: Whether to include Russell 2000 proxy.
             cap_min: Min market cap for Russell proxy.
             cap_max: Max market cap for Russell proxy.
+            fallback_cap_min: Min market cap for screener fallback.
+            fallback_max_symbols: Max symbols from screener fallback.
 
         Returns:
             Deduplicated sorted list of symbols.
         """
         all_symbols: set[str] = set()
+        constituent_count = 0
         indices = indices or ["sp500", "nasdaq"]
 
         for idx in indices:
             if idx == "sp500":
                 symbols = self.fetch_sp500()
                 logger.info(f"S&P 500: {len(symbols)} symbols")
+                constituent_count += len(symbols)
                 all_symbols.update(symbols)
             elif idx == "nasdaq":
                 symbols = self.fetch_nasdaq()
                 logger.info(f"NASDAQ: {len(symbols)} symbols")
+                constituent_count += len(symbols)
                 all_symbols.update(symbols)
             else:
                 logger.warning(f"Unknown index: {idx}")
+
+        # Fallback: if constituent endpoints returned 0 (402), use screener
+        if constituent_count == 0:
+            logger.warning(
+                "Constituent endpoints unavailable (402), " "falling back to company-screener"
+            )
+            fallback = self.fetch_us_stocks(
+                cap_min=fallback_cap_min, max_symbols=fallback_max_symbols
+            )
+            logger.info(
+                f"Company-screener fallback: {len(fallback)} US stocks "
+                f"(cap >= ${fallback_cap_min / 1e6:.0f}M)"
+            )
+            all_symbols.update(fallback)
 
         if russell_proxy:
             symbols = self.fetch_russell_proxy(cap_min, cap_max)

--- a/src/infrastructure/reporting/email_momentum_renderer.py
+++ b/src/infrastructure/reporting/email_momentum_renderer.py
@@ -75,7 +75,7 @@ def render_momentum_email_text(
             mktcap_str = _format_market_cap(mktcap) if mktcap else "N/A"
 
             lines.append(f"#{rank} {symbol} [{tier}]")
-            lines.append(f"   Mom 12-1: {mom:+.1%}  FIP: {fip:+.2f}")
+            lines.append(f"   Mom 12-1: {mom:+.1%}  FIP: {fip:.2f}")
             lines.append(f"   Composite: {comp:.2f}  Quality: {quality}")
             lines.append(f"   Close: ${close:.2f}  MktCap: {mktcap_str}")
             lines.append(f"   ADDV: ${addv:,.0f}  Slippage: ~{slip}bps")

--- a/src/infrastructure/reporting/email_momentum_renderer.py
+++ b/src/infrastructure/reporting/email_momentum_renderer.py
@@ -1,0 +1,123 @@
+"""Email renderer — plain-text momentum screener report.
+
+Renders momentum_watchlist.json as monospace plain-text for mobile email clients.
+Mirrors the format of email_pead_renderer.py.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.utils.regime_display import regime_label
+from src.utils.timezone import DisplayTimezone
+
+
+def render_momentum_email_text(
+    watchlist_path: str | Path,
+    display_timezone: str = "America/New_York",
+) -> str:
+    """Render momentum watchlist as plain-text email body.
+
+    Args:
+        watchlist_path: Path to momentum_watchlist.json.
+        display_timezone: IANA timezone for timestamp display.
+
+    Returns:
+        Plain-text string suitable for email body.
+    """
+    path = Path(watchlist_path)
+    if not path.exists():
+        return "Momentum Screen: No data available."
+
+    data = json.loads(path.read_text())
+    candidates = data.get("candidates", [])
+    regime = data.get("regime", "?")
+    universe_size = data.get("universe_size", 0)
+    passed_filters = data.get("passed_filters", 0)
+    generated_at = data.get("generated_at", "")
+    data_as_of = data.get("data_as_of", "")
+    errors = data.get("errors", [])
+
+    timestamp = _format_timestamp(generated_at, display_timezone)
+
+    lines: list[str] = []
+    lines.append("Momentum Screen")
+    lines.append(timestamp)
+    if data_as_of:
+        lines.append(f"Data as of: {data_as_of}")
+    lines.append(f"Regime: {regime} ({regime_label(regime)})")
+    lines.append("\u2550" * 42)
+    lines.append("")
+
+    if candidates:
+        count = len(candidates)
+        lines.append(
+            f"CANDIDATES ({count} found | universe: {universe_size} | passed: {passed_filters})"
+        )
+        lines.append("\u2500" * 42)
+
+        for c in candidates:
+            rank = c.get("rank", 0)
+            symbol = c.get("symbol", "?")
+            tier = c.get("liquidity_tier", "?").upper()
+            mom = c.get("momentum_12_1", 0)
+            fip = c.get("fip", 0)
+            comp = c.get("composite_rank", 0)
+            quality = c.get("quality_label", "?")
+            close = c.get("last_close", 0)
+            mktcap = c.get("market_cap")
+            addv = c.get("avg_daily_dollar_volume", 0)
+            slip = c.get("estimated_slippage_bps", 0)
+            size = c.get("position_size_factor", 1)
+
+            mktcap_str = _format_market_cap(mktcap) if mktcap else "N/A"
+
+            lines.append(f"#{rank} {symbol} [{tier}]")
+            lines.append(f"   Mom 12-1: {mom:+.1%}  FIP: {fip:+.2f}")
+            lines.append(f"   Composite: {comp:.2f}  Quality: {quality}")
+            lines.append(f"   Close: ${close:.2f}  MktCap: {mktcap_str}")
+            lines.append(f"   ADDV: ${addv:,.0f}  Slippage: ~{slip}bps")
+            lines.append(f"   Size: {size:.0%}")
+            lines.append("\u2500" * 42)
+    else:
+        lines.append(f"0 momentum candidates.")
+        lines.append(f"(universe: {universe_size}, passed: {passed_filters}, regime: {regime})")
+
+    if errors:
+        lines.append("")
+        lines.append(f"Errors ({len(errors)}):")
+        for err in errors[:5]:
+            lines.append(f"  - {err}")
+
+    lines.append("")
+    lines.append("\u2500" * 42)
+    lines.append("Full report \u2192 moremeds.github.io/apex/momentum/report.html")
+
+    return "\n".join(lines)
+
+
+def _format_timestamp(generated_at: str, display_timezone: str) -> str:
+    if generated_at:
+        try:
+            dt = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            disp = DisplayTimezone(display_timezone)
+            return disp.format_with_tz(dt, fmt="%b %d, %Y %I:%M %p %Z")
+        except (ValueError, AttributeError):
+            return generated_at
+    return datetime.now(tz=timezone.utc).strftime("%b %d, %Y %I:%M %p UTC")
+
+
+def _format_market_cap(mktcap: float | int | None) -> str:
+    if mktcap is None:
+        return "N/A"
+    if mktcap >= 1e12:
+        return f"${mktcap / 1e12:.1f}T"
+    if mktcap >= 1e9:
+        return f"${mktcap / 1e9:.1f}B"
+    if mktcap >= 1e6:
+        return f"${mktcap / 1e6:.0f}M"
+    return f"${mktcap:,.0f}"

--- a/src/infrastructure/reporting/email_pead_renderer.py
+++ b/src/infrastructure/reporting/email_pead_renderer.py
@@ -10,6 +10,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from src.utils.regime_display import regime_label as _regime_label
 from src.utils.timezone import DisplayTimezone
 
 
@@ -107,13 +108,3 @@ def _format_timestamp(generated_at: str, display_timezone: str) -> str:
         except (ValueError, AttributeError):
             return generated_at
     return datetime.now(tz=timezone.utc).strftime("%b %d, %Y %I:%M %p UTC")
-
-
-def _regime_label(regime: str) -> str:
-    labels = {
-        "R0": "Healthy Uptrend",
-        "R1": "Choppy/Extended",
-        "R2": "Risk-Off",
-        "R3": "Rebound Window",
-    }
-    return labels.get(regime, "Unknown")

--- a/src/infrastructure/reporting/momentum/templates.py
+++ b/src/infrastructure/reporting/momentum/templates.py
@@ -1,7 +1,8 @@
 """HTML templates for momentum screener dashboard.
 
-Renders a standalone dark-theme HTML page with watchlist table,
-filter funnel summary, and sector distribution.
+Renders standalone dark-theme HTML pages:
+- ``render_momentum_html``: live watchlist table + filter funnel
+- ``render_backtest_html``: walk-forward results + ablation comparison
 """
 
 from __future__ import annotations
@@ -79,7 +80,7 @@ def render_momentum_html(data: dict[str, Any]) -> str:
             <div class="card-label">Avg Momentum</div>
         </div>
         <div class="card">
-            <div class="card-value">{avg_fip:+.2f}</div>
+            <div class="card-value">{avg_fip:.2f}</div>
             <div class="card-label">Avg FIP</div>
         </div>
     </div>
@@ -138,7 +139,7 @@ def _build_table_rows(candidates: list[dict[str, Any]]) -> str:
         mom = c["momentum_12_1"]
         fip = c["fip"]
         mom_color = "color: #3fb950" if mom > 0 else "color: #f85149"
-        fip_color = "color: #3fb950" if fip > 0 else "color: #f85149"
+        fip_color = "color: #3fb950" if fip > 0.5 else "color: #f85149"
         quality_cls = c["quality_label"].lower()
 
         # Format market cap
@@ -158,7 +159,7 @@ def _build_table_rows(candidates: list[dict[str, Any]]) -> str:
                 <td>{c['rank']}</td>
                 <td class="symbol">{c['symbol']}</td>
                 <td style="{mom_color}">{mom:+.1%}</td>
-                <td style="{fip_color}">{fip:+.3f}</td>
+                <td style="{fip_color}">{fip:.3f}</td>
                 <td>{c['composite_rank']:.3f}</td>
                 <td><span class="quality-badge {quality_cls}">{c['quality_label']}</span></td>
                 <td>{tier_display}</td>
@@ -257,4 +258,233 @@ tr:hover { background: var(--bg-tertiary); }
 }
 .methodology h3 { margin-bottom: 12px; font-size: 16px; }
 .methodology p { color: var(--text-secondary); font-size: 13px; margin-bottom: 8px; }
+"""
+
+
+# ── Backtest HTML ─────────────────────────────────────────────────────
+
+
+def render_backtest_html(data: dict[str, Any]) -> str:
+    """Render momentum backtest + ablation HTML report.
+
+    Args:
+        data: Dict with keys ``backtest`` (walk-forward results) and
+              ``ablation`` (3-config comparison).  Both produced by
+              ``cmd_backtest`` in the momentum runner.
+
+    Returns:
+        Complete standalone HTML page.
+    """
+    bt = data.get("backtest", {})
+    abl = data.get("ablation", {})
+
+    start = bt.get("start", "?")
+    end = bt.get("end", "?")
+    top_n = abl.get("top_n", bt.get("top_n", "?"))
+    hold_days = abl.get("hold_days", bt.get("hold_days", "?"))
+
+    cum_ret = bt.get("cumulative_return", 0.0)
+    sharpe = bt.get("sharpe_approx", 0.0)
+    max_dd = bt.get("max_drawdown", 0.0)
+    avg_weekly = bt.get("avg_weekly_return", 0.0)
+    n_periods = len(bt.get("periods", []))
+
+    # Summary card colors
+    cum_color = "var(--accent-green)" if cum_ret >= 0 else "var(--accent-red)"
+    dd_color = "var(--accent-red)" if max_dd < -0.1 else "var(--accent-yellow)"
+
+    # Ablation table rows
+    ablation_rows = _build_ablation_rows(abl.get("configs", []))
+
+    # Period returns table rows
+    period_rows = _build_period_rows(bt.get("periods", []))
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Momentum Backtest</title>
+<style>
+{_BACKTEST_CSS}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <h1>Momentum Backtest</h1>
+        <span class="date-range">{start} &rarr; {end}</span>
+    </div>
+    <div class="meta">Top-{top_n} &middot; {hold_days}-day hold &middot; weekly rebalance</div>
+
+    <div class="cards">
+        <div class="card">
+            <div class="card-value" style="color:{cum_color}">{cum_ret:+.1%}</div>
+            <div class="card-label">Cumulative Return</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{sharpe:.2f}</div>
+            <div class="card-label">Sharpe (approx)</div>
+        </div>
+        <div class="card">
+            <div class="card-value" style="color:{dd_color}">{max_dd:+.1%}</div>
+            <div class="card-label">Max Drawdown</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{avg_weekly:+.3%}</div>
+            <div class="card-label">Avg Weekly</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{n_periods}</div>
+            <div class="card-label"># Periods</div>
+        </div>
+    </div>
+
+    <h2 class="section-title">Ablation Comparison</h2>
+    <table class="ablation">
+        <thead>
+            <tr>
+                <th>Configuration</th>
+                <th>Cum Return</th>
+                <th>Sharpe</th>
+                <th>Max DD</th>
+                <th>Avg Weekly</th>
+            </tr>
+        </thead>
+        <tbody>
+            {ablation_rows}
+        </tbody>
+    </table>
+
+    <h2 class="section-title">Period Returns</h2>
+    <div class="table-scroll">
+    <table>
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th># Picks</th>
+                <th>Avg Return</th>
+                <th>Top 5 Picks</th>
+            </tr>
+        </thead>
+        <tbody>
+            {period_rows}
+        </tbody>
+    </table>
+    </div>
+</div>
+</body>
+</html>"""
+
+
+def _build_ablation_rows(configs: list[dict[str, Any]]) -> str:
+    """Build HTML rows for the ablation comparison table."""
+    rows: list[str] = []
+    for cfg in configs:
+        label = cfg.get("label", "?")
+        cr = cfg.get("cumulative_return", 0.0)
+        sh = cfg.get("sharpe_approx", 0.0)
+        dd = cfg.get("max_drawdown", 0.0)
+        aw = cfg.get("avg_weekly_return", 0.0)
+        cr_color = "color: #3fb950" if cr >= 0 else "color: #f85149"
+        dd_color = "color: #f85149" if dd < -0.1 else "color: #d29922"
+        rows.append(f"""<tr>
+                <td class="config-label">{label}</td>
+                <td style="{cr_color}">{cr:+.2%}</td>
+                <td>{sh:.2f}</td>
+                <td style="{dd_color}">{dd:+.2%}</td>
+                <td>{aw:+.4%}</td>
+            </tr>""")
+    return "\n".join(rows)
+
+
+def _build_period_rows(periods: list[dict[str, Any]]) -> str:
+    """Build HTML rows for the period returns table."""
+    rows: list[str] = []
+    for p in periods:
+        ret = p.get("avg_return", 0.0)
+        ret_color = "color: #3fb950" if ret >= 0 else "color: #f85149"
+        picks = ", ".join(p.get("picks", [])[:5])
+        rows.append(f"""<tr>
+                <td>{p.get('date', '?')}</td>
+                <td>{p.get('n_picks', 0)}</td>
+                <td style="{ret_color}">{ret:+.2%}</td>
+                <td class="picks">{picks}</td>
+            </tr>""")
+    return "\n".join(rows)
+
+
+_BACKTEST_CSS = """
+:root {
+    --bg-primary: #0d1117;
+    --bg-secondary: #161b22;
+    --bg-tertiary: #21262d;
+    --text-primary: #e6edf3;
+    --text-secondary: #8b949e;
+    --border: #30363d;
+    --accent-green: #3fb950;
+    --accent-red: #f85149;
+    --accent-blue: #58a6ff;
+    --accent-yellow: #d29922;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+.container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+
+.header {
+    display: flex; align-items: center; gap: 16px;
+    margin-bottom: 8px;
+}
+.header h1 { font-size: 24px; font-weight: 600; }
+.date-range {
+    padding: 4px 12px; border-radius: 12px;
+    background: var(--bg-tertiary); color: var(--accent-blue);
+    font-size: 13px; font-weight: 600;
+}
+
+.meta { color: var(--text-secondary); font-size: 13px; margin-bottom: 20px; }
+
+.cards {
+    display: flex; gap: 16px; margin-bottom: 28px; flex-wrap: wrap;
+}
+.card {
+    background: var(--bg-secondary); border: 1px solid var(--border);
+    border-radius: 8px; padding: 16px 24px; flex: 1; min-width: 140px;
+    text-align: center;
+}
+.card-value { font-size: 28px; font-weight: 700; }
+.card-label { font-size: 12px; color: var(--text-secondary); margin-top: 4px; }
+
+.section-title {
+    font-size: 18px; font-weight: 600; margin-bottom: 12px;
+}
+
+table {
+    width: 100%; border-collapse: collapse;
+    background: var(--bg-secondary); border-radius: 8px; overflow: hidden;
+    margin-bottom: 24px;
+}
+table.ablation { margin-bottom: 32px; }
+thead { background: var(--bg-tertiary); }
+th {
+    padding: 10px 12px; text-align: left; font-size: 12px;
+    color: var(--text-secondary); font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+td { padding: 10px 12px; border-top: 1px solid var(--border); font-size: 14px; }
+tr:hover { background: var(--bg-tertiary); }
+
+.config-label { font-weight: 600; color: var(--accent-blue); }
+.picks { color: var(--text-secondary); font-size: 13px; }
+
+.table-scroll { max-height: 600px; overflow-y: auto; border-radius: 8px; }
+.table-scroll thead { position: sticky; top: 0; z-index: 1; }
 """

--- a/src/runners/momentum_runner.py
+++ b/src/runners/momentum_runner.py
@@ -1,11 +1,14 @@
 """Quantitative Momentum Screener CLI runner.
 
-Cache-first by default: screens from existing Parquet data.
-Use --update to fetch fresh universe + OHLCV before screening.
+Always-fresh: refreshes universe + incrementally updates OHLCV before
+screening. Incremental update only fetches new bars since each symbol's
+last Parquet date, so repeat runs are fast.
 
 Usage:
-    python -m src.runners.momentum_runner                           # screen from cache
-    python -m src.runners.momentum_runner --update                  # fetch + screen
+    python -m src.runners.momentum_runner                           # refresh + screen
+    python -m src.runners.momentum_runner --no-refresh              # screen from cache only
+    python -m src.runners.momentum_runner --no-email                # skip email
+    python -m src.runners.momentum_runner --no-earnings             # skip earnings blackout filter
     python -m src.runners.momentum_runner --backtest                # walk-forward backtest
     python -m src.runners.momentum_runner --include-recent-ipos     # adaptive momentum
     python -m src.runners.momentum_runner --html out/momentum/report.html
@@ -22,6 +25,7 @@ from typing import Any
 import numpy as np
 
 from src.utils.logging_setup import get_logger
+from src.utils.regime_display import regime_label
 
 logger = get_logger(__name__)
 
@@ -56,7 +60,7 @@ def _read_current_regime(signals_dir: Path, fallback: str = _REGIME_FALLBACK) ->
         for t in data.get("tickers", []):
             if t.get("symbol") == "SPY":
                 regime = t.get("regime", fallback)
-                logger.info(f"SPY regime: {regime}")
+                logger.info(f"SPY regime: {regime} ({regime_label(str(regime))})")
                 return str(regime)
     except Exception as e:
         logger.warning(f"Failed to read regime from summary.json: {e}")
@@ -64,7 +68,7 @@ def _read_current_regime(signals_dir: Path, fallback: str = _REGIME_FALLBACK) ->
     return fallback
 
 
-def _write_watchlist_json(result: Any, output_dir: Path) -> Path:
+def _write_watchlist_json(result: Any, output_dir: Path, data_as_of: date | None = None) -> Path:
     """Write screening results to JSON for downstream consumers."""
     data_dir = output_dir / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -94,14 +98,16 @@ def _write_watchlist_json(result: Any, output_dir: Path) -> Path:
             }
         )
 
-    payload = {
+    payload: dict[str, Any] = {
         "candidates": candidates_data,
         "universe_size": result.universe_size,
         "passed_filters": result.passed_filters,
         "regime": result.regime,
         "generated_at": result.generated_at.isoformat(),
-        "errors": result.errors,
+        "errors": [f"{k}: {v}" for k, v in result.errors.items()],
     }
+    if data_as_of is not None:
+        payload["data_as_of"] = data_as_of.isoformat()
 
     out_path.write_text(json.dumps(payload, indent=2))
     logger.info(f"Wrote {len(candidates_data)} candidates to {out_path}")
@@ -124,6 +130,7 @@ def cmd_update(config: Any) -> list[str]:
         russell_proxy=ucfg.russell_proxy_enabled,
         cap_min=ucfg.russell_proxy_market_cap_min,
         cap_max=ucfg.russell_proxy_market_cap_max,
+        fallback_max_symbols=ucfg.fallback_max_symbols,
     )
 
     # Download OHLCV
@@ -140,35 +147,81 @@ def cmd_screen(
     html_output: str | None = None,
     signals_dir: str | None = None,
     include_recent_ipos: bool = False,
+    send_email_flag: bool = True,
+    no_earnings: bool = False,
+    no_refresh: bool = False,
 ) -> Any:
-    """Run momentum screening from cached data."""
+    """Run momentum screening with universe + OHLCV refresh.
+
+    Always-fresh by default: refreshes universe, then incrementally
+    updates stale Parquet data (only fetches new bars — fast).
+    Use --no-refresh to skip both and screen from cache only.
+
+    Args:
+        no_earnings: Skip earnings blackout filter.
+        no_refresh: Skip universe + OHLCV refresh (use stale cache).
+    """
     from src.domain.screeners.momentum.screener import MomentumScreener
     from src.services.momentum_data_service import MomentumDataService
 
     svc = MomentumDataService()
 
-    # Read universe
-    symbols = svc.get_universe()
-    if not symbols:
-        logger.error("No universe cached. Run with --update first.")
-        return None
+    if no_refresh:
+        # Cache-only mode
+        print("[1/4] Using cached universe...", flush=True)
+        symbols = svc.get_universe()
+        if not symbols:
+            logger.error("No universe cached. Run without --no-refresh first.")
+            return None
+        print(f"  {len(symbols)} symbols from cache")
+    else:
+        # Always-fresh: refresh universe + incremental OHLCV
+        print("[1/4] Refreshing universe...", flush=True)
+        ucfg = config.universe
+        symbols = svc.update_universe(
+            indices=ucfg.indices,
+            russell_proxy=ucfg.russell_proxy_enabled,
+            cap_min=ucfg.russell_proxy_market_cap_min,
+            cap_max=ucfg.russell_proxy_market_cap_max,
+            fallback_max_symbols=ucfg.fallback_max_symbols,
+        )
+        print("[2/4] Updating OHLCV (incremental)...", flush=True)
+        months = (config.data_source.lookback_trading_days // 21) + 3
+        svc.update_ohlcv(symbols, months=months)
 
     # Read regime
     sig_dir = Path(signals_dir) if signals_dir else PROJECT_ROOT / "out" / "signals"
     regime = _read_current_regime(sig_dir)
 
-    # Read market caps
-    market_caps = svc.get_market_caps(symbols)
-
     # Load price + volume data
+    print("[3/4] Loading price data...", end=" ", flush=True)
     today = date.today()
     lookback_cal_days = int(config.data_source.lookback_trading_days * 1.5) + 50
     price_data = svc.get_bulk_closes(symbols, today, lookback_days=lookback_cal_days)
     volume_data = svc.get_bulk_volumes(symbols, today, lookback_days=lookback_cal_days)
+    market_caps = svc.get_market_caps(symbols)
+    print(f"{len(price_data)} symbols loaded")
 
-    logger.info(
-        f"Data loaded: {len(price_data)} symbols with closes, " f"{len(volume_data)} with volumes"
-    )
+    # Check data freshness
+    data_as_of = svc.get_data_as_of_date(list(price_data.keys()))
+    if data_as_of:
+        bdays_behind = int(np.busday_count(data_as_of, today))
+        if bdays_behind > 2:
+            print(
+                f"  WARNING: Data still {bdays_behind} business days behind "
+                f"(data: {data_as_of.isoformat()}, today: {today.isoformat()})"
+            )
+
+    # Fetch upcoming earnings for blackout filter
+    print("[4/4] Screening...", end=" ", flush=True)
+    earnings_dates = None
+    if not no_earnings and config.filters.earnings_blackout_days > 0:
+        earnings_dates = svc.get_upcoming_earnings(
+            list(price_data.keys()),
+            lookahead_days=config.filters.earnings_blackout_days + 2,
+        )
+        if earnings_dates:
+            logger.info(f"Earnings blackout: {len(earnings_dates)} symbols excluded")
 
     # Screen
     screener = MomentumScreener(config)
@@ -178,12 +231,15 @@ def cmd_screen(
         regime=regime,
         market_caps=market_caps,
         use_adaptive=include_recent_ipos,
+        earnings_dates=earnings_dates,
     )
+    print(f"{len(result.candidates)} candidates")
 
     # Print summary
-    print(f"\nMomentum Screen — {today.isoformat()}")
+    data_as_of_str = data_as_of.isoformat() if data_as_of else "unknown"
+    print(f"\nMomentum Screen — {today.isoformat()} (data: {data_as_of_str})")
     print(
-        f"Regime: {regime} | Universe: {result.universe_size} | "
+        f"Regime: {regime} ({regime_label(regime)}) | Universe: {result.universe_size} | "
         f"Passed: {result.passed_filters} | Top-N: {len(result.candidates)}"
     )
     print("=" * 80)
@@ -203,11 +259,11 @@ def cmd_screen(
                 f"{c.position_size_factor:4.0%}"
             )
     else:
-        print(f"0 momentum candidates (regime: {regime})")
+        print(f"0 momentum candidates (regime: {regime} - {regime_label(regime)})")
 
     # Write JSON
     output_dir = Path(html_output).parent if html_output else PROJECT_ROOT / "out" / "momentum"
-    _write_watchlist_json(result, output_dir)
+    _write_watchlist_json(result, output_dir, data_as_of=data_as_of)
 
     # Write HTML
     if html_output:
@@ -216,6 +272,21 @@ def cmd_screen(
         builder = MomentumReportBuilder()
         html_path = builder.build(result, html_output)
         logger.info(f"Momentum HTML report: {html_path}")
+
+    # Send email
+    if send_email_flag:
+        if result.candidates:
+            from src.infrastructure.reporting.email_momentum_renderer import (
+                render_momentum_email_text,
+            )
+            from src.utils.email_sender import send_email
+
+            watchlist_path = output_dir / "data" / "momentum_watchlist.json"
+            body = render_momentum_email_text(watchlist_path)
+            subject = f"APEX Momentum — {len(result.candidates)} candidates — {today.isoformat()}"
+            send_email(subject, body)
+        else:
+            print("0 candidates — email skipped.")
 
     return result
 
@@ -367,7 +438,9 @@ def main() -> None:
         description="Quantitative Momentum Screener (12-1 momentum + FIP)"
     )
     parser.add_argument(
-        "--update", action="store_true", help="Fetch universe + OHLCV before screening"
+        "--update",
+        action="store_true",
+        help="Legacy alias — universe + OHLCV refresh is now the default behavior",
     )
     parser.add_argument(
         "--backtest", action="store_true", help="Run walk-forward portfolio backtest"
@@ -379,6 +452,13 @@ def main() -> None:
     )
     parser.add_argument("--html", type=str, default=None, help="Output HTML report path")
     parser.add_argument("--signals-dir", type=str, default=None, help="Signal pipeline output dir")
+    parser.add_argument("--no-email", action="store_true", help="Skip email notification")
+    parser.add_argument("--no-earnings", action="store_true", help="Skip earnings blackout filter")
+    parser.add_argument(
+        "--no-refresh",
+        action="store_true",
+        help="Skip universe + OHLCV refresh (screen from stale cache)",
+    )
     args = parser.parse_args()
 
     config = _load_config()
@@ -394,6 +474,10 @@ def main() -> None:
             html_output=args.html,
             signals_dir=args.signals_dir,
             include_recent_ipos=args.include_recent_ipos,
+            send_email_flag=not args.no_email,
+            no_earnings=args.no_earnings,
+            # --update already fetched OHLCV; skip redundant refresh
+            no_refresh=args.no_refresh or args.update,
         )
 
 

--- a/src/runners/momentum_runner.py
+++ b/src/runners/momentum_runner.py
@@ -9,7 +9,7 @@ Usage:
     python -m src.runners.momentum_runner --no-refresh              # screen from cache only
     python -m src.runners.momentum_runner --no-email                # skip email
     python -m src.runners.momentum_runner --no-earnings             # skip earnings blackout filter
-    python -m src.runners.momentum_runner --backtest                # walk-forward backtest
+    python -m src.runners.momentum_runner --backtest                # walk-forward + ablation + HTML
     python -m src.runners.momentum_runner --include-recent-ipos     # adaptive momentum
     python -m src.runners.momentum_runner --html out/momentum/report.html
 """
@@ -17,12 +17,16 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from src.utils.logging_setup import get_logger
 from src.utils.regime_display import regime_label
@@ -151,11 +155,15 @@ def cmd_screen(
     no_earnings: bool = False,
     no_refresh: bool = False,
 ) -> Any:
-    """Run momentum screening with universe + OHLCV refresh.
+    """Run momentum screening with pre-filter → OHLCV → screen pipeline.
 
-    Always-fresh by default: refreshes universe, then incrementally
-    updates stale Parquet data (only fetches new bars — fast).
-    Use --no-refresh to skip both and screen from cache only.
+    Pipeline order (thesis-aligned):
+    [1/6] Load universe
+    [2/6] Pre-filter: market cap (from cached JSON, no OHLCV needed)
+    [3/6] Pre-filter: earnings blackout (FMP calendar, 1 API call)
+    [4/6] Load OHLCV (only for surviving symbols)
+    [5/6] Screen (remaining filters + momentum scoring + rank)
+    [6/6] Write results
 
     Args:
         no_earnings: Skip earnings blackout filter.
@@ -165,18 +173,18 @@ def cmd_screen(
     from src.services.momentum_data_service import MomentumDataService
 
     svc = MomentumDataService()
+    today = date.today()
 
+    # [1/6] Load universe
     if no_refresh:
-        # Cache-only mode
-        print("[1/4] Using cached universe...", flush=True)
+        print("[1/6] Using cached universe...", flush=True)
         symbols = svc.get_universe()
         if not symbols:
             logger.error("No universe cached. Run without --no-refresh first.")
             return None
         print(f"  {len(symbols)} symbols from cache")
     else:
-        # Always-fresh: refresh universe + incremental OHLCV
-        print("[1/4] Refreshing universe...", flush=True)
+        print("[1/6] Refreshing universe...", flush=True)
         ucfg = config.universe
         symbols = svc.update_universe(
             indices=ucfg.indices,
@@ -185,22 +193,59 @@ def cmd_screen(
             cap_max=ucfg.russell_proxy_market_cap_max,
             fallback_max_symbols=ucfg.fallback_max_symbols,
         )
-        print("[2/4] Updating OHLCV (incremental)...", flush=True)
+
+    universe_size_original = len(symbols)
+    logger.info(f"[1/6] Universe loaded: {universe_size_original} symbols")
+
+    # [2/6] Pre-filter: market cap (cheap — uses cached JSON, no OHLCV)
+    market_caps = svc.get_market_caps(symbols)
+    non_zero_caps = sum(1 for v in market_caps.values() if v > 0)
+    if non_zero_caps >= len(symbols) * 0.1:  # cache has >= 10% coverage
+        pre = len(symbols)
+        symbols = [s for s in symbols if market_caps.get(s, 0.0) >= config.filters.min_market_cap]
+        logger.info(f"[2/6] Market cap pre-filter: {pre} -> {len(symbols)} symbols")
+    else:
+        logger.warning(
+            f"[2/6] Market cap cache too sparse "
+            f"({non_zero_caps}/{len(symbols)}), skipping pre-filter"
+        )
+
+    # [3/6] Pre-filter: earnings blackout (live-only, 1 API call)
+    earnings_dates = None
+    if not no_earnings and config.filters.earnings_blackout_days > 0:
+        earnings_dates = svc.get_upcoming_earnings(
+            symbols,
+            lookahead_days=config.filters.earnings_blackout_days + 2,
+        )
+        if earnings_dates:
+            blackout = {
+                s
+                for s, d in earnings_dates.items()
+                if 0 <= (d - today).days <= config.filters.earnings_blackout_days
+            }
+            pre = len(symbols)
+            symbols = [s for s in symbols if s not in blackout]
+            logger.info(
+                f"[3/6] Earnings blackout: {pre} -> {len(symbols)} " f"(excluded {len(blackout)})"
+            )
+        else:
+            logger.info("[3/6] Earnings blackout: no upcoming earnings found")
+    else:
+        logger.info("[3/6] Earnings blackout: skipped")
+
+    # [4/6] Update OHLCV (only for surviving symbols) + load data
+    if not no_refresh:
+        print("[4/6] Updating OHLCV (incremental)...", flush=True)
         months = (config.data_source.lookback_trading_days // 21) + 3
         svc.update_ohlcv(symbols, months=months)
 
-    # Read regime
-    sig_dir = Path(signals_dir) if signals_dir else PROJECT_ROOT / "out" / "signals"
-    regime = _read_current_regime(sig_dir)
-
-    # Load price + volume data
-    print("[3/4] Loading price data...", end=" ", flush=True)
-    today = date.today()
     lookback_cal_days = int(config.data_source.lookback_trading_days * 1.5) + 50
     price_data = svc.get_bulk_closes(symbols, today, lookback_days=lookback_cal_days)
     volume_data = svc.get_bulk_volumes(symbols, today, lookback_days=lookback_cal_days)
-    market_caps = svc.get_market_caps(symbols)
-    print(f"{len(price_data)} symbols loaded")
+    logger.info(
+        f"[4/6] OHLCV loaded: {len(price_data)}/{len(symbols)} symbols with closes, "
+        f"{len(volume_data)} with volumes"
+    )
 
     # Check data freshness
     data_as_of = svc.get_data_as_of_date(list(price_data.keys()))
@@ -212,18 +257,12 @@ def cmd_screen(
                 f"(data: {data_as_of.isoformat()}, today: {today.isoformat()})"
             )
 
-    # Fetch upcoming earnings for blackout filter
-    print("[4/4] Screening...", end=" ", flush=True)
-    earnings_dates = None
-    if not no_earnings and config.filters.earnings_blackout_days > 0:
-        earnings_dates = svc.get_upcoming_earnings(
-            list(price_data.keys()),
-            lookahead_days=config.filters.earnings_blackout_days + 2,
-        )
-        if earnings_dates:
-            logger.info(f"Earnings blackout: {len(earnings_dates)} symbols excluded")
+    # Read regime
+    sig_dir = Path(signals_dir) if signals_dir else PROJECT_ROOT / "out" / "signals"
+    regime = _read_current_regime(sig_dir)
 
-    # Screen
+    # [5/6] Screen (remaining filters + momentum scoring + rank)
+    print("[5/6] Screening...", end=" ", flush=True)
     screener = MomentumScreener(config)
     result = screener.screen(
         price_data=price_data,
@@ -232,6 +271,10 @@ def cmd_screen(
         market_caps=market_caps,
         use_adaptive=include_recent_ipos,
         earnings_dates=earnings_dates,
+    )
+    logger.info(
+        f"[5/6] Screening: regime={regime}, passed_filters={result.passed_filters}, "
+        f"candidates={len(result.candidates)}"
     )
     print(f"{len(result.candidates)} candidates")
 
@@ -253,7 +296,7 @@ def cmd_screen(
         for c in result.candidates:
             s = c.signal
             print(
-                f"{c.rank:3d} {s.symbol:<7} {s.momentum_12_1:+8.1%} {s.fip:+5.2f} "
+                f"{c.rank:3d} {s.symbol:<7} {s.momentum_12_1:+8.1%} {s.fip:5.2f} "
                 f"{s.composite_rank:5.2f} {c.quality_label:<9} "
                 f"{s.liquidity_tier.value:<10} {s.last_close:8.2f} "
                 f"{c.position_size_factor:4.0%}"
@@ -261,7 +304,7 @@ def cmd_screen(
     else:
         print(f"0 momentum candidates (regime: {regime} - {regime_label(regime)})")
 
-    # Write JSON
+    # [6/6] Write results
     output_dir = Path(html_output).parent if html_output else PROJECT_ROOT / "out" / "momentum"
     _write_watchlist_json(result, output_dir, data_as_of=data_as_of)
 
@@ -291,14 +334,188 @@ def cmd_screen(
     return result
 
 
-def cmd_backtest(config: Any, html_output: str | None = None) -> None:
-    """Walk-forward momentum backtest using weekly rebalancing.
+def _generate_rebalance_dates(start: date, end: date) -> list[date]:
+    """Generate weekly rebalance dates (Fridays) between start and end."""
+    rebalance_dates: list[date] = []
+    current = start
+    while current <= end:
+        days_to_friday = (4 - current.weekday()) % 7
+        friday = current + timedelta(days=days_to_friday)
+        if friday > end:
+            break
+        rebalance_dates.append(friday)
+        current = friday + timedelta(days=7)
+    return rebalance_dates
+
+
+def _compute_max_drawdown(returns: list[float]) -> float:
+    """Max drawdown from a list of period returns. Returns negative value."""
+    if not returns:
+        return 0.0
+    cumulative = np.cumprod([1 + r for r in returns])
+    peak = np.maximum.accumulate(cumulative)
+    drawdown = (cumulative - peak) / peak
+    return float(np.min(drawdown))
+
+
+def _run_walk_forward(
+    screener: Any,
+    all_close_series: dict[str, "pd.Series[float]"],
+    all_volume_series: dict[str, "pd.Series[float]"],
+    market_caps: dict[str, float],
+    rebalance_dates: list[date],
+    top_n: int,
+    hold_days: int,
+    log_interval: int = 50,
+) -> list[dict[str, Any]]:
+    """PIT-correct walk-forward simulation.
 
     For each rebalance date:
-    1. Get point-in-time constituents (anti-survivorship)
-    2. Run MomentumScreener with is_backtest=True
-    3. Compute equal-weight portfolio returns over holding period
+    1. Trim series to as-of rebal_date (only data available at that point)
+    2. Approximate PIT market caps via price ratio scaling
+    3. Screen with trimmed np.ndarray (screener API unchanged)
+    4. Compute forward returns from rebal_date + hold_days
+
+    Market cap approximation: cap(t) ≈ cap(today) × price(t) / price(latest).
+    Assumes shares outstanding are roughly stable over the backtest window.
+
+    Args:
+        screener: MomentumScreener instance.
+        all_close_series: Symbol -> pd.Series (DatetimeIndex) of daily closes.
+        all_volume_series: Symbol -> pd.Series (DatetimeIndex) of daily volumes.
+        market_caps: Symbol -> market cap in USD (current snapshot).
+        rebalance_dates: List of rebalance dates.
+        top_n: Number of picks per period.
+        hold_days: Trading days to hold positions.
+        log_interval: Log progress every N periods.
+
+    Returns:
+        List of dicts with date, n_picks, avg_return, picks.
     """
+    import pandas as pd
+
+    portfolio_returns: list[dict[str, Any]] = []
+    total = len(rebalance_dates)
+
+    # Pre-compute latest close per symbol for PIT market cap scaling
+    latest_prices: dict[str, float] = {}
+    for sym, series in all_close_series.items():
+        if len(series) > 0:
+            latest_prices[sym] = float(series.iloc[-1])
+
+    for i, rebal_date in enumerate(rebalance_dates):
+        if (i + 1) % log_interval == 0 or i == total - 1:
+            logger.info(f"Walk-forward: {i + 1}/{total} periods processed")
+
+        rebal_ts = pd.Timestamp(rebal_date)
+
+        # Trim to PIT: only data available on rebal_date
+        trimmed_closes: dict[str, np.ndarray] = {}
+        trimmed_volumes: dict[str, np.ndarray] = {}
+        pit_market_caps: dict[str, float] = {}
+        for sym, series in all_close_series.items():
+            pit = series[series.index <= rebal_ts]
+            if len(pit) > 0:
+                trimmed_closes[sym] = pit.values
+                if sym in all_volume_series:
+                    vol_pit = all_volume_series[sym][all_volume_series[sym].index <= rebal_ts]
+                    trimmed_volumes[sym] = vol_pit.values
+
+                # Approximate PIT market cap: cap(t) ≈ cap(now) × price(t)/price(latest)
+                latest_p = latest_prices.get(sym, 0.0)
+                current_cap = market_caps.get(sym, 0.0)
+                if latest_p > 0 and current_cap > 0:
+                    pit_market_caps[sym] = current_cap * (float(pit.iloc[-1]) / latest_p)
+
+        result = screener.screen(
+            price_data=trimmed_closes,
+            volume_data=trimmed_volumes,
+            regime="R0",  # Backtest uses R0 (no regime gating)
+            market_caps=pit_market_caps,
+            is_backtest=True,
+        )
+
+        picks = [c.signal.symbol for c in result.candidates[:top_n]]
+        if not picks:
+            continue
+
+        # Compute forward returns from rebal_date
+        forward_rets: list[float] = []
+        for sym in picks:
+            if sym not in all_close_series:
+                continue
+            series = all_close_series[sym]
+            # Find last trading day on or before rebal_date.
+            # side="right" returns first index > rebal_ts, so -1 gives <=.
+            rebal_idx = series.index.searchsorted(rebal_ts, side="right") - 1
+            if rebal_idx < 0:
+                continue
+            if rebal_idx + hold_days < len(series):
+                p_entry = series.iloc[rebal_idx]
+                p_exit = series.iloc[rebal_idx + hold_days]
+                if p_entry > 0:
+                    ret = (p_exit - p_entry) / p_entry
+                    forward_rets.append(float(ret))
+
+        if forward_rets:
+            avg_ret = float(np.mean(forward_rets))
+            portfolio_returns.append(
+                {
+                    "date": rebal_date.isoformat(),
+                    "n_picks": len(picks),
+                    "avg_return": avg_ret,
+                    "picks": picks[:5],
+                }
+            )
+
+    return portfolio_returns
+
+
+def _print_backtest_summary(
+    portfolio_returns: list[dict[str, Any]],
+    start: date,
+    end: date,
+    top_n: int,
+    hold_days: int,
+) -> dict[str, float]:
+    """Print and return backtest summary metrics."""
+    all_rets = [pr["avg_return"] for pr in portfolio_returns]
+    cum_ret = float(np.prod([1 + r for r in all_rets]) - 1)
+    avg_weekly = float(np.mean(all_rets))
+    max_dd = _compute_max_drawdown(all_rets)
+    sharpe_approx = (
+        float(np.mean(all_rets) / np.std(all_rets) * np.sqrt(52)) if np.std(all_rets) > 0 else 0.0
+    )
+
+    print(f"\nMomentum Backtest Results — {start} to {end}")
+    print("=" * 60)
+    print(f"Rebalance periods:  {len(portfolio_returns)}")
+    print(f"Cumulative return:  {cum_ret:+.2%}")
+    print(f"Avg weekly return:  {avg_weekly:+.4%}")
+    print(f"Sharpe (approx):    {sharpe_approx:.2f}")
+    print(f"Max drawdown:       {max_dd:+.2%}")
+    print(f"Holding period:     {hold_days} days")
+    print(f"Portfolio size:     {top_n}")
+
+    return {
+        "cumulative_return": cum_ret,
+        "avg_weekly_return": avg_weekly,
+        "sharpe_approx": sharpe_approx,
+        "max_drawdown": max_dd,
+    }
+
+
+def cmd_backtest(config: Any, html_output: str | None = None) -> None:
+    """Walk-forward momentum backtest + ablation + HTML report.
+
+    Loads cached data once, then:
+    1. Runs full walk-forward simulation (M+FIP+Filters config)
+    2. Runs 3 ablation configs (M-only / M+FIP / M+FIP+Filters)
+    3. Writes JSON results and always generates an HTML report
+    """
+    from src.domain.screeners.momentum.config import MomentumFilters, ScoringConfig
+    from src.domain.screeners.momentum.screener import MomentumScreener
+    from src.infrastructure.reporting.momentum.templates import render_backtest_html
     from src.services.momentum_data_service import MomentumDataService
 
     svc = MomentumDataService()
@@ -311,126 +528,178 @@ def cmd_backtest(config: Any, html_output: str | None = None) -> None:
 
     logger.info(f"Backtest: {start} to {end}, top-{top_n}, {hold_days}-day hold")
 
-    # Load all available data
+    # Load all available data once (PIT-correct date-indexed Series)
     symbols = svc.get_universe()
     if not symbols:
-        logger.error("No universe cached. Run with --update first.")
+        logger.error("No universe cached. Run without --no-refresh first.")
         return
 
     lookback_cal_days = int(config.data_source.lookback_trading_days * 1.5) + 50
-    all_closes = svc.get_bulk_closes(
-        symbols, end, lookback_days=(end - start).days + lookback_cal_days
-    )
-    all_volumes = svc.get_bulk_volumes(
-        symbols, end, lookback_days=(end - start).days + lookback_cal_days
-    )
+    total_cal_days = (end - start).days + lookback_cal_days
+    all_close_series = svc.get_bulk_close_series(symbols, end, lookback_days=total_cal_days)
+    all_volume_series = svc.get_bulk_volume_series(symbols, end, lookback_days=total_cal_days)
     market_caps = svc.get_market_caps(symbols)
+    rebalance_dates = _generate_rebalance_dates(start, end)
 
-    from src.domain.screeners.momentum.screener import MomentumScreener
+    logger.info(
+        f"Loaded {len(all_close_series)} close series, "
+        f"{len(all_volume_series)} volume series, "
+        f"{len(rebalance_dates)} rebalance dates"
+    )
 
+    # ── Walk-forward simulation (full config) ─────────────────────────
     screener = MomentumScreener(config)
+    portfolio_returns = _run_walk_forward(
+        screener=screener,
+        all_close_series=all_close_series,
+        all_volume_series=all_volume_series,
+        market_caps=market_caps,
+        rebalance_dates=rebalance_dates,
+        top_n=top_n,
+        hold_days=hold_days,
+    )
 
-    # Generate weekly rebalance dates (Fridays)
-    rebalance_dates: list[date] = []
-    current = start
-    while current <= end:
-        # Find next Friday
-        days_to_friday = (4 - current.weekday()) % 7
-        friday = current + timedelta(days=days_to_friday)
-        if friday > end:
-            break
-        rebalance_dates.append(friday)
-        current = friday + timedelta(days=7)
-
-    logger.info(f"Backtest: {len(rebalance_dates)} rebalance dates")
-
-    # Walk-forward simulation
-    portfolio_returns: list[dict[str, Any]] = []
-
-    for rebal_date in rebalance_dates:
-        # Trim price data to as-of rebal_date
-        trimmed_closes: dict[str, np.ndarray] = {}
-        trimmed_volumes: dict[str, np.ndarray] = {}
-
-        for sym in all_closes:
-            closes_full = all_closes[sym]
-            # Estimate how many bars to trim (rough: calendar days ~ 1.4x trading)
-            # This is a simplification; in production you'd index by date
-            trimmed_closes[sym] = closes_full
-            if sym in all_volumes:
-                trimmed_volumes[sym] = all_volumes[sym]
-
-        result = screener.screen(
-            price_data=trimmed_closes,
-            volume_data=trimmed_volumes,
-            regime="R0",  # Backtest uses R0 (no regime gating)
-            market_caps=market_caps,
-            is_backtest=True,
-        )
-
-        picks = [c.signal.symbol for c in result.candidates[:top_n]]
-        if not picks:
-            continue
-
-        # Compute forward returns (simplified: use available data)
-        forward_rets: list[float] = []
-        for sym in picks:
-            if sym in all_closes:
-                closes = all_closes[sym]
-                if len(closes) > hold_days:
-                    ret = (closes[-1] - closes[-(hold_days + 1)]) / closes[-(hold_days + 1)]
-                    forward_rets.append(float(ret))
-
-        if forward_rets:
-            avg_ret = float(np.mean(forward_rets))
-            portfolio_returns.append(
-                {
-                    "date": rebal_date.isoformat(),
-                    "n_picks": len(picks),
-                    "avg_return": avg_ret,
-                    "picks": picks[:5],  # Top 5 for logging
-                }
-            )
-
-    # Print backtest summary
+    bt_metrics: dict[str, float] = {}
     if portfolio_returns:
-        all_rets = [pr["avg_return"] for pr in portfolio_returns]
-        cum_ret = float(np.prod([1 + r for r in all_rets]) - 1)
-        avg_weekly = float(np.mean(all_rets))
-        sharpe_approx = (
-            float(np.mean(all_rets) / np.std(all_rets) * np.sqrt(52)) if np.std(all_rets) > 0 else 0
-        )
-
-        print(f"\nMomentum Backtest Results — {start} to {end}")
-        print("=" * 60)
-        print(f"Rebalance periods:  {len(portfolio_returns)}")
-        print(f"Cumulative return:  {cum_ret:+.2%}")
-        print(f"Avg weekly return:  {avg_weekly:+.4%}")
-        print(f"Sharpe (approx):    {sharpe_approx:.2f}")
-        print(f"Holding period:     {hold_days} days")
-        print(f"Portfolio size:     {top_n}")
-
-        # Write JSON results
-        output_dir = Path(html_output).parent if html_output else PROJECT_ROOT / "out" / "momentum"
-        output_dir.mkdir(parents=True, exist_ok=True)
-        bt_path = output_dir / "data" / "momentum_backtest.json"
-        bt_path.parent.mkdir(parents=True, exist_ok=True)
-        bt_path.write_text(
-            json.dumps(
-                {
-                    "start": start.isoformat(),
-                    "end": end.isoformat(),
-                    "cumulative_return": cum_ret,
-                    "avg_weekly_return": avg_weekly,
-                    "sharpe_approx": sharpe_approx,
-                    "periods": portfolio_returns,
-                },
-                indent=2,
-            )
-        )
-        logger.info(f"Backtest results: {bt_path}")
+        bt_metrics = _print_backtest_summary(portfolio_returns, start, end, top_n, hold_days)
     else:
         print("No backtest results generated (insufficient data)")
+
+    # ── Ablation: 3 configs ───────────────────────────────────────────
+    logger.info("Ablation: running 3 configurations...")
+
+    no_filters = MomentumFilters(
+        min_market_cap=0,
+        min_avg_daily_dollar_volume=0,
+        min_price=0,
+        min_daily_turnover_rate=0,
+        earnings_blackout_days=0,
+    )
+    ablation_configs: list[tuple[str, Any]] = [
+        (
+            "M-only",
+            dataclasses.replace(
+                config,
+                scoring=dataclasses.replace(config.scoring, fip_weight=0.0, momentum_weight=1.0),
+                filters=no_filters,
+            ),
+        ),
+        (
+            "M+FIP",
+            dataclasses.replace(
+                config,
+                scoring=ScoringConfig(
+                    momentum_weight=0.5,
+                    fip_weight=0.5,
+                    top_n=config.scoring.top_n,
+                ),
+                filters=no_filters,
+            ),
+        ),
+        (
+            "M+FIP+Filters",
+            dataclasses.replace(config),
+        ),
+    ]
+
+    ablation_results: list[tuple[str, dict[str, Any]]] = []
+
+    for idx, (label, abl_config) in enumerate(ablation_configs, 1):
+        logger.info(
+            f"[{idx}/3] {label}: running walk-forward " f"({len(rebalance_dates)} periods)..."
+        )
+        abl_screener = MomentumScreener(abl_config)
+        abl_returns = _run_walk_forward(
+            screener=abl_screener,
+            all_close_series=all_close_series,
+            all_volume_series=all_volume_series,
+            market_caps=market_caps,
+            rebalance_dates=rebalance_dates,
+            top_n=top_n,
+            hold_days=hold_days,
+        )
+
+        if abl_returns:
+            all_rets = [pr["avg_return"] for pr in abl_returns]
+            cum_ret = float(np.prod([1 + r for r in all_rets]) - 1)
+            avg_weekly = float(np.mean(all_rets))
+            max_dd = _compute_max_drawdown(all_rets)
+            sharpe = (
+                float(np.mean(all_rets) / np.std(all_rets) * np.sqrt(52))
+                if np.std(all_rets) > 0
+                else 0.0
+            )
+            metrics: dict[str, Any] = {
+                "cumulative_return": cum_ret,
+                "avg_weekly_return": avg_weekly,
+                "sharpe_approx": sharpe,
+                "max_drawdown": max_dd,
+                "n_periods": len(abl_returns),
+            }
+            logger.info(
+                f"[{idx}/3] {label}: cum_ret={cum_ret:+.1%}, "
+                f"sharpe={sharpe:.2f}, max_dd={max_dd:+.1%}"
+            )
+        else:
+            metrics = {
+                "cumulative_return": 0.0,
+                "avg_weekly_return": 0.0,
+                "sharpe_approx": 0.0,
+                "max_drawdown": 0.0,
+                "n_periods": 0,
+            }
+            logger.info(f"[{idx}/3] {label}: no results")
+
+        ablation_results.append((label, metrics))
+
+    # Print ablation comparison table
+    print(f"\nAblation Results — {start} to {end}")
+    print("=" * 72)
+    print(f"{'Config':<20} {'Cum Return':>12} {'Sharpe':>8} {'Max DD':>10} {'Avg Weekly':>12}")
+    print("-" * 72)
+    for label, m in ablation_results:
+        print(
+            f"{label:<20} {m['cumulative_return']:>+11.2%} "
+            f"{m['sharpe_approx']:>8.2f} "
+            f"{m['max_drawdown']:>+9.2%} "
+            f"{m['avg_weekly_return']:>+11.4%}"
+        )
+    print("=" * 72)
+
+    # ── Write JSON + HTML ─────────────────────────────────────────────
+    output_path = (
+        Path(html_output) if html_output else PROJECT_ROOT / "out" / "momentum" / "backtest.html"
+    )
+    output_dir = output_path.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = output_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    bt_data = {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "top_n": top_n,
+        "hold_days": hold_days,
+        **bt_metrics,
+        "periods": portfolio_returns,
+    }
+    abl_data = {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "top_n": top_n,
+        "hold_days": hold_days,
+        "configs": [{"label": label, **m} for label, m in ablation_results],
+    }
+
+    (data_dir / "momentum_backtest.json").write_text(json.dumps(bt_data, indent=2))
+    (data_dir / "momentum_ablation.json").write_text(json.dumps(abl_data, indent=2))
+    logger.info(f"Backtest JSON: {data_dir / 'momentum_backtest.json'}")
+    logger.info(f"Ablation JSON: {data_dir / 'momentum_ablation.json'}")
+
+    # Always generate HTML
+    html_content = render_backtest_html({"backtest": bt_data, "ablation": abl_data})
+    output_path.write_text(html_content)
+    logger.info(f"Backtest HTML report: {output_path}")
 
 
 def main() -> None:
@@ -443,7 +712,9 @@ def main() -> None:
         help="Legacy alias — universe + OHLCV refresh is now the default behavior",
     )
     parser.add_argument(
-        "--backtest", action="store_true", help="Run walk-forward portfolio backtest"
+        "--backtest",
+        action="store_true",
+        help="Run walk-forward backtest + ablation comparison (always produces HTML)",
     )
     parser.add_argument(
         "--include-recent-ipos",

--- a/src/services/bar_loader.py
+++ b/src/services/bar_loader.py
@@ -101,19 +101,19 @@ def _fetch_yahoo(
     start_date: date,
     end_date: date,
 ) -> dict[str, pd.DataFrame]:
-    """Fetch bars from Yahoo Finance.
+    """Fetch bars from Yahoo Finance using batch download.
 
-    yf.Ticker.history() returns split- and dividend-adjusted prices by default
-    (auto_adjust=True since yfinance 0.2.x), so the output is suitable for
-    momentum ranking and backtesting without further adjustment.
+    Uses yf.download() for multi-symbol batch fetching (single HTTP request
+    per batch of ~500 symbols) instead of per-symbol requests.
+
+    yfinance returns split- and dividend-adjusted prices by default
+    (auto_adjust=True since yfinance 0.2.x).
     """
     try:
         import yfinance as yf
     except ImportError:
         logger.debug("yfinance not installed")
         return {}
-
-    delay = _get_rate_delay("yahoo")
 
     interval_map = {
         "1d": "1d",
@@ -128,46 +128,72 @@ def _fetch_yahoo(
     interval = interval_map.get(timeframe, "1d")
 
     result: dict[str, pd.DataFrame] = {}
-    for symbol in symbols:
-        try:
-            if delay > 0:
-                time.sleep(delay)
-            ticker = yf.Ticker(symbol)
-            df = ticker.history(
-                start=start_date.isoformat(),
-                end=end_date.isoformat(),
-                interval=interval,
-            )
-            if df.empty:
-                continue
 
-            # Standardize
-            df.columns = [c.lower() for c in df.columns]
+    # Batch download — yf.download handles multiple tickers in one call
+    try:
+        raw = yf.download(
+            symbols,
+            start=start_date.isoformat(),
+            end=end_date.isoformat(),
+            interval=interval,
+            group_by="ticker",
+            threads=True,
+            progress=False,
+        )
+
+        if raw.empty:
+            return {}
+
+        # yf.download returns different shapes for 1 vs N symbols
+        if len(symbols) == 1:
+            sym = symbols[0]
+            df = raw.copy()
+            df.columns = [c.lower() if isinstance(c, str) else c[0].lower() for c in df.columns]
             for col in ["dividends", "stock splits", "adj close"]:
                 if col in df.columns:
                     df = df.drop(columns=[col])
+            df = df.dropna(subset=["close"])
+            if not df.empty:
+                result[sym] = _maybe_resample(df, timeframe, interval)
+        else:
+            for sym in symbols:
+                try:
+                    if sym not in raw.columns.get_level_values(0):
+                        continue
+                    df = raw[sym].copy()
+                    df.columns = [c.lower() for c in df.columns]
+                    for col in ["dividends", "stock splits", "adj close"]:
+                        if col in df.columns:
+                            df = df.drop(columns=[col])
+                    df = df.dropna(subset=["close"])
+                    if not df.empty:
+                        result[sym] = _maybe_resample(df, timeframe, interval)
+                except Exception as e:
+                    logger.debug(f"Yahoo parse failed for {sym}: {e}")
 
-            # Aggregate if needed (4h/2h from 1h)
-            if timeframe in ("4h", "2h") and interval == "1h":
-                df = (
-                    df.resample(timeframe)
-                    .agg(
-                        {
-                            "open": "first",
-                            "high": "max",
-                            "low": "min",
-                            "close": "last",
-                            "volume": "sum",
-                        }
-                    )
-                    .dropna()
-                )
-
-            result[symbol] = df
-        except Exception as e:
-            logger.warning(f"Yahoo fetch failed for {symbol}: {e}")
+    except Exception as e:
+        logger.warning(f"Yahoo batch download failed: {e}")
 
     return result
+
+
+def _maybe_resample(df: pd.DataFrame, timeframe: str, interval: str) -> pd.DataFrame:
+    """Aggregate intraday bars if the target timeframe differs from download interval."""
+    if timeframe in ("4h", "2h") and interval == "1h":
+        df = (
+            df.resample(timeframe)
+            .agg(
+                {
+                    "open": "first",
+                    "high": "max",
+                    "low": "min",
+                    "close": "last",
+                    "volume": "sum",
+                }
+            )
+            .dropna()
+        )
+    return df
 
 
 # ── Public API ──────────────────────────────────────────────────

--- a/src/services/bar_loader.py
+++ b/src/services/bar_loader.py
@@ -18,7 +18,6 @@ Usage:
 from __future__ import annotations
 
 import logging
-import time
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional

--- a/src/services/momentum_data_service.py
+++ b/src/services/momentum_data_service.py
@@ -50,6 +50,7 @@ class MomentumDataService:
         russell_proxy: bool = True,
         cap_min: float = 300_000_000,
         cap_max: float = 10_000_000_000,
+        fallback_max_symbols: int = 800,
         api_key: str | None = None,
     ) -> list[str]:
         """Fetch index constituents via FMP and cache to JSON.
@@ -59,6 +60,7 @@ class MomentumDataService:
             russell_proxy: Include Russell 2000 proxy.
             cap_min: Min market cap for Russell proxy.
             cap_max: Max market cap for Russell proxy.
+            fallback_max_symbols: Max symbols from company-screener fallback.
             api_key: Optional FMP API key override.
 
         Returns:
@@ -68,12 +70,14 @@ class MomentumDataService:
             FMPIndexConstituentsAdapter,
         )
 
+        print("  Fetching universe from FMP...", end=" ", flush=True)
         adapter = FMPIndexConstituentsAdapter(api_key=api_key)
         symbols = adapter.get_combined_universe(
             indices=indices,
             russell_proxy=russell_proxy,
             cap_min=cap_min,
             cap_max=cap_max,
+            fallback_max_symbols=fallback_max_symbols,
         )
 
         # Save cache
@@ -85,6 +89,7 @@ class MomentumDataService:
             "count": len(symbols),
         }
         self._universe_cache.write_text(json.dumps(cache_data, indent=2))
+        print(f"{len(symbols)} symbols")
         logger.info(f"Universe cache updated: {len(symbols)} symbols → {self._universe_cache}")
         return symbols
 
@@ -112,14 +117,14 @@ class MomentumDataService:
         months: int = 15,
         batch_size: int = 500,
     ) -> int:
-        """Download daily OHLCV and store in Parquet.
+        """Incrementally update daily OHLCV in Parquet.
 
-        Uses unified bar loader (FMP -> Yahoo -> IB) for data sourcing,
-        then writes each symbol to the ParquetHistoricalStore.
+        Smart refresh: checks each symbol's last Parquet date and only
+        fetches new bars. Symbols with no existing data get a full download.
 
         Args:
             symbols: List of symbols to fetch.
-            months: Months of history to fetch (15 = ~13mo lookback + buffer).
+            months: Months of history for symbols missing data entirely.
             batch_size: Symbols per batch call.
 
         Returns:
@@ -128,36 +133,105 @@ class MomentumDataService:
         from src.infrastructure.stores.parquet_historical_store import (
             ParquetHistoricalStore,
         )
-        from src.services.bar_loader import load_bars
 
         store = ParquetHistoricalStore(self._hist_dir)
         end_date = date.today()
 
+        # Partition symbols by freshness
+        stale: list[str] = []
+        missing: list[str] = []
+        fresh_count = 0
+
+        for sym in symbols:
+            parquet_path = self._hist_dir / sym.upper() / "1d.parquet"
+            if not parquet_path.exists():
+                missing.append(sym)
+                continue
+            try:
+                df = pd.read_parquet(parquet_path, columns=["timestamp"])
+                if df.empty:
+                    missing.append(sym)
+                    continue
+                last_date = pd.Timestamp(df["timestamp"].iloc[-1]).date()
+                if last_date < end_date - timedelta(days=1):
+                    stale.append(sym)
+                else:
+                    fresh_count += 1
+            except Exception:
+                missing.append(sym)
+
+        print(
+            f"  OHLCV: {fresh_count} fresh, {len(stale)} stale, "
+            f"{len(missing)} missing (of {len(symbols)} total)"
+        )
+
+        success_count = 0
+
+        # Incremental: stale symbols only need recent bars (14 days buffer)
+        if stale:
+            print(f"  Updating {len(stale)} stale symbols (14 days)...", flush=True)
+            success_count += self._batch_fetch_and_store(
+                stale, store, days=14, batch_size=batch_size
+            )
+
+        # Full download: symbols with no Parquet data
+        if missing:
+            print(
+                f"  Downloading {len(missing)} new symbols ({months} months)...",
+                flush=True,
+            )
+            success_count += self._batch_fetch_and_store(
+                missing, store, days=months * 31, batch_size=batch_size
+            )
+
+        if fresh_count == len(symbols):
+            print("  All symbols up to date — nothing to fetch")
+        else:
+            print(f"  Done: {success_count} updated, {fresh_count} already fresh")
+
+        return success_count
+
+    def _batch_fetch_and_store(
+        self,
+        symbols: list[str],
+        store: Any,
+        days: int,
+        batch_size: int = 500,
+    ) -> int:
+        """Fetch bars in batches and upsert into Parquet store."""
+        from src.services.bar_loader import load_bars
+
+        end_date = date.today()
         success_count = 0
         total_batches = (len(symbols) + batch_size - 1) // batch_size
 
         for batch_idx in range(total_batches):
             batch_start = batch_idx * batch_size
             batch = symbols[batch_start : batch_start + batch_size]
-            logger.info(f"Downloading batch {batch_idx + 1}/{total_batches} ({len(batch)} symbols)")
+            print(
+                f"    Batch {batch_idx + 1}/{total_batches} " f"({len(batch)} symbols)...",
+                end=" ",
+                flush=True,
+            )
 
-            bars_dict = load_bars(batch, timeframe="1d", days=months * 31, end_date=end_date)
+            bars_dict = load_bars(batch, timeframe="1d", days=days, end_date=end_date)
 
+            batch_ok = 0
             for symbol, df in bars_dict.items():
                 try:
                     if df.empty:
                         continue
-                    # Capitalize columns for _df_to_bars compatibility
                     df_compat = df.copy()
                     df_compat.columns = [c.capitalize() for c in df_compat.columns]
                     bar_list = self._df_to_bars(df_compat, symbol)
                     if bar_list:
                         store.write_bars(symbol, "1d", bar_list, mode="upsert")
                         success_count += 1
+                        batch_ok += 1
                 except Exception as e:
                     logger.warning(f"Failed to process {symbol}: {e}")
+            print(f"{batch_ok}/{len(batch)} ok")
 
-        logger.info(f"OHLCV update complete: {success_count}/{len(symbols)} symbols written")
         return success_count
 
     def get_daily_data(self, symbol: str, start: date, end: date) -> pd.DataFrame | None:
@@ -244,6 +318,76 @@ class MomentumDataService:
                 result[symbol] = df["volume"].values
 
         return result
+
+    def get_data_as_of_date(self, symbols: list[str], sample_size: int = 5) -> date | None:
+        """Determine the most recent data date by probing Parquet files.
+
+        Uses a deterministic sample (sorted, first N) so results are
+        reproducible across runs.
+
+        Returns:
+            The most recent data date found, or None if no data.
+        """
+        sampled = sorted(symbols)[:sample_size] if symbols else []
+        latest: date | None = None
+
+        for symbol in sampled:
+            parquet_path = self._hist_dir / symbol.upper() / "1d.parquet"
+            if not parquet_path.exists():
+                continue
+            try:
+                df = pd.read_parquet(parquet_path)
+                if "timestamp" in df.columns:
+                    df = df.set_index("timestamp")
+                if df.empty:
+                    continue
+                last_ts = pd.Timestamp(df.index[-1])
+                last_date = last_ts.date()
+                if latest is None or last_date > latest:
+                    latest = last_date
+            except Exception as e:
+                logger.warning(f"Failed to read data_as_of for {symbol}: {e}")
+
+        return latest
+
+    def get_upcoming_earnings(self, symbols: list[str], lookahead_days: int = 7) -> dict[str, date]:
+        """Fetch upcoming earnings dates for given symbols.
+
+        Calls FMP earnings calendar and filters to provided symbol list.
+        Fail-open: returns empty dict on any error.
+
+        Args:
+            symbols: Symbols to check.
+            lookahead_days: Days ahead to scan for earnings.
+
+        Returns:
+            Dict of symbol -> earnings date for symbols reporting soon.
+        """
+        try:
+            from src.infrastructure.adapters.earnings.fmp_earnings import (
+                FMPEarningsAdapter,
+            )
+
+            adapter = FMPEarningsAdapter()
+            today = date.today()
+            end = today + timedelta(days=lookahead_days)
+            calendar = adapter.fetch_earnings_calendar(today, end)
+
+            symbol_set = set(symbols)
+            result: dict[str, date] = {}
+            for entry in calendar:
+                sym = entry.get("symbol", "")
+                if sym in symbol_set and "date" in entry:
+                    try:
+                        result[sym] = date.fromisoformat(entry["date"])
+                    except (ValueError, TypeError):
+                        continue
+
+            logger.info(f"Upcoming earnings: {len(result)} symbols within {lookahead_days} days")
+            return result
+        except Exception as e:
+            logger.warning(f"Earnings calendar fetch failed (fail-open): {e}")
+            return {}
 
     def get_market_caps(self, symbols: list[str]) -> dict[str, float]:
         """Read market caps from the existing MarketCapService cache.

--- a/src/services/momentum_data_service.py
+++ b/src/services/momentum_data_service.py
@@ -198,8 +198,21 @@ class MomentumDataService:
         days: int,
         batch_size: int = 500,
     ) -> int:
-        """Fetch bars in batches and upsert into Parquet store."""
+        """Fetch bars in batches and upsert into Parquet store.
+
+        When fetching > 250 symbols, uses Yahoo batch download directly
+        (single HTTP call per 500-symbol batch) instead of FMP's serial
+        per-symbol path which incurs 0.3s rate-limit sleep per symbol.
+        """
         from src.services.bar_loader import load_bars
+
+        # Yahoo's yf.download() handles 500 symbols in one HTTP call;
+        # FMP loops per-symbol with 0.3s sleep → ~3 min/batch vs ~5s/batch.
+        # Keep FMP as fallback so Yahoo outages don't lose data entirely.
+        use_yahoo_batch = len(symbols) > 250
+        source_override: list[str] | None = ["yahoo", "fmp"] if use_yahoo_batch else None
+        if use_yahoo_batch:
+            logger.info(f"Large batch ({len(symbols)} symbols): using Yahoo-first batch download")
 
         end_date = date.today()
         success_count = 0
@@ -214,7 +227,13 @@ class MomentumDataService:
                 flush=True,
             )
 
-            bars_dict = load_bars(batch, timeframe="1d", days=days, end_date=end_date)
+            bars_dict = load_bars(
+                batch,
+                timeframe="1d",
+                days=days,
+                end_date=end_date,
+                source_priority=source_override,
+            )
 
             batch_ok = 0
             for symbol, df in bars_dict.items():
@@ -317,6 +336,48 @@ class MomentumDataService:
             if df is not None and not df.empty:
                 result[symbol] = df["volume"].values
 
+        return result
+
+    def get_bulk_close_series(
+        self,
+        symbols: list[str],
+        end: date,
+        lookback_days: int = 300,
+    ) -> dict[str, pd.Series]:
+        """Batch read closing prices as date-indexed Series (for PIT backtest).
+
+        Returns:
+            Dict of symbol -> pd.Series with DatetimeIndex of daily closes.
+        """
+        start = end - timedelta(days=lookback_days)
+        result: dict[str, pd.Series] = {}
+        for symbol in symbols:
+            df = self.get_daily_data(symbol, start, end)
+            if df is not None and not df.empty:
+                result[symbol] = df["close"]
+        logger.info(
+            f"Loaded close series: {len(result)}/{len(symbols)} symbols "
+            f"({start.isoformat()} to {end.isoformat()})"
+        )
+        return result
+
+    def get_bulk_volume_series(
+        self,
+        symbols: list[str],
+        end: date,
+        lookback_days: int = 300,
+    ) -> dict[str, pd.Series]:
+        """Batch read daily volumes as date-indexed Series (for PIT backtest).
+
+        Returns:
+            Dict of symbol -> pd.Series with DatetimeIndex of daily volumes.
+        """
+        start = end - timedelta(days=lookback_days)
+        result: dict[str, pd.Series] = {}
+        for symbol in symbols:
+            df = self.get_daily_data(symbol, start, end)
+            if df is not None and not df.empty:
+                result[symbol] = df["volume"]
         return result
 
     def get_data_as_of_date(self, symbols: list[str], sample_size: int = 5) -> date | None:

--- a/src/utils/email_sender.py
+++ b/src/utils/email_sender.py
@@ -1,0 +1,95 @@
+"""Shared email sender — reads SMTP config from secrets.yaml with env var overrides.
+
+Used by momentum, PEAD, and signal runners to send email notifications.
+Fail-open: returns False on error, never raises.
+
+Config priority:
+    1. Environment variables (CI: SMTP_SERVER, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD, SIGNAL_REPORT_RECIPIENTS)
+    2. config/secrets.yaml (local dev)
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from email.mime.text import MIMEText
+from pathlib import Path
+from typing import Any
+
+from src.utils.logging_setup import get_logger
+
+logger = get_logger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_secrets_yaml() -> dict[str, Any]:
+    """Load config/secrets.yaml if it exists."""
+    path = _PROJECT_ROOT / "config" / "secrets.yaml"
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+
+        return yaml.safe_load(path.read_text()) or {}
+    except Exception as e:
+        logger.warning(f"Failed to read secrets.yaml: {e}")
+        return {}
+
+
+def _get_smtp_config() -> dict[str, str]:
+    """Resolve SMTP config: env vars take precedence over secrets.yaml."""
+    secrets = _load_secrets_yaml()
+    email_cfg = secrets.get("email", {})
+
+    return {
+        "server": os.environ.get("SMTP_SERVER", "smtp.gmail.com"),
+        "port": os.environ.get("SMTP_PORT", "587"),
+        "username": os.environ.get("SMTP_USERNAME", email_cfg.get("SMTP_USERNAME", "")),
+        "password": os.environ.get("SMTP_PASSWORD", email_cfg.get("SMTP_APP_PASSWORD", "")),
+        "recipients": os.environ.get("SIGNAL_REPORT_RECIPIENTS", email_cfg.get("EMAIL_DEST", "")),
+    }
+
+
+def send_email(
+    subject: str,
+    body: str,
+    content_type: str = "text/plain",
+) -> bool:
+    """Send an email via SMTP.
+
+    Args:
+        subject: Email subject line.
+        body: Email body text.
+        content_type: MIME content type (default: text/plain).
+
+    Returns:
+        True if sent successfully, False otherwise.
+    """
+    cfg = _get_smtp_config()
+
+    if not cfg["username"] or not cfg["password"]:
+        logger.warning("SMTP credentials not configured. Skipping email.")
+        return False
+
+    if not cfg["recipients"]:
+        logger.warning("No email recipients configured. Skipping email.")
+        return False
+
+    try:
+        msg = MIMEText(body, content_type.split("/")[-1])
+        msg["Subject"] = subject
+        msg["From"] = f"APEX Signal Bot <{cfg['username']}>"
+        msg["To"] = cfg["recipients"]
+
+        with smtplib.SMTP(cfg["server"], int(cfg["port"]), timeout=30) as server:
+            server.starttls()
+            server.login(cfg["username"], cfg["password"])
+            server.send_message(msg)
+
+        logger.info(f"Email sent: {subject}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to send email: {e}")
+        return False

--- a/src/utils/regime_display.py
+++ b/src/utils/regime_display.py
@@ -1,0 +1,20 @@
+"""Shared regime label utility — single source of truth via MarketRegime.display_name."""
+
+from __future__ import annotations
+
+
+def regime_label(code: str) -> str:
+    """Convert regime code string to human-readable display name.
+
+    Args:
+        code: Regime code, e.g. "R0", "R1", "R2", "R3".
+
+    Returns:
+        Display name like "Healthy Uptrend", or "Unknown" for invalid codes.
+    """
+    from src.domain.signals.indicators.regime.models import MarketRegime
+
+    try:
+        return MarketRegime(code).display_name
+    except ValueError:
+        return "Unknown"

--- a/tests/unit/reporting/test_email_momentum_renderer.py
+++ b/tests/unit/reporting/test_email_momentum_renderer.py
@@ -105,7 +105,7 @@ class TestRenderMomentumEmailText:
         assert "#1 AAPL [MEGA]" in result
         assert "#2 NVDA [MEGA]" in result
         assert "Mom 12-1: +32.1%" in result
-        assert "FIP: +1.42" in result
+        assert "FIP: 1.42" in result
         assert "Composite: 0.92" in result
         assert "Quality: STRONG" in result
         assert "Close: $198.50" in result

--- a/tests/unit/reporting/test_email_momentum_renderer.py
+++ b/tests/unit/reporting/test_email_momentum_renderer.py
@@ -1,0 +1,197 @@
+"""Tests for src.infrastructure.reporting.email_momentum_renderer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.infrastructure.reporting.email_momentum_renderer import (
+    render_momentum_email_text,
+)
+
+
+@pytest.fixture()
+def watchlist_path(tmp_path: Path) -> Path:
+    return tmp_path / "data" / "momentum_watchlist.json"
+
+
+@pytest.fixture()
+def sample_candidates() -> list[dict]:
+    return [
+        {
+            "rank": 1,
+            "symbol": "AAPL",
+            "momentum_12_1": 0.3215,
+            "fip": 1.42,
+            "momentum_percentile": 0.95,
+            "fip_percentile": 0.88,
+            "composite_rank": 0.92,
+            "last_close": 198.50,
+            "market_cap": 3100000000000,
+            "avg_daily_dollar_volume": 12500000000,
+            "liquidity_tier": "mega",
+            "estimated_slippage_bps": 1,
+            "lookback_days": 252,
+            "quality_label": "STRONG",
+            "position_size_factor": 1.0,
+            "regime": "R0",
+        },
+        {
+            "rank": 2,
+            "symbol": "NVDA",
+            "momentum_12_1": 0.2850,
+            "fip": 0.95,
+            "momentum_percentile": 0.90,
+            "fip_percentile": 0.75,
+            "composite_rank": 0.83,
+            "last_close": 875.20,
+            "market_cap": 2200000000000,
+            "avg_daily_dollar_volume": 18000000000,
+            "liquidity_tier": "mega",
+            "estimated_slippage_bps": 2,
+            "lookback_days": 252,
+            "quality_label": "GOOD",
+            "position_size_factor": 0.8,
+            "regime": "R0",
+        },
+    ]
+
+
+class TestRenderMomentumEmailText:
+    def test_render_missing_file(self, tmp_path: Path) -> None:
+        result = render_momentum_email_text(tmp_path / "nonexistent.json")
+        assert result == "Momentum Screen: No data available."
+
+    def test_render_zero_candidates(self, watchlist_path: Path) -> None:
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": [],
+            "universe_size": 500,
+            "passed_filters": 120,
+            "regime": "R1",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "errors": [],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+
+        assert "0 momentum candidates" in result
+        assert "Choppy/Extended" in result
+        assert "R1" in result
+        assert "universe: 500" in result
+
+    def test_render_candidates(self, watchlist_path: Path, sample_candidates: list[dict]) -> None:
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": sample_candidates,
+            "universe_size": 500,
+            "passed_filters": 120,
+            "regime": "R0",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "errors": [],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+
+        # Verify header
+        assert "Momentum Screen" in result
+        assert "Healthy Uptrend" in result
+
+        # Verify candidate fields
+        assert "#1 AAPL [MEGA]" in result
+        assert "#2 NVDA [MEGA]" in result
+        assert "Mom 12-1: +32.1%" in result
+        assert "FIP: +1.42" in result
+        assert "Composite: 0.92" in result
+        assert "Quality: STRONG" in result
+        assert "Close: $198.50" in result
+        assert "MktCap: $3.1T" in result
+        assert "ADDV: $12,500,000,000" in result
+        assert "Slippage: ~1bps" in result
+        assert "Size: 100%" in result
+
+    def test_regime_name_in_output(self, watchlist_path: Path) -> None:
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": [],
+            "universe_size": 100,
+            "passed_filters": 30,
+            "regime": "R2",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "errors": [],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+        assert "Risk-Off" in result
+
+    def test_errors_displayed(self, watchlist_path: Path) -> None:
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": [],
+            "universe_size": 100,
+            "passed_filters": 30,
+            "regime": "R0",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "errors": ["TSLA: insufficient data", "GME: delisted"],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+        assert "Errors (2)" in result
+        assert "TSLA: insufficient data" in result
+
+    def test_data_as_of_displayed(self, watchlist_path: Path) -> None:
+        """data_as_of field should appear in email output when present."""
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": [],
+            "universe_size": 100,
+            "passed_filters": 30,
+            "regime": "R0",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "data_as_of": "2026-02-17",
+            "errors": [],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+        assert "Data as of: 2026-02-17" in result
+
+    def test_data_as_of_missing(self, watchlist_path: Path) -> None:
+        """No data_as_of should not break rendering."""
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": [],
+            "universe_size": 100,
+            "passed_filters": 30,
+            "regime": "R0",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "errors": [],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+        assert "Data as of" not in result
+
+    def test_errors_as_list_works(self, watchlist_path: Path) -> None:
+        """Errors serialized as list (from dict) should render correctly."""
+        watchlist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "candidates": [],
+            "universe_size": 100,
+            "passed_filters": 30,
+            "regime": "R0",
+            "generated_at": "2026-02-18T21:30:00+00:00",
+            "errors": ["TSLA: momentum computation failed", "GME: FIP computation failed"],
+        }
+        watchlist_path.write_text(json.dumps(data))
+
+        result = render_momentum_email_text(str(watchlist_path))
+        assert "Errors (2)" in result
+        assert "TSLA: momentum computation failed" in result
+        assert "GME: FIP computation failed" in result

--- a/tests/unit/screeners/test_index_constituents.py
+++ b/tests/unit/screeners/test_index_constituents.py
@@ -1,0 +1,113 @@
+"""Tests for FMPIndexConstituentsAdapter: fetch_us_stocks, get_combined_universe fallback."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.infrastructure.adapters.fmp.index_constituents import FMPIndexConstituentsAdapter
+
+
+@pytest.fixture()
+def adapter() -> FMPIndexConstituentsAdapter:
+    """Create adapter with a dummy API key (all network calls are mocked)."""
+    return FMPIndexConstituentsAdapter(api_key="test-key")
+
+
+class TestFetchUsStocks:
+    def test_sorts_by_market_cap_descending(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        mock_data = [
+            {"symbol": "SMALL", "marketCap": 1_000_000_000},
+            {"symbol": "BIG", "marketCap": 100_000_000_000},
+            {"symbol": "MID", "marketCap": 10_000_000_000},
+        ]
+        with patch.object(adapter, "_fmp_get", return_value=mock_data):
+            result = adapter.fetch_us_stocks(max_symbols=10)
+        assert result == ["BIG", "MID", "SMALL"]
+
+    def test_caps_at_max_symbols(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        mock_data = [{"symbol": f"S{i}", "marketCap": i * 1e9} for i in range(10)]
+        with patch.object(adapter, "_fmp_get", return_value=mock_data):
+            result = adapter.fetch_us_stocks(max_symbols=3)
+        assert len(result) == 3
+
+    def test_handles_none_market_cap(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        """None marketCap should not crash — treated as 0."""
+        mock_data = [
+            {"symbol": "GOOD", "marketCap": 5_000_000_000},
+            {"symbol": "NULL_CAP", "marketCap": None},
+            {"symbol": "MISSING_CAP"},  # No marketCap key at all
+        ]
+        with patch.object(adapter, "_fmp_get", return_value=mock_data):
+            result = adapter.fetch_us_stocks(max_symbols=10)
+        assert "GOOD" in result
+        assert "NULL_CAP" in result
+        assert "MISSING_CAP" in result
+        # GOOD should be first (highest cap)
+        assert result[0] == "GOOD"
+
+    def test_handles_string_market_cap(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        """Non-numeric marketCap (e.g. string) should be treated as 0."""
+        mock_data = [
+            {"symbol": "GOOD", "marketCap": 5_000_000_000},
+            {"symbol": "BAD", "marketCap": "not a number"},
+        ]
+        with patch.object(adapter, "_fmp_get", return_value=mock_data):
+            result = adapter.fetch_us_stocks(max_symbols=10)
+        assert result == ["GOOD", "BAD"]
+
+    def test_skips_invalid_symbols(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        mock_data = [
+            {"symbol": "OK", "marketCap": 1e9},
+            {"symbol": "", "marketCap": 2e9},  # Empty symbol
+            {"symbol": 123, "marketCap": 3e9},  # Non-string symbol
+            {"marketCap": 4e9},  # Missing symbol key
+        ]
+        with patch.object(adapter, "_fmp_get", return_value=mock_data):
+            result = adapter.fetch_us_stocks(max_symbols=10)
+        assert result == ["OK"]
+
+    def test_empty_response(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        with patch.object(adapter, "_fmp_get", return_value=[]):
+            result = adapter.fetch_us_stocks()
+        assert result == []
+
+    def test_non_list_response(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        with patch.object(adapter, "_fmp_get", return_value={"error": "forbidden"}):
+            result = adapter.fetch_us_stocks()
+        assert result == []
+
+
+class TestGetCombinedUniverseFallback:
+    def test_fallback_when_constituents_empty(self, adapter: FMPIndexConstituentsAdapter) -> None:
+        """When sp500 + nasdaq both return 0 (402), should use company-screener."""
+        with (
+            patch.object(adapter, "fetch_sp500", return_value=[]),
+            patch.object(adapter, "fetch_nasdaq", return_value=[]),
+            patch.object(adapter, "fetch_russell_proxy", return_value=["RSL1"]),
+            patch.object(adapter, "fetch_us_stocks", return_value=["FB1", "FB2"]) as mock_fallback,
+        ):
+            result = adapter.get_combined_universe(
+                indices=["sp500", "nasdaq"],
+                russell_proxy=True,
+                fallback_max_symbols=500,
+            )
+        mock_fallback.assert_called_once_with(cap_min=500_000_000, max_symbols=500)
+        assert "FB1" in result
+        assert "FB2" in result
+        assert "RSL1" in result
+
+    def test_no_fallback_when_constituents_present(
+        self, adapter: FMPIndexConstituentsAdapter
+    ) -> None:
+        """When constituent endpoints work, should NOT call fallback."""
+        with (
+            patch.object(adapter, "fetch_sp500", return_value=["AAPL"]),
+            patch.object(adapter, "fetch_nasdaq", return_value=[]),
+            patch.object(adapter, "fetch_russell_proxy", return_value=[]),
+            patch.object(adapter, "fetch_us_stocks") as mock_fallback,
+        ):
+            result = adapter.get_combined_universe(indices=["sp500", "nasdaq"])
+        mock_fallback.assert_not_called()
+        assert "AAPL" in result

--- a/tests/unit/screeners/test_momentum_runner.py
+++ b/tests/unit/screeners/test_momentum_runner.py
@@ -1,0 +1,69 @@
+"""Tests for momentum runner helper functions."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+from src.domain.screeners.momentum.models import MomentumScreenResult
+
+
+class TestWriteWatchlistJson:
+    def test_errors_serialized_as_list(self, tmp_path: Path) -> None:
+        """dict[str, str] errors should become a list of 'key: value' strings."""
+        from src.runners.momentum_runner import _write_watchlist_json
+
+        result = MomentumScreenResult(
+            candidates=[],
+            universe_size=100,
+            passed_filters=50,
+            regime="R0",
+            generated_at=datetime(2026, 2, 18, 12, 0, 0),
+            errors={"TSLA": "insufficient data", "GME": "delisted"},
+        )
+
+        out_path = _write_watchlist_json(result, tmp_path)
+        data = json.loads(out_path.read_text())
+
+        errors = data["errors"]
+        assert isinstance(errors, list)
+        assert len(errors) == 2
+        assert "TSLA: insufficient data" in errors
+        assert "GME: delisted" in errors
+
+    def test_data_as_of_included_when_provided(self, tmp_path: Path) -> None:
+        from src.runners.momentum_runner import _write_watchlist_json
+
+        result = MomentumScreenResult(
+            candidates=[],
+            universe_size=100,
+            passed_filters=50,
+            regime="R0",
+            generated_at=datetime(2026, 2, 18, 12, 0, 0),
+            errors={},
+        )
+
+        out_path = _write_watchlist_json(result, tmp_path, data_as_of=date(2026, 2, 17))
+        data = json.loads(out_path.read_text())
+
+        assert data["data_as_of"] == "2026-02-17"
+
+    def test_data_as_of_absent_when_none(self, tmp_path: Path) -> None:
+        from src.runners.momentum_runner import _write_watchlist_json
+
+        result = MomentumScreenResult(
+            candidates=[],
+            universe_size=100,
+            passed_filters=50,
+            regime="R0",
+            generated_at=datetime(2026, 2, 18, 12, 0, 0),
+            errors={},
+        )
+
+        out_path = _write_watchlist_json(result, tmp_path, data_as_of=None)
+        data = json.loads(out_path.read_text())
+
+        assert "data_as_of" not in data

--- a/tests/unit/screeners/test_momentum_runner.py
+++ b/tests/unit/screeners/test_momentum_runner.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 import json
 from datetime import date, datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import numpy as np
 import pandas as pd
-import pytest
 
 from src.domain.screeners.momentum.models import MomentumScreenResult
 

--- a/tests/unit/screeners/test_momentum_runner.py
+++ b/tests/unit/screeners/test_momentum_runner.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from datetime import date, datetime
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from src.domain.screeners.momentum.models import MomentumScreenResult
@@ -67,3 +70,313 @@ class TestWriteWatchlistJson:
         data = json.loads(out_path.read_text())
 
         assert "data_as_of" not in data
+
+
+class TestGenerateRebalanceDates:
+    def test_produces_fridays(self) -> None:
+        from src.runners.momentum_runner import _generate_rebalance_dates
+
+        dates = _generate_rebalance_dates(date(2024, 1, 1), date(2024, 1, 31))
+        for d in dates:
+            assert d.weekday() == 4, f"{d} is not a Friday"
+
+    def test_empty_when_range_too_small(self) -> None:
+        from src.runners.momentum_runner import _generate_rebalance_dates
+
+        # Mon to Wed — no Friday in range
+        dates = _generate_rebalance_dates(date(2024, 1, 1), date(2024, 1, 3))
+        assert dates == []
+
+    def test_weekly_spacing(self) -> None:
+        from src.runners.momentum_runner import _generate_rebalance_dates
+
+        dates = _generate_rebalance_dates(date(2024, 1, 1), date(2024, 3, 31))
+        for i in range(1, len(dates)):
+            delta = (dates[i] - dates[i - 1]).days
+            assert delta == 7, f"Gap {dates[i-1]} -> {dates[i]} = {delta} days"
+
+
+class TestComputeMaxDrawdown:
+    def test_no_drawdown_in_uptrend(self) -> None:
+        from src.runners.momentum_runner import _compute_max_drawdown
+
+        dd = _compute_max_drawdown([0.01, 0.02, 0.03])
+        assert dd == 0.0
+
+    def test_full_loss(self) -> None:
+        from src.runners.momentum_runner import _compute_max_drawdown
+
+        dd = _compute_max_drawdown([-0.5, -0.5])
+        # cumulative: [0.5, 0.25], peak: [0.5, 0.5], drawdown: [0, -0.5]
+        assert dd <= -0.5
+
+    def test_empty_returns(self) -> None:
+        from src.runners.momentum_runner import _compute_max_drawdown
+
+        assert _compute_max_drawdown([]) == 0.0
+
+
+class TestRunWalkForward:
+    """Tests for _run_walk_forward including PIT market caps and searchsorted."""
+
+    @staticmethod
+    def _make_close_series(
+        prices: list[float], start: date = date(2024, 1, 2)
+    ) -> "pd.Series[float]":
+        """Create a DatetimeIndex Series of daily closes (business days)."""
+        idx = pd.bdate_range(start=start, periods=len(prices))
+        return pd.Series(prices, index=idx, dtype=float)
+
+    @staticmethod
+    def _make_mock_screener(pick_symbols: list[str]) -> MagicMock:
+        """Create a screener mock that always returns the given symbols."""
+        from src.domain.screeners.momentum.models import (
+            MomentumCandidate,
+            MomentumSignal,
+        )
+        from src.domain.screeners.pead.models import LiquidityTier
+
+        candidates = []
+        for i, sym in enumerate(pick_symbols):
+            signal = MomentumSignal(
+                symbol=sym,
+                momentum_12_1=0.1,
+                fip=0.6,
+                momentum_percentile=0.8,
+                fip_percentile=0.7,
+                composite_rank=0.75,
+                last_close=100.0,
+                market_cap=1e9,
+                avg_daily_dollar_volume=50e6,
+                liquidity_tier=LiquidityTier.LARGE_CAP,
+                estimated_slippage_bps=10,
+                lookback_days=252,
+            )
+            candidates.append(
+                MomentumCandidate(
+                    signal=signal,
+                    rank=i + 1,
+                    quality_label="STRONG",
+                    position_size_factor=1.0,
+                    regime="R0",
+                )
+            )
+
+        mock_result = MagicMock()
+        mock_result.candidates = candidates
+        screener = MagicMock()
+        screener.screen.return_value = mock_result
+        return screener
+
+    def test_pit_market_caps_scaled_by_price(self) -> None:
+        """Market caps passed to screener should reflect rebalance-date prices."""
+        from src.runners.momentum_runner import _run_walk_forward
+
+        # AAPL: starts at $100, ends at $200 → at rebal, cap should be ~half
+        prices = [100.0 + i for i in range(60)]  # 100..159
+        series = self._make_close_series(prices)
+
+        screener = self._make_mock_screener(["AAPL"])
+        rebal_dates = [series.index[10].date()]  # early date where price ~110
+
+        _run_walk_forward(
+            screener=screener,
+            all_close_series={"AAPL": series},
+            all_volume_series={"AAPL": series * 1000},
+            market_caps={"AAPL": 2e9},  # current cap at price=159
+            rebalance_dates=rebal_dates,
+            top_n=5,
+            hold_days=5,
+        )
+
+        # Check what market_caps were passed to screener
+        call_kwargs = screener.screen.call_args
+        pit_caps = call_kwargs.kwargs.get("market_caps") or call_kwargs[1].get("market_caps")
+        aapl_pit_cap = pit_caps["AAPL"]
+
+        # At index 10, price = 110; latest price = 159
+        # pit_cap should be 2e9 * (110/159) ≈ 1.384e9
+        expected = 2e9 * (110.0 / 159.0)
+        assert (
+            abs(aapl_pit_cap - expected) < 1e6
+        ), f"PIT cap {aapl_pit_cap:.0f} != expected {expected:.0f}"
+
+    def test_rebal_on_holiday_uses_preceding_bar(self) -> None:
+        """Rebalance date falling on a non-trading day should use the last available bar."""
+        from src.runners.momentum_runner import _run_walk_forward
+
+        # Create series with a gap (simulate weekend/holiday)
+        idx = pd.to_datetime(
+            [
+                "2024-01-02",
+                "2024-01-03",
+                "2024-01-08",
+                "2024-01-09",
+                "2024-01-10",
+                "2024-01-11",
+                "2024-01-12",
+                "2024-01-15",
+                "2024-01-16",
+                "2024-01-17",
+                "2024-01-18",
+                "2024-01-19",
+                "2024-01-22",
+                "2024-01-23",
+                "2024-01-24",
+            ]
+        )
+        prices = [100.0 + i * 2 for i in range(len(idx))]
+        series = pd.Series(prices, index=idx, dtype=float)
+
+        screener = self._make_mock_screener(["TEST"])
+
+        # Rebalance on Saturday Jan 6 — should use Jan 3 (preceding bar)
+        _run_walk_forward(
+            screener=screener,
+            all_close_series={"TEST": series},
+            all_volume_series={"TEST": series * 1000},
+            market_caps={"TEST": 1e9},
+            rebalance_dates=[date(2024, 1, 5)],  # Friday Jan 5 — not in index
+            top_n=5,
+            hold_days=3,
+        )
+
+        # Screener should still be called (preceding bar Jan 3 exists)
+        assert screener.screen.called
+
+    def test_returns_empty_when_no_data(self) -> None:
+        from src.runners.momentum_runner import _run_walk_forward
+
+        screener = self._make_mock_screener([])
+        result = _run_walk_forward(
+            screener=screener,
+            all_close_series={},
+            all_volume_series={},
+            market_caps={},
+            rebalance_dates=[date(2024, 1, 5)],
+            top_n=5,
+            hold_days=5,
+        )
+        assert result == []
+
+
+class TestRenderBacktestHtml:
+    """Tests for the backtest HTML template."""
+
+    def test_renders_complete_html(self) -> None:
+        from src.infrastructure.reporting.momentum.templates import render_backtest_html
+
+        data = {
+            "backtest": {
+                "start": "2023-01-01",
+                "end": "2025-12-31",
+                "top_n": 20,
+                "hold_days": 5,
+                "cumulative_return": 0.45,
+                "sharpe_approx": 1.23,
+                "max_drawdown": -0.15,
+                "avg_weekly_return": 0.004,
+                "periods": [
+                    {
+                        "date": "2023-01-06",
+                        "n_picks": 20,
+                        "avg_return": 0.012,
+                        "picks": ["AAPL", "MSFT"],
+                    },
+                    {"date": "2023-01-13", "n_picks": 18, "avg_return": -0.005, "picks": ["NVDA"]},
+                ],
+            },
+            "ablation": {
+                "top_n": 20,
+                "hold_days": 5,
+                "configs": [
+                    {
+                        "label": "M-only",
+                        "cumulative_return": 0.30,
+                        "sharpe_approx": 0.9,
+                        "max_drawdown": -0.20,
+                        "avg_weekly_return": 0.003,
+                    },
+                    {
+                        "label": "M+FIP",
+                        "cumulative_return": 0.38,
+                        "sharpe_approx": 1.1,
+                        "max_drawdown": -0.18,
+                        "avg_weekly_return": 0.0035,
+                    },
+                    {
+                        "label": "M+FIP+Filters",
+                        "cumulative_return": 0.45,
+                        "sharpe_approx": 1.23,
+                        "max_drawdown": -0.15,
+                        "avg_weekly_return": 0.004,
+                    },
+                ],
+            },
+        }
+
+        html = render_backtest_html(data)
+
+        # Structure checks
+        assert "<!DOCTYPE html>" in html
+        assert "Momentum Backtest" in html
+        assert "2023-01-01" in html
+        assert "2025-12-31" in html
+
+        # Summary cards
+        assert "+45.0%" in html  # cum return
+        assert "1.23" in html  # sharpe
+
+        # Ablation table
+        assert "M-only" in html
+        assert "M+FIP" in html
+        assert "M+FIP+Filters" in html
+
+        # Period rows
+        assert "2023-01-06" in html
+        assert "AAPL, MSFT" in html
+
+    def test_handles_empty_data(self) -> None:
+        from src.infrastructure.reporting.momentum.templates import render_backtest_html
+
+        html = render_backtest_html({"backtest": {}, "ablation": {}})
+        assert "<!DOCTYPE html>" in html
+        assert "Momentum Backtest" in html
+
+    def test_ablation_rows_color_coded(self) -> None:
+        from src.infrastructure.reporting.momentum.templates import _build_ablation_rows
+
+        rows = _build_ablation_rows(
+            [
+                {
+                    "label": "Positive",
+                    "cumulative_return": 0.5,
+                    "sharpe_approx": 1.0,
+                    "max_drawdown": -0.05,
+                    "avg_weekly_return": 0.01,
+                },
+                {
+                    "label": "Negative",
+                    "cumulative_return": -0.2,
+                    "sharpe_approx": -0.5,
+                    "max_drawdown": -0.3,
+                    "avg_weekly_return": -0.01,
+                },
+            ]
+        )
+        # Positive return → green
+        assert "#3fb950" in rows
+        # Negative return → red
+        assert "#f85149" in rows
+
+    def test_period_rows_return_colors(self) -> None:
+        from src.infrastructure.reporting.momentum.templates import _build_period_rows
+
+        rows = _build_period_rows(
+            [
+                {"date": "2024-01-05", "n_picks": 10, "avg_return": 0.02, "picks": ["A"]},
+                {"date": "2024-01-12", "n_picks": 8, "avg_return": -0.01, "picks": ["B"]},
+            ]
+        )
+        assert "#3fb950" in rows  # positive
+        assert "#f85149" in rows  # negative

--- a/tests/unit/screeners/test_momentum_screener.py
+++ b/tests/unit/screeners/test_momentum_screener.py
@@ -6,7 +6,9 @@ Uses synthetic OHLCV data that simulates real market patterns
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -359,6 +361,73 @@ class TestMomentumScreener:
         result = screener.screen(price_data, volume_data, "R0", market_caps)
         assert len(result.candidates) == 0
 
+    def test_earnings_blackout_excludes_reporting_symbol(self) -> None:
+        """Symbol reporting within blackout window should be excluded."""
+        price_data, volume_data, market_caps = _build_screener_data()
+
+        config_with_blackout = {
+            **DEFAULT_CONFIG,
+            "filters": {**DEFAULT_CONFIG["filters"], "earnings_blackout_days": 5},
+        }
+        screener = MomentumScreener(config_with_blackout)
+
+        today = date.today()
+        earnings_dates = {"SYM05": today + timedelta(days=3)}  # Reporting in 3 days
+
+        # With blackout: SYM05 should be excluded
+        with patch("src.domain.screeners.momentum.screener.date") as mock_date:
+            mock_date.today.return_value = today
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            result = screener.screen(
+                price_data, volume_data, "R0", market_caps, earnings_dates=earnings_dates
+            )
+
+        symbols = [c.signal.symbol for c in result.candidates]
+        assert "SYM05" not in symbols
+
+    def test_earnings_blackout_skipped_in_backtest(self) -> None:
+        """Backtest mode should ignore earnings blackout (no look-ahead bias)."""
+        price_data, volume_data, market_caps = _build_screener_data()
+
+        config_with_blackout = {
+            **DEFAULT_CONFIG,
+            "filters": {**DEFAULT_CONFIG["filters"], "earnings_blackout_days": 5},
+        }
+        screener = MomentumScreener(config_with_blackout)
+
+        today = date.today()
+        earnings_dates = {sym: today + timedelta(days=2) for sym in price_data}
+
+        # Backtest mode: all symbols should still be eligible
+        result = screener.screen(
+            price_data,
+            volume_data,
+            "R0",
+            market_caps,
+            is_backtest=True,
+            earnings_dates=earnings_dates,
+        )
+        assert len(result.candidates) > 0
+
+    def test_earnings_blackout_disabled_when_zero(self) -> None:
+        """earnings_blackout_days=0 should not filter anything."""
+        price_data, volume_data, market_caps = _build_screener_data()
+
+        config_no_blackout = {
+            **DEFAULT_CONFIG,
+            "filters": {**DEFAULT_CONFIG["filters"], "earnings_blackout_days": 0},
+        }
+        screener = MomentumScreener(config_no_blackout)
+
+        today = date.today()
+        earnings_dates = {sym: today + timedelta(days=1) for sym in price_data}
+
+        result = screener.screen(
+            price_data, volume_data, "R0", market_caps, earnings_dates=earnings_dates
+        )
+        # All symbols should still be eligible (blackout disabled)
+        assert len(result.candidates) > 0
+
 
 # ── config.py Tests ───────────────────────────────────────────────────
 
@@ -373,6 +442,9 @@ class TestConfig:
             assert config.data_source.lookback_trading_days == 252
             assert config.scoring.top_n == 30
             assert config.regime_rules.r2_block_entirely is True
+            assert config.filters.min_avg_daily_dollar_volume == 20_000_000
+            assert config.filters.earnings_blackout_days == 5
+            assert config.universe.fallback_max_symbols == 800
 
     def test_from_dict_defaults(self) -> None:
         config = MomentumConfig.from_dict({})

--- a/tests/unit/screeners/test_momentum_screener.py
+++ b/tests/unit/screeners/test_momentum_screener.py
@@ -133,13 +133,43 @@ class TestFIP:
         closes = _make_uptrend(300)
         result = compute_fip(closes, skip=21, lookback=252)
         assert result is not None
-        assert -1.0 <= result <= 1.0, "FIP must be in [-1, 1]"
+        assert 0.0 <= result <= 1.0, "FIP must be in [0, 1]"
 
-    def test_downtrend_negative_fip(self) -> None:
+    def test_downtrend_low_fip(self) -> None:
         closes = _make_downtrend(300)
         result = compute_fip(closes, skip=21, lookback=252)
         assert result is not None
-        assert result < 0, "Downtrend should have negative FIP"
+        assert result < 0.5, "Downtrend should have FIP < 0.5 (fewer positive days)"
+
+    def test_fip_thesis_formula(self) -> None:
+        """Verify FIP = n_pos / total per thesis specification.
+
+        Constructs a price series where exactly 60 out of 100 daily
+        returns are positive, then verifies FIP ≈ 0.60.
+        """
+        # Build a series with exactly 60 positive returns out of 100
+        # in the momentum window (positions -(252+21) to -21)
+        n = 252 + 21 + 10  # extra buffer
+        closes = np.ones(n) * 100.0
+
+        # Fill the momentum window with controlled returns
+        # Window: daily_closes[-(273):-(21)] = 252 prices → 251 returns
+        window_start = n - 273
+        window_end = n - 21
+        window_len = window_end - window_start  # 252 prices → 251 returns
+
+        # We want exactly 60% of 251 returns to be positive
+        n_pos_target = int(round(0.60 * (window_len - 1)))  # 151
+
+        for i in range(window_start, window_end):
+            if i - window_start < n_pos_target:
+                closes[i + 1] = closes[i] * 1.001  # positive return
+            else:
+                closes[i + 1] = closes[i] * 0.999  # negative return
+
+        result = compute_fip(closes, skip=21, lookback=252)
+        assert result is not None
+        assert abs(result - n_pos_target / (window_len - 1)) < 0.01
 
     def test_insufficient_data_returns_none(self) -> None:
         result = compute_fip(np.array([100.0, 101.0]), skip=21, lookback=252)

--- a/tests/unit/services/test_momentum_data_service.py
+++ b/tests/unit/services/test_momentum_data_service.py
@@ -1,0 +1,98 @@
+"""Tests for MomentumDataService new methods: get_data_as_of_date, get_upcoming_earnings."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.services.momentum_data_service import MomentumDataService
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> MomentumDataService:
+    """Create service with temp dirs."""
+    return MomentumDataService(
+        universe_cache_path=tmp_path / "universe.json",
+        historical_base_dir=tmp_path / "historical",
+    )
+
+
+def _write_parquet(hist_dir: Path, symbol: str, last_date: str) -> None:
+    """Write a minimal Parquet file with given last date."""
+    sym_dir = hist_dir / symbol.upper()
+    sym_dir.mkdir(parents=True, exist_ok=True)
+    dates = pd.date_range(end=last_date, periods=10, freq="B")
+    df = pd.DataFrame(
+        {"close": range(10), "volume": range(10)},
+        index=dates,
+    )
+    df.index.name = "timestamp"
+    df.to_parquet(sym_dir / "1d.parquet")
+
+
+class TestGetDataAsOfDate:
+    def test_returns_max_date(self, svc: MomentumDataService, tmp_path: Path) -> None:
+        hist = tmp_path / "historical"
+        _write_parquet(hist, "AAPL", "2026-02-14")
+        _write_parquet(hist, "MSFT", "2026-02-17")
+        _write_parquet(hist, "GOOG", "2026-02-10")
+
+        result = svc.get_data_as_of_date(["AAPL", "GOOG", "MSFT"])
+        assert result == date(2026, 2, 17)
+
+    def test_deterministic_sample(self, svc: MomentumDataService, tmp_path: Path) -> None:
+        """Same input always yields same output (no random sampling)."""
+        hist = tmp_path / "historical"
+        _write_parquet(hist, "AAPL", "2026-02-14")
+        _write_parquet(hist, "MSFT", "2026-02-17")
+
+        r1 = svc.get_data_as_of_date(["MSFT", "AAPL"])
+        r2 = svc.get_data_as_of_date(["MSFT", "AAPL"])
+        assert r1 == r2
+
+    def test_empty_symbols(self, svc: MomentumDataService) -> None:
+        assert svc.get_data_as_of_date([]) is None
+
+    def test_no_parquet_files(self, svc: MomentumDataService) -> None:
+        assert svc.get_data_as_of_date(["AAPL", "MSFT"]) is None
+
+
+class TestGetUpcomingEarnings:
+    def test_happy_path(self, svc: MomentumDataService) -> None:
+        today = date.today()
+        tomorrow = today + timedelta(days=1)
+        mock_calendar = [
+            {"symbol": "AAPL", "date": tomorrow.isoformat()},
+            {"symbol": "TSLA", "date": tomorrow.isoformat()},
+            {"symbol": "OTHER", "date": tomorrow.isoformat()},
+        ]
+
+        with patch(
+            "src.services.momentum_data_service.MomentumDataService.get_upcoming_earnings",
+            wraps=svc.get_upcoming_earnings,
+        ):
+            with patch(
+                "src.infrastructure.adapters.earnings.fmp_earnings.FMPEarningsAdapter"
+            ) as mock_cls:
+                instance = MagicMock()
+                instance.fetch_earnings_calendar.return_value = mock_calendar
+                mock_cls.return_value = instance
+
+                result = svc.get_upcoming_earnings(["AAPL", "TSLA"], lookahead_days=7)
+
+        assert "AAPL" in result
+        assert "TSLA" in result
+        assert "OTHER" not in result  # Not in provided symbols list
+
+    def test_fail_open_on_error(self, svc: MomentumDataService) -> None:
+        """Should return empty dict on any exception, not crash."""
+        with patch(
+            "src.infrastructure.adapters.earnings.fmp_earnings.FMPEarningsAdapter",
+            side_effect=ValueError("no API key"),
+        ):
+            result = svc.get_upcoming_earnings(["AAPL"])
+        assert result == {}

--- a/tests/unit/test_email_sender.py
+++ b/tests/unit/test_email_sender.py
@@ -1,0 +1,110 @@
+"""Tests for src.utils.email_sender."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.utils.email_sender import _get_smtp_config, send_email
+
+
+class TestGetSmtpConfig:
+    """Test SMTP config resolution."""
+
+    def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SMTP_SERVER", "custom.smtp.com")
+        monkeypatch.setenv("SMTP_PORT", "465")
+        monkeypatch.setenv("SMTP_USERNAME", "user@test.com")
+        monkeypatch.setenv("SMTP_PASSWORD", "secret")
+        monkeypatch.setenv("SIGNAL_REPORT_RECIPIENTS", "dest@test.com")
+
+        cfg = _get_smtp_config()
+        assert cfg["server"] == "custom.smtp.com"
+        assert cfg["port"] == "465"
+        assert cfg["username"] == "user@test.com"
+        assert cfg["password"] == "secret"
+        assert cfg["recipients"] == "dest@test.com"
+
+    def test_defaults_without_env_or_yaml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Clear env vars that might be set
+        for key in [
+            "SMTP_SERVER",
+            "SMTP_PORT",
+            "SMTP_USERNAME",
+            "SMTP_PASSWORD",
+            "SIGNAL_REPORT_RECIPIENTS",
+        ]:
+            monkeypatch.delenv(key, raising=False)
+
+        with patch("src.utils.email_sender._load_secrets_yaml", return_value={}):
+            cfg = _get_smtp_config()
+            assert cfg["server"] == "smtp.gmail.com"
+            assert cfg["port"] == "587"
+            assert cfg["username"] == ""
+            assert cfg["password"] == ""
+
+    def test_load_from_secrets_yaml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in [
+            "SMTP_SERVER",
+            "SMTP_PORT",
+            "SMTP_USERNAME",
+            "SMTP_PASSWORD",
+            "SIGNAL_REPORT_RECIPIENTS",
+        ]:
+            monkeypatch.delenv(key, raising=False)
+
+        mock_yaml = {
+            "email": {
+                "SMTP_USERNAME": "yaml@test.com",
+                "SMTP_APP_PASSWORD": "yaml-pass",
+                "EMAIL_DEST": "yaml-dest@test.com",
+            }
+        }
+        with patch("src.utils.email_sender._load_secrets_yaml", return_value=mock_yaml):
+            cfg = _get_smtp_config()
+            assert cfg["username"] == "yaml@test.com"
+            assert cfg["password"] == "yaml-pass"
+            assert cfg["recipients"] == "yaml-dest@test.com"
+
+
+class TestSendEmail:
+    """Test send_email() function."""
+
+    def test_returns_false_without_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in ["SMTP_USERNAME", "SMTP_PASSWORD", "SIGNAL_REPORT_RECIPIENTS"]:
+            monkeypatch.delenv(key, raising=False)
+
+        with patch("src.utils.email_sender._load_secrets_yaml", return_value={}):
+            result = send_email("Test Subject", "Test Body")
+            assert result is False
+
+    def test_returns_false_on_smtp_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SMTP_USERNAME", "user@test.com")
+        monkeypatch.setenv("SMTP_PASSWORD", "secret")
+        monkeypatch.setenv("SIGNAL_REPORT_RECIPIENTS", "dest@test.com")
+
+        mock_smtp = MagicMock()
+        mock_smtp.__enter__ = MagicMock(return_value=mock_smtp)
+        mock_smtp.__exit__ = MagicMock(return_value=False)
+        mock_smtp.starttls.side_effect = ConnectionRefusedError("Connection refused")
+
+        with patch("src.utils.email_sender.smtplib.SMTP", return_value=mock_smtp):
+            result = send_email("Test", "Body")
+            assert result is False
+
+    def test_returns_true_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SMTP_USERNAME", "user@test.com")
+        monkeypatch.setenv("SMTP_PASSWORD", "secret")
+        monkeypatch.setenv("SIGNAL_REPORT_RECIPIENTS", "dest@test.com")
+
+        mock_smtp = MagicMock()
+        mock_smtp.__enter__ = MagicMock(return_value=mock_smtp)
+        mock_smtp.__exit__ = MagicMock(return_value=False)
+
+        with patch("src.utils.email_sender.smtplib.SMTP", return_value=mock_smtp):
+            result = send_email("Test Subject", "Test Body")
+            assert result is True
+            mock_smtp.starttls.assert_called_once()
+            mock_smtp.login.assert_called_once_with("user@test.com", "secret")
+            mock_smtp.send_message.assert_called_once()

--- a/tests/unit/test_regime_display.py
+++ b/tests/unit/test_regime_display.py
@@ -1,0 +1,27 @@
+"""Tests for src.utils.regime_display."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.regime_display import regime_label
+
+
+class TestRegimeLabel:
+    """Test regime_label() utility."""
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("R0", "Healthy Uptrend"),
+            ("R1", "Choppy/Extended"),
+            ("R2", "Risk-Off"),
+            ("R3", "Rebound Window"),
+        ],
+    )
+    def test_all_regime_codes(self, code: str, expected: str) -> None:
+        assert regime_label(code) == expected
+
+    @pytest.mark.parametrize("bad_code", ["R9", "", "invalid", "r0"])
+    def test_unknown_code(self, bad_code: str) -> None:
+        assert regime_label(bad_code) == "Unknown"


### PR DESCRIPTION
  - Incremental OHLCV: partitions symbols into fresh/stale/missing,
      only fetches new bars for stale symbols (14 days) instead of re-downloading full history every time
  - Batch Yahoo: replaced per-symbol yf.Ticker.history() with yf.download() batch call for dramatically faster fetching
  - Always-fresh default: cmd_screen() refreshes universe + OHLCV automatically; --no-refresh to opt out
  - Progress output: [1/4]→[4/4] phase indicators with batch counts
  - Universe fallback: fetch_us_stocks() for FMP 402 on constituents
  - Earnings blackout: 5-day exclusion filter (fail-open, skip in backtest)
  - ADDV raised to $20M per thesis spec
  - Fix errors dict→list serialization in watchlist JSON