### PR TITLE
fix: R2 data resolution + treemap sector grouping

### DIFF
--- a/src/server/main.py
+++ b/src/server/main.py
@@ -70,15 +70,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     lb_enabled = config.providers.get("longbridge")
     has_lb_creds = bool(os.environ.get("LONGPORT_APP_KEY"))
 
-    # ── R2 client (optional — only if credentials available) ──
-    has_r2_creds = bool(os.environ.get("R2_ACCESS_KEY_ID"))
-    if has_r2_creds:
-        try:
-            from src.infrastructure.adapters.r2.client import R2Client
-            r2_client = R2Client()
-            logger.info("R2 client initialized")
-        except Exception:
-            logger.exception("Failed to initialize R2 client")
+    # ── R2 client (optional — tries env vars then config/secrets.yaml) ──
+    try:
+        from src.infrastructure.adapters.r2.client import R2Client
+        r2_client = R2Client()
+        logger.info("R2 client initialized")
+    except (ValueError, ImportError):
+        logger.info("R2 client not available (no credentials)")
+    except Exception:
+        logger.exception("Failed to initialize R2 client")
 
     # ── Longbridge connection (deferred — SDK takes ~13s to connect) ──
     async def _connect_longbridge():

--- a/src/server/routes/monitor.py
+++ b/src/server/routes/monitor.py
@@ -109,10 +109,10 @@ def create_monitor_router(
         r2 = _get_r2_client(request)
         data = None
 
-        # Try R2 first
+        # Try R2 first (stored under meta/ prefix)
         if r2 is not None:
             try:
-                data = r2.get_json("data_quality.json")
+                data = r2.get_json("meta/data_quality.json")
             except Exception as e:
                 logger.error("R2 fetch data_quality.json failed: %s", e)
 

--- a/src/server/routes/screeners.py
+++ b/src/server/routes/screeners.py
@@ -55,6 +55,12 @@ def _fetch_static_sync(filename: str) -> Any | None:
 class _CachedProxy:
     """TTL cache with R2 primary + GitHub Pages fallback."""
 
+    # R2 stores these files under meta/ prefix; GitHub Pages uses bare filenames
+    _R2_KEY_MAP: dict[str, str] = {
+        "universe.json": "meta/universe.json",
+        "data_quality.json": "meta/data_quality.json",
+    }
+
     def __init__(self, r2_client: Any, ttl_sec: int = 300):
         self._r2 = r2_client
         self._ttl = ttl_sec
@@ -91,11 +97,12 @@ class _CachedProxy:
             if now < expires_at:
                 return data
 
-        # 2. R2
+        # 2. R2 (some files live under meta/ prefix in R2)
         r2 = r2_override or self._r2
+        r2_key = self._R2_KEY_MAP.get(key, key)
         if r2 is not None:
             try:
-                data = r2.get_json(key)
+                data = r2.get_json(r2_key)
                 if data is not None:
                     self._cache[key] = (now + self._ttl, data)
                     return data

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useCallback } from "react"
 import { useNavigate } from "react-router-dom"
 import type Plotly from "plotly.js"
 import Plot from "react-plotly.js"
-import { useSymbols, useSummary, useScoreHistory } from "@/lib/api"
+import { useSymbols, useSummary, useScoreHistory, useUniverse } from "@/lib/api"
 import { useMarketStore } from "@/stores/market"
 
 // ── ETF Configuration (mirrors static dashboard model.py) ────────────────────
@@ -114,6 +114,7 @@ export function Overview() {
   const { data: symbolsData } = useSymbols()
   const { data: summaryRaw } = useSummary()
   const { data: scoreHistoryRaw } = useScoreHistory()
+  const { data: universeRaw } = useUniverse()
   const quotes = useMarketStore((s) => s.quotes)
   const signals = useMarketStore((s) => s.signals)
 
@@ -128,13 +129,32 @@ export function Overview() {
     regime_counts?: Record<string, number>
   } | undefined
 
+  // Parse universe for sector + market cap enrichment
+  const universeMap = useMemo(() => {
+    const map: Record<string, { sector?: string; marketCap?: number }> = {}
+    const udata = universeRaw as {
+      tickers?: { symbol: string; sector?: string; marketCap?: number }[]
+    } | undefined
+    for (const t of udata?.tickers ?? []) {
+      map[t.symbol] = { sector: t.sector, marketCap: t.marketCap }
+    }
+    return map
+  }, [universeRaw])
+
+  // Build tickerMap from summary, enriched with universe sector + market cap
   const tickerMap = useMemo(() => {
     const map: Record<string, TickerData> = {}
     for (const t of summary?.tickers ?? []) {
-      if (t.symbol) map[t.symbol] = t
+      if (!t.symbol) continue
+      const uni = universeMap[t.symbol]
+      map[t.symbol] = {
+        ...t,
+        sector: t.sector ?? uni?.sector,
+        market_cap: t.market_cap ?? uni?.marketCap,
+      }
     }
     return map
-  }, [summary])
+  }, [summary, universeMap])
 
   // Parse score history for sparklines
   const sparklines = useMemo(() => {
@@ -197,11 +217,11 @@ export function Overview() {
   const treemapData = useMemo(() => {
     if (treemapSymbols.length === 0) return null
 
-    const labels: string[] = ["Universe"]
-    const parents: string[] = [""]
-    const values: number[] = [0]
-    const colors: string[] = [""]
-    const texts: string[] = [""]
+    const labels: string[] = []
+    const parents: string[] = []
+    const values: number[] = []
+    const colors: string[] = []
+    const texts: string[] = []
 
     // Group by sector
     const sectors = new Map<string, string[]>()
@@ -211,13 +231,12 @@ export function Overview() {
       sectors.get(sector)!.push(sym)
     }
 
-    for (const [sector, syms] of sectors) {
-      labels.push(sector)
-      parents.push("Universe")
-      values.push(0)
-      colors.push("")
-      texts.push("")
+    // Build stock entries first (to compute sector totals for branchvalues="total")
+    const sectorTotals = new Map<string, number>()
+    const stockEntries: { sym: string; sector: string; size: number; color: string; text: string }[] = []
 
+    for (const [sector, syms] of sectors) {
+      let sectorTotal = 0
       for (const sym of syms) {
         const td = tickerMap[sym]
         const price = getPrice(sym) ?? 1
@@ -234,12 +253,37 @@ export function Overview() {
         else if (colorBy === "daily_change") color = getDailyChangeColor(td?.daily_change_pct ?? null)
         else color = getAlignmentColor(td?.alignment_score ?? null)
 
-        labels.push(sym)
-        parents.push(sector)
-        values.push(size)
-        colors.push(color)
-        texts.push(`${sym}<br>$${price.toFixed(2)}<br>${td?.daily_change_pct != null ? `${td.daily_change_pct >= 0 ? "+" : ""}${td.daily_change_pct.toFixed(2)}%` : ""}`)
+        const text = `${sym}<br>$${price.toFixed(2)}<br>${td?.daily_change_pct != null ? `${td.daily_change_pct >= 0 ? "+" : ""}${td.daily_change_pct.toFixed(2)}%` : ""}`
+        stockEntries.push({ sym, sector, size, color, text })
+        sectorTotal += size
       }
+      sectorTotals.set(sector, sectorTotal)
+    }
+
+    // Root node (value = sum of all sectors)
+    const rootTotal = Array.from(sectorTotals.values()).reduce((a, b) => a + b, 0)
+    labels.push("Universe")
+    parents.push("")
+    values.push(rootTotal)
+    colors.push("")
+    texts.push("")
+
+    // Sector nodes (value = sum of their stocks)
+    for (const [sector] of sectors) {
+      labels.push(sector)
+      parents.push("Universe")
+      values.push(sectorTotals.get(sector)!)
+      colors.push("")
+      texts.push("")
+    }
+
+    // Stock leaf nodes
+    for (const entry of stockEntries) {
+      labels.push(entry.sym)
+      parents.push(entry.sector)
+      values.push(entry.size)
+      colors.push(entry.color)
+      texts.push(entry.text)
     }
 
     return { labels, parents, values, colors, texts }
@@ -375,7 +419,7 @@ export function Overview() {
                     colors: treemapData.colors,
                     line: { color: "#0d1520", width: 1.5 },
                   },
-                  branchvalues: "remainder" as const,
+                  branchvalues: "total" as const,
                   textfont: { color: "#c0cad8", size: 12 },
                   pathbar: { visible: false },
                 } as unknown as Plotly.Data,


### PR DESCRIPTION
## Summary
- **R2 client init**: Try creating unconditionally (loads from `config/secrets.yaml` fallback, not just env vars) — unlocks full 9,304 data quality entries (was only 10 from GitHub Pages fallback)
- **R2 key paths**: Fix `monitor.py` to use `meta/data_quality.json`; add `_R2_KEY_MAP` to `screeners.py` for `meta/` prefix mapping
- **Treemap sector grouping**: Enrich summary tickers with `universe.json` sector + marketCap data, compute sector totals for `branchvalues="total"`, stocks now properly grouped by sector (technology, financials, healthcare, etc.)

## Test plan
- [ ] Verify `/api/monitor/data-quality` returns 9,304+ entries (not 10)
- [ ] Verify `/api/universe` returns 2,326+ tickers with sector data
- [ ] Verify Overview treemap shows stocks grouped by sector
- [ ] Verify treemap Color By / Size By controls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)