### PR TITLE
refactor: split hourly-signals into 5 jobs + harden build pipeline

### DIFF
--- a/.github/workflows/dashboard-refresh.yml
+++ b/.github/workflows/dashboard-refresh.yml
@@ -1,7 +1,7 @@
 name: "Dashboard: Manual Refresh"
 
-# Manual trigger for UI-only changes (no pipeline re-run needed if
-# out/signals/ is already up to date).
+# Manual trigger that regenerates signals (test subset of ~10 symbols)
+# and rebuilds the dashboard. Deploys to preview branch, not production.
 
 on:
   workflow_dispatch:
@@ -100,11 +100,26 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build and deploy dashboard
+      - name: Build dashboard
         run: |
           source .venv/bin/activate
           python -c "from src.infrastructure.reporting.dashboard import DashboardBuilder; DashboardBuilder().build()"
-          npx wrangler@3 pages deploy out/site/ --project-name apex-dashboard
+
+      - name: Smoke check dashboard artifacts
+        run: |
+          for f in out/site/index.html out/site/assets/app.js out/site/data/summary.json; do
+            if [ ! -s "$f" ]; then
+              echo "ERROR: Missing or empty required file: $f"
+              exit 1
+            fi
+          done
+          echo "Smoke check passed"
+
+      # Deploy to preview branch (not production) — this workflow uses a
+      # 10-symbol test subset, not the full universe. It also does not
+      # prefetch score_history.json (contrast with hourly-signals which does).
+      - name: Deploy to Cloudflare Pages (preview)
+        run: npx wrangler@3 pages deploy out/site/ --project-name apex-dashboard --branch dashboard-preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/hourly-signals.yml
+++ b/.github/workflows/hourly-signals.yml
@@ -1,7 +1,12 @@
 name: "Intraday: Signal Reports"
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Signal report generation during market hours.
+# Signal report generation during market hours — split into 5 jobs:
+#
+#   setup-and-check (3 min)
+#       ├──→ signal-pipeline (30 min) ──┬──→ notify (10 min)
+#       │                               └──→ dashboard (10 min)
+#       └──→ strategy-compare (30 min, parallel to signal-pipeline)
 #
 # DST-safe design: Cron triggers cover BOTH EDT (UTC-4) and EST (UTC-5).
 # The Python market-check step uses America/New_York timezone to classify
@@ -14,11 +19,6 @@ name: "Intraday: Signal Reports"
 #   1:00-1:59pm ET:   4H bar close (1H+4H)
 #   2:00-3:59pm ET:   Intraday hourly (1H only)
 #   4:00-4:59pm ET:   Post-close (1H+4H+1D, no retrain)
-#
-# Pipeline:
-#   Step 1: Update market caps
-#   Step 2: Retrain models (skipped at post-close)
-#   Step 3: Generate and deploy report
 #
 # Email: Plain-text TUI-formatted report (monospace, mobile-friendly)
 # ═══════════════════════════════════════════════════════════════════════════
@@ -38,6 +38,10 @@ on:
         description: "Also run strategy comparison backtests"
         type: boolean
         default: false
+      force_run:
+        description: "Override: run even on weekends/holidays"
+        type: boolean
+        default: false
 
 concurrency:
   group: hourly-signals
@@ -52,74 +56,45 @@ env:
   CACHE_VERSION: v1
 
 jobs:
-  generate-report:
-    name: Generate Signal Report
+  # ═══════════════════════════════════════════════════════════════════════
+  # Job 1: Setup & Check — lightweight market-hours classification
+  # ═══════════════════════════════════════════════════════════════════════
+  setup-and-check:
+    name: Setup & Check
     runs-on: ubuntu-latest
-    timeout-minutes: 90  # Longer timeout for retraining
+    timeout-minutes: 3
+    outputs:
+      should_run: ${{ steps.market-check.outputs.should_run }}
+      should_retrain: ${{ steps.market-check.outputs.should_retrain }}
+      run_strategy_compare: ${{ steps.market-check.outputs.run_strategy_compare }}
+      timeframes: ${{ steps.market-check.outputs.timeframes }}
+      send_1h: ${{ steps.market-check.outputs.send_1h }}
+      send_4h: ${{ steps.market-check.outputs.send_4h }}
+      send_1d: ${{ steps.market-check.outputs.send_1d }}
+      et_time: ${{ steps.market-check.outputs.et_time }}
+      et_date: ${{ steps.market-check.outputs.et_date }}
+      et_day_key: ${{ steps.market-check.outputs.et_day_key }}
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          sparse-checkout: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Cache Python dependencies
-        id: cache-python-deps
-        uses: actions/cache@v5
-        with:
-          path: |
-            .venv
-            ~/.cache/uv
-            ~/.cache/pip
-          key: ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
-          restore-keys: |
-            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
-            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-
-
-      - name: Cache TA-Lib
-        id: cache-talib
-        uses: actions/cache@v5
-        with:
-          path: ~/ta-lib-install
-          key: talib-0.6.4-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Install TA-Lib
-        run: |
-          if [ -d "$HOME/ta-lib-install/lib" ]; then
-            echo "Restoring TA-Lib from cache..."
-            sudo cp -r $HOME/ta-lib-install/lib/* /usr/lib/
-            sudo cp -r $HOME/ta-lib-install/include/* /usr/include/
-            sudo ldconfig
-          else
-            echo "Building TA-Lib 0.6.4 from source..."
-            sudo apt-get update && sudo apt-get install -y wget build-essential
-            wget https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz
-            tar -xzf ta-lib-0.6.4-src.tar.gz
-            cd ta-lib-0.6.4 && ./configure --prefix=/usr && make -j$(nproc) && sudo make install
-            sudo ldconfig
-            mkdir -p $HOME/ta-lib-install/lib $HOME/ta-lib-install/include
-            cp -r /usr/lib/libta* $HOME/ta-lib-install/lib/ 2>/dev/null || true
-            cp -r /usr/include/ta-lib $HOME/ta-lib-install/include/ 2>/dev/null || true
-          fi
-
-      - name: Install dependencies
-        run: |
-          .venv/bin/python --version 2>/dev/null || uv venv --clear
-          source .venv/bin/activate
-          uv pip install -e ".[dev,observability]"
+      - name: Install market calendar
+        run: pip install pandas-market-calendars
 
       - name: Check market open
         id: market-check
         env:
           INPUT_RUN_STRATEGY_COMPARE: ${{ inputs.run_strategy_compare || 'false' }}
+          INPUT_FORCE_RUN: ${{ inputs.force_run || 'false' }}
         run: |
-          source .venv/bin/activate
           python << 'EOF'
           import pandas_market_calendars as mcal
           from datetime import date, datetime, timezone
@@ -132,6 +107,7 @@ jobs:
 
           is_trading_day = not schedule.empty
           is_manual = os.environ.get('GITHUB_EVENT_NAME') == 'workflow_dispatch'
+          force_run = os.environ.get('INPUT_FORCE_RUN', 'false') == 'true'
 
           # ── DST-safe classification using ET timezone ─────────────────
           # Uses America/New_York (auto-switches EDT/EST) instead of UTC
@@ -170,7 +146,8 @@ jobs:
               send_4h = "true"
               send_1d = "true"
               run_strategy_compare = "true" if manual_compare else "false"
-              label = f"Manual dispatch (compare={'on' if manual_compare else 'off'}, market {'open' if is_trading_day else 'closed'})"
+              label_suffix = " [force_run]" if force_run else ""
+              label = f"Manual dispatch{label_suffix} (compare={'on' if manual_compare else 'off'}, market {'open' if is_trading_day else 'closed'})"
           elif not is_trading_day or not in_window:
               should_run = False
               should_retrain = False
@@ -243,20 +220,86 @@ jobs:
           print(label)
           EOF
 
+      - name: Holiday notice
+        if: steps.market-check.outputs.should_run != 'true' && steps.market-check.outputs.run_strategy_compare != 'true'
+        run: echo "::notice::Market is closed today. Skipping report generation."
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # Job 2: Signal Pipeline — generate report + deploy to gh-pages
+  # ═══════════════════════════════════════════════════════════════════════
+  signal-pipeline:
+    name: Signal Pipeline
+    needs: [setup-and-check]
+    if: needs.setup-and-check.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-
+
+      - name: Cache TA-Lib
+        id: cache-talib
+        uses: actions/cache@v5
+        with:
+          path: ~/ta-lib-install
+          key: talib-0.6.4-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install TA-Lib
+        run: |
+          if [ -d "$HOME/ta-lib-install/lib" ]; then
+            echo "Restoring TA-Lib from cache..."
+            sudo cp -r $HOME/ta-lib-install/lib/* /usr/lib/
+            sudo cp -r $HOME/ta-lib-install/include/* /usr/include/
+            sudo ldconfig
+          else
+            echo "Building TA-Lib 0.6.4 from source..."
+            sudo apt-get update && sudo apt-get install -y wget build-essential
+            wget https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz
+            tar -xzf ta-lib-0.6.4-src.tar.gz
+            cd ta-lib-0.6.4 && ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+            sudo ldconfig
+            mkdir -p $HOME/ta-lib-install/lib $HOME/ta-lib-install/include
+            cp -r /usr/lib/libta* $HOME/ta-lib-install/lib/ 2>/dev/null || true
+            cp -r /usr/include/ta-lib $HOME/ta-lib-install/include/ 2>/dev/null || true
+          fi
+
+      - name: Install dependencies
+        run: |
+          .venv/bin/python --version 2>/dev/null || uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e ".[dev,observability]"
+
       - name: Cache historical data
-        if: steps.market-check.outputs.should_run == 'true'
-        id: cache-historical
         uses: actions/cache@v5
         with:
           path: data/historical
-          key: ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-${{ steps.market-check.outputs.et_day_key }}-${{ hashFiles('config/universe.yaml') }}
+          key: ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-${{ needs.setup-and-check.outputs.et_day_key }}-${{ hashFiles('config/universe.yaml') }}
           restore-keys: |
-            ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-${{ steps.market-check.outputs.et_day_key }}-
+            ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-${{ needs.setup-and-check.outputs.et_day_key }}-
             ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-
 
       - name: Cache turning point models
-        if: steps.market-check.outputs.should_run == 'true'
-        id: cache-models
         uses: actions/cache@v5
         with:
           path: models/turning_point
@@ -264,21 +307,9 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_VERSION }}-models-${{ runner.os }}-
 
-      - name: Cache diagnostics
-        if: steps.market-check.outputs.should_run == 'true'
-        run: |
-          echo "deps cache hit: ${{ steps.cache-python-deps.outputs.cache-hit }}"
-          echo "historical cache hit: ${{ steps.cache-historical.outputs.cache-hit }}"
-          echo "models cache hit: ${{ steps.cache-models.outputs.cache-hit }}"
-          du -sh .venv 2>/dev/null || true
-          du -sh ~/.cache/uv 2>/dev/null || true
-          du -sh data/historical 2>/dev/null || true
-          du -sh models/turning_point 2>/dev/null || true
-
       # === PIPELINE ===
 
       - name: "Step 1/3: Update market caps"
-        if: steps.market-check.outputs.should_run == 'true'
         run: |
           source .venv/bin/activate
           python -m src.runners.signal_runner --update-market-caps \
@@ -287,7 +318,7 @@ jobs:
           LOG_LEVEL: WARNING
 
       - name: "Step 2/3: Retrain models"
-        if: steps.market-check.outputs.should_retrain == 'true'
+        if: needs.setup-and-check.outputs.should_retrain == 'true'
         run: |
           source .venv/bin/activate
           python -m src.runners.signal_runner --retrain-models \
@@ -296,7 +327,6 @@ jobs:
           LOG_LEVEL: WARNING
 
       - name: Fetch existing score history from gh-pages
-        if: steps.market-check.outputs.should_run == 'true'
         continue-on-error: true
         run: |
           mkdir -p out/signals/data
@@ -304,12 +334,11 @@ jobs:
           git show origin/gh-pages:data/score_history.json > out/signals/data/score_history.json 2>/dev/null || echo '{"snapshots":[]}' > out/signals/data/score_history.json
 
       - name: "Step 3/3: Generate and deploy report"
-        if: steps.market-check.outputs.should_run == 'true'
         run: |
           source .venv/bin/activate
           python -m src.runners.signal_runner --live \
             --universe ${{ env.UNIVERSE }} \
-            --timeframes ${{ steps.market-check.outputs.timeframes }} \
+            --timeframes ${{ needs.setup-and-check.outputs.timeframes }} \
             --format package \
             --html-output out/signals \
             --deploy github
@@ -317,21 +346,128 @@ jobs:
           LOG_LEVEL: WARNING
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # === STRATEGY COMPARISON (first report of day, 5:00am ET) ===
+      - name: "Screeners (from cache)"
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          python -m src.runners.momentum_runner --screen --no-refresh || true
+          python -m src.runners.pead_runner --screen || true
+        env:
+          LOG_LEVEL: WARNING
 
-      - name: "Run strategy comparison backtests"
-        if: steps.market-check.outputs.run_strategy_compare == 'true'
+      - name: Smoke check signal output
+        run: |
+          if [ ! -s "out/signals/data/summary.json" ]; then
+            echo "ERROR: Missing or empty out/signals/data/summary.json"
+            exit 1
+          fi
+          echo "Signal output smoke check passed"
+
+      - name: Upload signal data artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: signal-data
+          path: out/signals/
+          if-no-files-found: error
+          retention-days: 1
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # Job 3: Strategy Comparison — parallel to signal-pipeline
+  # ═══════════════════════════════════════════════════════════════════════
+  strategy-compare:
+    name: Strategy Comparison
+    needs: [setup-and-check]
+    if: needs.setup-and-check.outputs.run_strategy_compare == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-
+
+      - name: Cache TA-Lib
+        id: cache-talib
+        uses: actions/cache@v5
+        with:
+          path: ~/ta-lib-install
+          key: talib-0.6.4-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install TA-Lib
+        run: |
+          if [ -d "$HOME/ta-lib-install/lib" ]; then
+            echo "Restoring TA-Lib from cache..."
+            sudo cp -r $HOME/ta-lib-install/lib/* /usr/lib/
+            sudo cp -r $HOME/ta-lib-install/include/* /usr/include/
+            sudo ldconfig
+          else
+            echo "Building TA-Lib 0.6.4 from source..."
+            sudo apt-get update && sudo apt-get install -y wget build-essential
+            wget https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz
+            tar -xzf ta-lib-0.6.4-src.tar.gz
+            cd ta-lib-0.6.4 && ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+            sudo ldconfig
+            mkdir -p $HOME/ta-lib-install/lib $HOME/ta-lib-install/include
+            cp -r /usr/lib/libta* $HOME/ta-lib-install/lib/ 2>/dev/null || true
+            cp -r /usr/include/ta-lib $HOME/ta-lib-install/include/ 2>/dev/null || true
+          fi
+
+      - name: Install dependencies
+        run: |
+          .venv/bin/python --version 2>/dev/null || uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e ".[dev,observability]"
+
+      - name: Cache historical data
+        uses: actions/cache@v5
+        with:
+          path: data/historical
+          key: ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-${{ needs.setup-and-check.outputs.et_day_key }}-${{ hashFiles('config/universe.yaml') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-${{ needs.setup-and-check.outputs.et_day_key }}-
+            ${{ env.CACHE_VERSION }}-historical-${{ runner.os }}-
+
+      - name: Run strategy comparison backtests
         run: |
           source .venv/bin/activate
           python -m src.runners.strategy_compare_runner \
             --universe ${{ env.UNIVERSE }} \
             --years 3 \
-            --output out/signals/strategies.html
+            --output out/signals/strategies.html \
+            --json-output out/signals/data/strategies.json
         env:
           LOG_LEVEL: WARNING
 
-      - name: "Deploy strategies.html to gh-pages"
-        if: steps.market-check.outputs.run_strategy_compare == 'true'
+      - name: Upload strategy data artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: strategy-data
+          path: |
+            out/signals/strategies.html
+            out/signals/data/strategies.json
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Deploy strategies.html to gh-pages
         run: |
           git fetch origin gh-pages --depth=1 2>/dev/null || true
           rm -rf /tmp/strategy-deploy
@@ -352,10 +488,77 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # === RENDER EMAILS ===
+  # ═══════════════════════════════════════════════════════════════════════
+  # Job 4: Notify — render & send emails (rerunnable on SMTP failure)
+  # ═══════════════════════════════════════════════════════════════════════
+  notify:
+    name: Send Notifications
+    needs: [setup-and-check, signal-pipeline]
+    if: needs.setup-and-check.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-
+
+      - name: Cache TA-Lib
+        id: cache-talib
+        uses: actions/cache@v5
+        with:
+          path: ~/ta-lib-install
+          key: talib-0.6.4-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install TA-Lib
+        run: |
+          if [ -d "$HOME/ta-lib-install/lib" ]; then
+            echo "Restoring TA-Lib from cache..."
+            sudo cp -r $HOME/ta-lib-install/lib/* /usr/lib/
+            sudo cp -r $HOME/ta-lib-install/include/* /usr/include/
+            sudo ldconfig
+          else
+            echo "Building TA-Lib 0.6.4 from source..."
+            sudo apt-get update && sudo apt-get install -y wget build-essential
+            wget https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz
+            tar -xzf ta-lib-0.6.4-src.tar.gz
+            cd ta-lib-0.6.4 && ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+            sudo ldconfig
+            mkdir -p $HOME/ta-lib-install/lib $HOME/ta-lib-install/include
+            cp -r /usr/lib/libta* $HOME/ta-lib-install/lib/ 2>/dev/null || true
+            cp -r /usr/include/ta-lib $HOME/ta-lib-install/include/ 2>/dev/null || true
+          fi
+
+      - name: Install dependencies
+        run: |
+          .venv/bin/python --version 2>/dev/null || uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e ".[dev,observability]"
+
+      - name: Download signal data
+        uses: actions/download-artifact@v6
+        with:
+          name: signal-data
+          path: out/signals
 
       - name: Render email content
-        if: steps.market-check.outputs.should_run == 'true'
         run: |
           source .venv/bin/activate
           python << 'PYEOF'
@@ -382,14 +585,12 @@ jobs:
               print(f"Rendered {tag} email ({len(text)} chars)")
           PYEOF
         env:
-          SEND_1H: ${{ steps.market-check.outputs.send_1h }}
-          SEND_4H: ${{ steps.market-check.outputs.send_4h }}
-          SEND_1D: ${{ steps.market-check.outputs.send_1d }}
-
-      # === SEND EMAILS ===
+          SEND_1H: ${{ needs.setup-and-check.outputs.send_1h }}
+          SEND_4H: ${{ needs.setup-and-check.outputs.send_4h }}
+          SEND_1D: ${{ needs.setup-and-check.outputs.send_1d }}
 
       - name: "Send email: 1H"
-        if: steps.market-check.outputs.send_1h == 'true'
+        if: needs.setup-and-check.outputs.send_1h == 'true'
         continue-on-error: true
         uses: dawidd6/action-send-mail@v9
         with:
@@ -397,7 +598,7 @@ jobs:
           server_port: ${{ secrets.SMTP_PORT || 587 }}
           username: ${{ secrets.SMTP_USERNAME }}
           password: ${{ secrets.SMTP_PASSWORD }}
-          subject: "APEX Intraday 1H — ${{ steps.market-check.outputs.et_date }} ${{ steps.market-check.outputs.et_time }}"
+          subject: "APEX Intraday 1H — ${{ needs.setup-and-check.outputs.et_date }} ${{ needs.setup-and-check.outputs.et_time }}"
           to: ${{ secrets.SIGNAL_REPORT_RECIPIENTS }}
           from: "APEX Signal Bot <${{ secrets.SMTP_USERNAME }}>"
           body: file://${{ github.workspace }}/email_body_1h.txt
@@ -405,7 +606,7 @@ jobs:
           convert_markdown: false
 
       - name: "Send email: 4H"
-        if: steps.market-check.outputs.send_4h == 'true'
+        if: needs.setup-and-check.outputs.send_4h == 'true'
         continue-on-error: true
         uses: dawidd6/action-send-mail@v9
         with:
@@ -413,7 +614,7 @@ jobs:
           server_port: ${{ secrets.SMTP_PORT || 587 }}
           username: ${{ secrets.SMTP_USERNAME }}
           password: ${{ secrets.SMTP_PASSWORD }}
-          subject: "APEX Intraday 4H — ${{ steps.market-check.outputs.et_date }} ${{ steps.market-check.outputs.et_time }}"
+          subject: "APEX Intraday 4H — ${{ needs.setup-and-check.outputs.et_date }} ${{ needs.setup-and-check.outputs.et_time }}"
           to: ${{ secrets.SIGNAL_REPORT_RECIPIENTS }}
           from: "APEX Signal Bot <${{ secrets.SMTP_USERNAME }}>"
           body: file://${{ github.workspace }}/email_body_4h.txt
@@ -421,7 +622,7 @@ jobs:
           convert_markdown: false
 
       - name: "Send email: 1D"
-        if: steps.market-check.outputs.send_1d == 'true'
+        if: needs.setup-and-check.outputs.send_1d == 'true'
         continue-on-error: true
         uses: dawidd6/action-send-mail@v9
         with:
@@ -429,44 +630,128 @@ jobs:
           server_port: ${{ secrets.SMTP_PORT || 587 }}
           username: ${{ secrets.SMTP_USERNAME }}
           password: ${{ secrets.SMTP_PASSWORD }}
-          subject: "APEX End of Day — ${{ steps.market-check.outputs.et_date }} ${{ steps.market-check.outputs.et_time }}"
+          subject: "APEX End of Day — ${{ needs.setup-and-check.outputs.et_date }} ${{ needs.setup-and-check.outputs.et_time }}"
           to: ${{ secrets.SIGNAL_REPORT_RECIPIENTS }}
           from: "APEX Signal Bot <${{ secrets.SMTP_USERNAME }}>"
           body: file://${{ github.workspace }}/email_body_1d.txt
           content_type: text/plain
           convert_markdown: false
 
-      - name: Holiday notice
-        if: steps.market-check.outputs.should_run != 'true' && steps.market-check.outputs.run_strategy_compare != 'true'
-        run: echo "::notice::Market is closed today. Skipping report generation."
+  # ═══════════════════════════════════════════════════════════════════════
+  # Job 5: Dashboard — build + deploy to Cloudflare Pages
+  # ═══════════════════════════════════════════════════════════════════════
+  dashboard:
+    name: Cloudflare Dashboard
+    needs: [setup-and-check, signal-pipeline, strategy-compare]
+    # Run when signal-pipeline succeeded; strategy-compare must be success or skipped (not cancelled/failed)
+    if: |
+      always() &&
+      needs.setup-and-check.outputs.should_run == 'true' &&
+      needs.signal-pipeline.result == 'success' &&
+      (needs.strategy-compare.result == 'success' || needs.strategy-compare.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+            ${{ env.CACHE_VERSION }}-deps-${{ runner.os }}-
+
+      - name: Cache TA-Lib
+        id: cache-talib
+        uses: actions/cache@v5
+        with:
+          path: ~/ta-lib-install
+          key: talib-0.6.4-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install TA-Lib
+        run: |
+          if [ -d "$HOME/ta-lib-install/lib" ]; then
+            echo "Restoring TA-Lib from cache..."
+            sudo cp -r $HOME/ta-lib-install/lib/* /usr/lib/
+            sudo cp -r $HOME/ta-lib-install/include/* /usr/include/
+            sudo ldconfig
+          else
+            echo "Building TA-Lib 0.6.4 from source..."
+            sudo apt-get update && sudo apt-get install -y wget build-essential
+            wget https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz
+            tar -xzf ta-lib-0.6.4-src.tar.gz
+            cd ta-lib-0.6.4 && ./configure --prefix=/usr && make -j$(nproc) && sudo make install
+            sudo ldconfig
+            mkdir -p $HOME/ta-lib-install/lib $HOME/ta-lib-install/include
+            cp -r /usr/lib/libta* $HOME/ta-lib-install/lib/ 2>/dev/null || true
+            cp -r /usr/include/ta-lib $HOME/ta-lib-install/include/ 2>/dev/null || true
+          fi
+
+      - name: Install dependencies
+        run: |
+          .venv/bin/python --version 2>/dev/null || uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e ".[dev,observability]"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Download signal data
+        uses: actions/download-artifact@v6
+        with:
+          name: signal-data
+          path: out/signals
+
+      # Strategy data is optional — only produced when run_strategy_compare=true
+      - name: Download strategy data (if available)
+        if: needs.strategy-compare.result == 'success'
+        uses: actions/download-artifact@v6
+        with:
+          name: strategy-data
+          path: out/signals
+          merge-multiple: true
+
+      - name: Build Cloudflare dashboard
+        run: |
+          source .venv/bin/activate
+          python -c "from src.infrastructure.reporting.dashboard import DashboardBuilder; DashboardBuilder().build()"
+
+      - name: Smoke check dashboard artifacts
+        run: |
+          for f in out/site/index.html out/site/assets/app.js out/site/data/summary.json; do
+            if [ ! -s "$f" ]; then
+              echo "ERROR: Missing or empty required file: $f"
+              exit 1
+            fi
+          done
+          echo "Smoke check passed"
+
+      - name: Deploy to Cloudflare Pages
+        continue-on-error: true
+        run: npx wrangler@3 pages deploy out/site/ --project-name apex-dashboard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Upload report artifact
-        if: steps.market-check.outputs.should_run == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: signal-report-${{ github.run_id }}
           path: out/signals/
           if-no-files-found: warn
           retention-days: 7
-
-      # === CLOUDFLARE DASHBOARD ===
-
-      - name: Setup Node.js for Wrangler
-        if: steps.market-check.outputs.should_run == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Build Cloudflare dashboard
-        if: steps.market-check.outputs.should_run == 'true'
-        run: |
-          source .venv/bin/activate
-          python -c "from src.infrastructure.reporting.dashboard import DashboardBuilder; DashboardBuilder().build()"
-
-      - name: Deploy to Cloudflare Pages
-        if: steps.market-check.outputs.should_run == 'true'
-        continue-on-error: true
-        run: npx wrangler@3 pages deploy out/site/ --project-name apex-dashboard
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # APEX Development Makefile
 # Quick commands for common development tasks
 
-.PHONY: install run run-dev run-prod run-demo run-headless lint format type-check dead-code complexity quality test test-all coverage clean help validate-fast validate signals-test dashboard-test signals signals-deploy strategy-compare strategy-verify strategy-compare-quick behavioral behavioral-full behavioral-cases pead pead-test pead-screen
+.PHONY: install run run-dev run-prod run-demo run-headless lint format type-check dead-code complexity quality test test-all coverage clean help validate-fast validate signals-test dashboard-test dashboard-data dashboard-data-ready dashboard-signal dashboard-signal-qa signals signals-deploy strategy-compare strategy-verify strategy-compare-quick behavioral behavioral-full behavioral-cases pead pead-test pead-screen
 
 # Virtual environment - use .venv/bin executables directly
 VENV := .venv/bin
@@ -43,7 +43,6 @@ help:
 	@echo ""
 	@echo "$(GREEN)Signal Pipeline:$(RESET)"
 	@echo "  make signals-test      Quick test (20 symbols) + strategy comparison + HTTP server"
-	@echo "  make dashboard-test    CF dashboard test (signals + screeners + backtest → serve :8801)"
 	@echo "  make signals           Full production run (all features)"
 	@echo "  make signals-deploy    Deploy to GitHub Pages"
 	@echo "  make strategy-compare  Run strategy backtests + comparison dashboard"
@@ -73,7 +72,13 @@ help:
 	@echo "  make quantitative-moment-backtest Walk-forward backtest + ablation + HTML"
 	@echo "  make quantitative-moment-test     Run unit tests"
 	@echo ""
-	@echo "$(GREEN)Cloudflare Dashboard:$(RESET)"
+	@echo "$(GREEN)Dashboard Data Pipeline:$(RESET)"
+	@echo "  make dashboard-data-ready  Validate & backfill OHLCV data coverage"
+	@echo "  make dashboard-signal      Generate signal report (full universe)"
+	@echo "  make dashboard-signal-qa   Run quality gates (G1-G15)"
+	@echo "  make dashboard-data        Full pipeline (signals + screeners + backtests)"
+	@echo ""
+	@echo "$(GREEN)Dashboard Web Build & Deploy:$(RESET)"
 	@echo "  make dashboard-build   Build CF dashboard from pipeline output"
 	@echo "  make dashboard-dev     Build + serve locally (:8801)"
 	@echo "  make dashboard-deploy  Build + deploy to Cloudflare Pages"
@@ -288,38 +293,51 @@ signals-test:
 	@echo "$(YELLOW)Press Ctrl+C to stop$(RESET)"
 	cd /tmp/signal_test && python3 -m http.server 8800
 
-# CF Dashboard test: signals → screeners → strategy compare → CF build → serve
-dashboard-test:
-	@echo "$(BOLD)Dashboard test pipeline (20 symbols)...$(RESET)"
+# DEPRECATED: Use 'make dashboard-data && make dashboard-dev' instead.
+dashboard-test: dashboard-data dashboard-build
+	@lsof -ti:8801 | xargs kill -9 2>/dev/null || true
+	@echo "$(BOLD)Serving dashboard at http://localhost:8801$(RESET)"
+	@open http://localhost:8801 &
+	python3 -m http.server 8801 --directory out/site
+
+dashboard-data-ready:  ## Validate & backfill OHLCV data coverage
+	@echo "$(BOLD)Validating data coverage...$(RESET)"
+	$(PYTHON) scripts/historical_data_loader.py validate --timeframes 1d,4h,1h
 	@echo ""
-	@echo "Step 1/5: Signal generation..."
+	@echo "$(BOLD)Backfilling gaps (if any)...$(RESET)"
+	$(PYTHON) scripts/historical_data_loader.py backfill --timeframes 1d,4h,1h --source fmp
+	@echo ""
+	@echo "$(BOLD)Generating coverage report...$(RESET)"
+	$(PYTHON) scripts/historical_data_loader.py report --output out/coverage/coverage_report.html
+	@echo "$(GREEN)✓ Data ready$(RESET)"
+
+dashboard-signal:  ## Generate signal report (full universe, no deploy)
+	@echo "$(BOLD)Generating signals (full universe)...$(RESET)"
 	$(PYTHON) -m src.runners.signal_runner --live \
-		--symbols SPY QQQ XLB GLD TLT UVXY AAPL NVDA JPM XOM UNH HD DIS TSLA AMD META SLV IWM DIA MU \
+		--universe config/universe.yaml \
 		--timeframes 1d 1h 4h \
 		--format package \
 		--html-output out/signals
+	@echo "$(GREEN)✓ Signals ready in out/signals/$(RESET)"
+
+dashboard-signal-qa:  ## Run signal quality gates (G1-G15)
+	@echo "$(BOLD)Running quality gates...$(RESET)"
+	$(PYTHON) scripts/validate_gates.py --all --package out/signals
+	@echo "$(GREEN)✓ QA gates passed$(RESET)"
+
+dashboard-data: dashboard-signal  ## Full data pipeline (signals + screeners + strategy compare)
 	@echo ""
-	@echo "Step 2/5: Momentum screener (from cache if available)..."
+	@echo "Step 2/3: Screeners (optional)..."
 	$(PYTHON) -m src.runners.momentum_runner --screen --no-refresh || true
-	@echo ""
-	@echo "Step 3/5: PEAD screener (from cache if available)..."
 	$(PYTHON) -m src.runners.pead_runner --screen || true
 	@echo ""
-	@echo "Step 4/5: Strategy comparison backtests..."
+	@echo "Step 3/3: Strategy comparison..."
 	$(PYTHON) -m src.runners.strategy_compare_runner \
-		--symbols SPY QQQ AAPL NVDA JPM XOM UNH HD DIS TSLA \
+		--universe config/universe.yaml \
 		--years 3 \
 		--output out/signals/strategies.html \
 		--json-output out/signals/data/strategies.json
-	@echo ""
-	@echo "Step 5/5: Building CF dashboard..."
-	$(PYTHON) -c "from src.infrastructure.reporting.dashboard import DashboardBuilder; DashboardBuilder().build()"
-	@echo "$(GREEN)✓ Dashboard built → out/site/$(RESET)"
-	@lsof -ti:8801 | xargs kill -9 2>/dev/null || true
-	@echo "$(BOLD)Serving dashboard at http://localhost:8801$(RESET)"
-	@echo "$(YELLOW)Press Ctrl+C to stop$(RESET)"
-	@open http://localhost:8801 &
-	cd out/site && python3 -m http.server 8801
+	@echo "$(GREEN)✓ Dashboard data ready$(RESET)"
 
 # Full production run with ALL features (update-caps, retrain, heatmap, validate)
 # Uses unified config/universe.yaml for all operations

--- a/scripts/build-dashboard.mjs
+++ b/scripts/build-dashboard.mjs
@@ -123,14 +123,9 @@ if (tsFiles.length > 0) {
     esbuildOk = true;
     console.log(`[build] esbuild compiled ${tsFiles.length} TS files`);
   } catch (err) {
-    // Fallback: copy .ts → .js (works if code is valid JS + type annotations)
-    console.warn("[build] esbuild unavailable or failed — falling back to .ts → .js copy");
-    for (const f of tsFiles) {
-      const jsPath = f.replace(/\.ts$/, ".js");
-      if (!existsSync(jsPath)) {
-        cpSync(f, jsPath);
-      }
-    }
+    console.error("[build] ERROR: esbuild compilation failed");
+    console.error(err.stderr?.toString().slice(0, 500) || err.message);
+    process.exit(1);
   }
 
   // Remove .ts sources from output (keep only compiled .js)

--- a/scripts/historical_data_loader.py
+++ b/scripts/historical_data_loader.py
@@ -429,8 +429,10 @@ async def cmd_backfill(args: argparse.Namespace) -> int:
         source_priority = ["yahoo"]
     elif args.source == "ib":
         source_priority = ["ib", "yahoo"]
+    elif args.source == "fmp":
+        source_priority = ["fmp", "yahoo"]
     else:
-        source_priority = ["ib", "yahoo"]  # Default: IB first
+        source_priority = ["fmp", "yahoo"]  # Default: FMP first (matches config/base.yaml)
 
     # Discover symbols
     print("Discovering symbols...")
@@ -1079,8 +1081,8 @@ def main() -> int:
     )
     download_parser.add_argument(
         "--source",
-        choices=["yahoo", "ib"],
-        help="Data source (default: auto)",
+        choices=["yahoo", "ib", "fmp"],
+        help="Data source (default: auto = fmp > yahoo)",
     )
     download_parser.add_argument(
         "--ib-host",
@@ -1158,9 +1160,9 @@ def main() -> int:
     )
     backfill_parser.add_argument(
         "--source",
-        choices=["yahoo", "ib", "auto"],
+        choices=["yahoo", "ib", "fmp", "auto"],
         default="auto",
-        help="Data source (default: auto = ib > yahoo)",
+        help="Data source (default: auto = fmp > yahoo)",
     )
     backfill_parser.add_argument(
         "--dry-run",

--- a/src/infrastructure/reporting/dashboard/builder.py
+++ b/src/infrastructure/reporting/dashboard/builder.py
@@ -177,17 +177,14 @@ class DashboardBuilder:
                 capture_output=True,
             )
         except FileNotFoundError:
-            logger.warning(
+            raise RuntimeError(
                 "esbuild not available (npx not found). "
-                "Falling back to direct .ts → .js rename (strip types manually)."
+                "Install Node.js and npm to compile TypeScript assets."
             )
-            # Fallback: just rename .ts → .js (works if code is valid JS + type annotations)
-            for f in ts_files:
-                js_path = f.with_suffix(".js")
-                if not js_path.exists():
-                    shutil.copy2(f, js_path)
         except subprocess.CalledProcessError as e:
-            logger.warning("esbuild compilation failed: %s", e.stderr.decode()[:500])
+            raise RuntimeError(
+                f"esbuild compilation failed (exit {e.returncode}): {e.stderr.decode()[:500]}"
+            ) from e
 
         # Remove .ts sources from output (keep only compiled .js)
         for f in assets_dir.rglob("*.ts"):

--- a/src/infrastructure/reporting/dashboard/static/index.html
+++ b/src/infrastructure/reporting/dashboard/static/index.html
@@ -28,7 +28,9 @@
           crossorigin="anonymous"></script>
 
   <!-- Plotly (eager — used by overview treemap + signal charts + backtest) -->
-  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"
+          integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC"
+          crossorigin="anonymous"></script>
 </head>
 <body class="apex-dash">
 

--- a/tests/unit/reporting/test_dashboard_builder.py
+++ b/tests/unit/reporting/test_dashboard_builder.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any, Dict
+from unittest.mock import patch
 
 import pytest
 
@@ -14,6 +16,16 @@ from src.infrastructure.reporting.dashboard.data_transformer import (
     TransformConfig,
     _trim_symbol_data,
 )
+
+
+def _fake_esbuild(*args, **kwargs):
+    """Mock esbuild: rename .ts → .js (simulates transpile-only compilation)."""
+    cmd = args[0] if args else kwargs.get("args", [])
+    ts_files = [f for f in cmd if f.endswith(".ts")]
+    for ts_path in ts_files:
+        p = Path(ts_path)
+        if p.exists():
+            shutil.copy2(p, p.with_suffix(".js"))
 
 
 @pytest.fixture
@@ -287,8 +299,9 @@ class TestScreenerMerge:
         assert screeners["pead"] is None
 
 
+@patch("subprocess.run", side_effect=_fake_esbuild)
 class TestFullBuild:
-    def test_produces_correct_structure(self, source_dir: Path, tmp_path: Path):
+    def test_produces_correct_structure(self, _mock_run, source_dir: Path, tmp_path: Path):
         """Full build produces index.html, assets, data directory."""
         output = tmp_path / "site"
         builder = DashboardBuilder(source_dir=source_dir, max_bars=100)
@@ -306,7 +319,7 @@ class TestFullBuild:
         assert manifest.total_size_bytes > 0
         assert len(manifest.symbols) == 2
 
-    def test_no_ts_files_in_output(self, source_dir: Path, tmp_path: Path):
+    def test_no_ts_files_in_output(self, _mock_run, source_dir: Path, tmp_path: Path):
         """Output dir has .js files (compiled from .ts), no .ts files."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -318,7 +331,7 @@ class TestFullBuild:
         assert (output / "assets" / "app.js").exists()
         assert (output / "assets" / "charts.js").exists()
 
-    def test_no_types_or_tsconfig_in_output(self, source_dir: Path, tmp_path: Path):
+    def test_no_types_or_tsconfig_in_output(self, _mock_run, source_dir: Path, tmp_path: Path):
         """types/ directory and tsconfig.json are removed from output."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -326,7 +339,7 @@ class TestFullBuild:
         assert not (output / "assets" / "types").exists()
         assert not (output / "assets" / "tsconfig.json").exists()
 
-    def test_html_contains_all_pages(self, source_dir: Path, tmp_path: Path):
+    def test_html_contains_all_pages(self, _mock_run, source_dir: Path, tmp_path: Path):
         """HTML shell contains all 5 page sections and import map."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -338,7 +351,7 @@ class TestFullBuild:
         assert "importmap" in html
         assert "lightweight-charts" in html
 
-    def test_overview_has_etf_dashboard_containers(self, source_dir: Path, tmp_path: Path):
+    def test_overview_has_etf_dashboard_containers(self, _mock_run, source_dir: Path, tmp_path: Path):
         """Overview page has ETF dashboard, controls, stats, treemap containers."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -349,7 +362,7 @@ class TestFullBuild:
         assert 'id="overview-stats"' in html
         assert 'id="overview-heatmap"' in html
 
-    def test_overview_has_no_movers_alerts(self, source_dir: Path, tmp_path: Path):
+    def test_overview_has_no_movers_alerts(self, _mock_run, source_dir: Path, tmp_path: Path):
         """Overview page does not contain legacy movers/alerts sections."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -359,7 +372,7 @@ class TestFullBuild:
         assert "overview-alerts" not in html
         assert "overview-benchmarks" not in html
 
-    def test_signals_has_chart_container(self, source_dir: Path, tmp_path: Path):
+    def test_signals_has_chart_container(self, _mock_run, source_dir: Path, tmp_path: Path):
         """Signals page has LC v5 multi-pane chart wrapper and sections div."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -369,7 +382,7 @@ class TestFullBuild:
         assert 'id="signals-chart-main"' in html
         assert 'id="signals-sections"' in html
 
-    def test_html_contains_plotly(self, source_dir: Path, tmp_path: Path):
+    def test_html_contains_plotly(self, _mock_run, source_dir: Path, tmp_path: Path):
         """HTML shell contains Plotly script tag for treemap + backtest charts."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -377,7 +390,7 @@ class TestFullBuild:
         html = (output / "index.html").read_text()
         assert "plotly" in html.lower()
 
-    def test_html_contains_backtest_content_container(self, source_dir: Path, tmp_path: Path):
+    def test_html_contains_backtest_content_container(self, _mock_run, source_dir: Path, tmp_path: Path):
         """HTML has backtest-content container for dynamic tab rendering."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -386,7 +399,7 @@ class TestFullBuild:
         assert 'id="backtest-content"' in html
         assert 'id="backtest-empty"' in html
 
-    def test_cf_headers_content(self, source_dir: Path, tmp_path: Path):
+    def test_cf_headers_content(self, _mock_run, source_dir: Path, tmp_path: Path):
         """CF _headers file contains correct cache and security headers."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -398,8 +411,9 @@ class TestFullBuild:
         assert "X-Frame-Options: DENY" in headers
 
 
+@patch("subprocess.run", side_effect=_fake_esbuild)
 class TestSourceImmutability:
-    def test_source_files_unchanged(self, source_dir: Path, tmp_path: Path):
+    def test_source_files_unchanged(self, _mock_run, source_dir: Path, tmp_path: Path):
         """Source files are not modified during build."""
         # Record file contents before build
         src_data = source_dir / "data" / "AAPL_1d.json"
@@ -410,3 +424,26 @@ class TestSourceImmutability:
 
         # Verify source unchanged
         assert src_data.read_text() == original
+
+
+class TestEsbuildFailFast:
+    """Verify builder raises on esbuild/npx failures instead of silently degrading."""
+
+    def test_raises_on_npx_not_found(self, source_dir: Path, tmp_path: Path):
+        """Builder raises RuntimeError when npx is not installed."""
+        output = tmp_path / "site"
+        with patch("subprocess.run", side_effect=FileNotFoundError("npx")):
+            with pytest.raises(RuntimeError, match="npx not found"):
+                DashboardBuilder(source_dir=source_dir).build(output_dir=output)
+
+    def test_raises_on_esbuild_compile_error(self, source_dir: Path, tmp_path: Path):
+        """Builder raises RuntimeError when esbuild exits non-zero."""
+        import subprocess
+
+        error = subprocess.CalledProcessError(
+            returncode=1, cmd=["npx", "esbuild"], stderr=b"Parse error: unexpected token"
+        )
+        output = tmp_path / "site"
+        with patch("subprocess.run", side_effect=error):
+            with pytest.raises(RuntimeError, match="esbuild compilation failed"):
+                DashboardBuilder(source_dir=source_dir).build(output_dir=output)

--- a/tests/unit/reporting/test_dashboard_builder.py
+++ b/tests/unit/reporting/test_dashboard_builder.py
@@ -351,7 +351,9 @@ class TestFullBuild:
         assert "importmap" in html
         assert "lightweight-charts" in html
 
-    def test_overview_has_etf_dashboard_containers(self, _mock_run, source_dir: Path, tmp_path: Path):
+    def test_overview_has_etf_dashboard_containers(
+        self, _mock_run, source_dir: Path, tmp_path: Path
+    ):
         """Overview page has ETF dashboard, controls, stats, treemap containers."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)
@@ -390,7 +392,9 @@ class TestFullBuild:
         html = (output / "index.html").read_text()
         assert "plotly" in html.lower()
 
-    def test_html_contains_backtest_content_container(self, _mock_run, source_dir: Path, tmp_path: Path):
+    def test_html_contains_backtest_content_container(
+        self, _mock_run, source_dir: Path, tmp_path: Path
+    ):
         """HTML has backtest-content container for dynamic tab rendering."""
         output = tmp_path / "site"
         DashboardBuilder(source_dir=source_dir).build(output_dir=output)


### PR DESCRIPTION
## Summary

- **Split monolithic `hourly-signals.yml`** (1 job, 15-30 min) into 5 independent jobs: `setup-and-check` → `signal-pipeline` | `strategy-compare` (parallel) → `notify` + `dashboard`. Each job can be individually rerun from the GitHub Actions UI.
- **Build system fail-fast**: both Python (`builder.py`) and Node.js (`build-dashboard.mjs`) builders now raise/exit on esbuild failure instead of silently copying `.ts→.js` (which produces broken browser JS). Added SRI hash to Plotly CDN tag.
- **Data pipeline hardening**: unified source priority to `fmp > yahoo`, added artifact smoke gates before deploys, `dashboard-refresh.yml` now deploys to preview branch.
- **Makefile restructure**: new pipeline-stage targets (`dashboard-data-ready`, `dashboard-signal`, `dashboard-signal-qa`) that compose into `dashboard-data`. CI and local commands now use identical phases.
- **Hermetic tests**: builder unit tests mock esbuild so they pass offline. Added 2 error-path tests for `FileNotFoundError` and `CalledProcessError`.

## Test plan

- [x] All 28 dashboard builder tests pass (`pytest tests/unit/reporting/test_dashboard_builder.py`)
- [x] YAML syntax valid for both workflow files
- [x] All Makefile help targets resolve (`make -n`)
- [x] Injected TS syntax error → both builders fail with clear error messages
- [x] Smoke gate catches missing `summary.json`
- [x] SRI hash matches computed value
- [ ] Trigger `workflow_dispatch` with `force_run: true` + `run_strategy_compare: true` → verify 5-job dependency graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)