### PR TITLE
feat(advisor): add trading advisor with equity signals, VRP, and premium strategies

### DIFF
--- a/src/domain/services/advisor/advisor_service.py
+++ b/src/domain/services/advisor/advisor_service.py
@@ -1,0 +1,203 @@
+"""AdvisorService — orchestrates premium and equity advisors.
+
+Uses get_recent_signals() callable (signal buffer in pipeline) instead of
+RuleEngine.get_evaluation_history() which requires trace_mode.
+
+VIX data cached at compute_all level to avoid redundant calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from src.domain.services.advisor.equity_advisor import EquityAdvisor
+from src.domain.services.advisor.models import EquityAdvice, MarketContext, PremiumAdvice
+from src.domain.services.advisor.premium_advisor import PremiumAdvisor
+from src.domain.services.advisor.vrp import compute_term_structure, compute_vrp
+
+logger = logging.getLogger(__name__)
+
+
+class AdvisorService:
+    """Orchestrates premium + equity advisors with live data feeds."""
+
+    def __init__(
+        self,
+        get_regime_states: Callable,
+        get_indicator_states: Callable,
+        get_vix_data: Callable,
+        get_underlying_close: Callable,
+        get_recent_signals: Callable,
+        etf_symbols: list[str],
+        universe_symbols: list[str],
+        sector_map: dict[str, str],
+    ) -> None:
+        self._get_regime_states = get_regime_states
+        self._get_indicator_states = get_indicator_states
+        self._get_vix_data = get_vix_data
+        self._get_underlying_close = get_underlying_close
+        self._get_recent_signals = get_recent_signals
+        self._etf_symbols = etf_symbols
+        self._universe_symbols = universe_symbols
+        self._sector_map = sector_map
+
+        self._premium_advisor = PremiumAdvisor()
+        self._equity_advisor = EquityAdvisor()
+
+    def compute_all(self) -> dict[str, Any]:
+        """Compute advice for all ETFs (premium) and universe (equity)."""
+        # Cache VIX data for this computation cycle
+        vix_cache = self._get_vix_data()
+
+        ctx = self._build_market_context(vix_cache)
+        premium = [self._compute_premium(sym, ctx, vix_cache) for sym in self._etf_symbols]
+        equity = [self._compute_equity(sym, ctx) for sym in self._universe_symbols]
+
+        return {
+            "market_context": ctx,
+            "premium": [a for a in premium if a is not None],
+            "equity": [a for a in equity if a is not None],
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def compute_symbol(self, symbol: str) -> dict[str, Any]:
+        """Compute advice for a single symbol."""
+        vix_cache = self._get_vix_data()
+        ctx = self._build_market_context(vix_cache)
+        result: dict[str, Any] = {
+            "market_context": ctx,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        if symbol in self._etf_symbols:
+            result["premium"] = self._compute_premium(symbol, ctx, vix_cache)
+
+        result["equity"] = self._compute_equity(symbol, ctx) or EquityAdvice(
+            symbol=symbol,
+            sector=self._sector_map.get(symbol, "Unknown"),
+            action="HOLD",
+            confidence=0,
+            regime=ctx.regime if ctx else "R1",
+            signal_summary={"bullish": 0, "bearish": 0, "neutral": 0},
+            top_signals=[],
+            trend_pulse=None,
+            key_levels={},
+            reasoning=["Insufficient data"],
+        )
+
+        return result
+
+    def _build_market_context(self, vix_cache: tuple) -> MarketContext:
+        """Build market-level context from current data."""
+        regimes = self._get_regime_states("1d")
+        spy_regime = regimes.get("SPY", {})
+
+        vix_series, vix3m_series = vix_cache
+
+        vix_val = (
+            float(vix_series.iloc[-1]) if vix_series is not None and len(vix_series) > 0 else 0
+        )
+        vix3m_val = (
+            float(vix3m_series.iloc[-1])
+            if vix3m_series is not None and len(vix3m_series) > 0
+            else 0
+        )
+
+        # VRP for SPY (market-level)
+        spy_close = self._get_underlying_close("SPY")
+        vrp_zscore = 0.0
+        iv_pctile = 50.0
+        if vix_series is not None and spy_close is not None and len(vix_series) > 60:
+            try:
+                vrp_result = compute_vrp(vix_series, spy_close)
+                vrp_zscore = vrp_result.vrp_zscore
+                iv_pctile = vrp_result.iv_percentile
+            except Exception:
+                logger.debug("VRP computation failed — using defaults")
+
+        ts_ratio, ts_state = (
+            compute_term_structure(vix_val, vix3m_val) if vix3m_val > 0 else (1.0, "flat")
+        )
+
+        return MarketContext(
+            regime=spy_regime.get("regime", "R1"),
+            regime_name=spy_regime.get("regime_name", "Unknown"),
+            regime_confidence=spy_regime.get("confidence", 50),
+            vix=vix_val,
+            vix_percentile=iv_pctile,
+            vrp_zscore=vrp_zscore,
+            term_structure_ratio=ts_ratio,
+            term_structure_state=ts_state,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def _compute_premium(
+        self, symbol: str, ctx: MarketContext, vix_cache: tuple
+    ) -> PremiumAdvice | None:
+        """Compute premium advice for an ETF symbol."""
+        try:
+            vix_series, _ = vix_cache
+            underlying = self._get_underlying_close(symbol)
+
+            if vix_series is None or underlying is None or len(vix_series) < 60:
+                return None
+
+            vrp = compute_vrp(vix_series, underlying)
+            spot = float(underlying.iloc[-1])
+
+            # Determine trend direction from indicators
+            states = self._get_indicator_states(symbol, "1d")
+            trend = self._infer_trend(states)
+
+            return self._premium_advisor.advise(
+                symbol=symbol,
+                spot=spot,
+                regime=ctx.regime,
+                vrp=vrp,
+                term_structure_ratio=ctx.term_structure_ratio,
+                earnings_days_away=None,  # TODO: wire earnings service
+                trend_direction=trend,
+            )
+        except Exception:
+            logger.exception("Premium advice failed for %s", symbol)
+            return None
+
+    def _compute_equity(self, symbol: str, ctx: MarketContext) -> EquityAdvice | None:
+        """Compute equity advice for a symbol."""
+        try:
+            regimes = self._get_regime_states("1d")
+            sym_regime = regimes.get(symbol, {}).get("regime", ctx.regime)
+            sector = self._sector_map.get(symbol, "Unknown")
+
+            # Get active signals from signal buffer
+            active = self._get_recent_signals(symbol)
+
+            # Get indicator state
+            states = self._get_indicator_states(symbol, "1d")
+            flat_state: dict[str, Any] = {}
+            if isinstance(states, dict):
+                for key, val in states.items():
+                    if isinstance(key, tuple) and len(key) == 3:
+                        _, _, ind_name = key
+                        flat_state[ind_name] = val
+                    else:
+                        flat_state[key] = val
+
+            return self._equity_advisor.synthesize(symbol, sector, active, sym_regime, flat_state)
+        except Exception:
+            logger.exception("Equity advice failed for %s", symbol)
+            return None
+
+    def _infer_trend(self, states: dict) -> str:
+        """Infer trend direction from indicator states."""
+        for key, val in states.items():
+            ind_name = key[2] if isinstance(key, tuple) and len(key) == 3 else key
+            if ind_name == "supertrend" and isinstance(val, dict):
+                direction = val.get("direction")
+                if direction == "up":
+                    return "up"
+                elif direction == "down":
+                    return "down"
+        return "sideways"

--- a/src/domain/services/advisor/equity_advisor.py
+++ b/src/domain/services/advisor/equity_advisor.py
@@ -1,0 +1,169 @@
+"""Equity advisor — synthesizes signals into BUY/HOLD/SELL recommendations.
+
+Signal count is factored into confidence calculation.
+A single signal produces at most BUY/SELL; STRONG requires 3+ aligned signals.
+"""
+
+from __future__ import annotations
+
+import math
+
+from src.domain.services.advisor.models import EquityAdvice
+
+# Minimum signal count for STRONG recommendations
+_MIN_SIGNALS_FOR_STRONG = 3
+
+
+class EquityAdvisor:
+    """Synthesizes active signals into per-symbol equity recommendations."""
+
+    def synthesize(
+        self,
+        symbol: str,
+        sector: str,
+        active_signals: list[dict],
+        regime: str,
+        indicator_state: dict,
+    ) -> EquityAdvice:
+        if not active_signals:
+            return EquityAdvice(
+                symbol=symbol,
+                sector=sector,
+                action="HOLD",
+                confidence=5,
+                regime=regime,
+                signal_summary={"bullish": 0, "bearish": 0, "neutral": 0},
+                top_signals=[],
+                trend_pulse=None,
+                key_levels={},
+                reasoning=["No active signals"],
+            )
+
+        # Score each signal
+        score = 0.0
+        total_weight = 0.0
+        for sig in active_signals:
+            direction = sig.get("direction", "neutral")
+            strength = sig.get("strength", 50)
+            dir_weight = {"bullish": 1.0, "bearish": -1.0, "neutral": 0.0}.get(direction, 0.0)
+
+            # TrendPulse signals get 1.5x weight
+            rule = sig.get("rule", "")
+            multiplier = 1.5 if rule.startswith("trend_pulse") else 1.0
+
+            weighted = strength * dir_weight * multiplier
+            score += weighted
+            total_weight += abs(strength * multiplier)
+
+        # Normalize to -100..+100
+        normalized = (score / total_weight * 100) if total_weight > 0 else 0
+
+        # Dampen score when signal count is low
+        # sqrt(n)/sqrt(3) — reaches 1.0 at 3 signals, 0.58 at 1 signal
+        signal_count = len([s for s in active_signals if s.get("direction") != "neutral"])
+        count_factor = min(
+            math.sqrt(max(signal_count, 1)) / math.sqrt(_MIN_SIGNALS_FOR_STRONG), 1.0
+        )
+        normalized *= count_factor
+
+        # Regime adjustment
+        regime_mult = {"R0": 1.0, "R1": 0.7, "R2": 0.0, "R3": 0.3}.get(regime, 0.5)
+
+        if normalized > 0:
+            adjusted = normalized * regime_mult
+        else:
+            # For sell signals, R2 amplifies
+            sell_mult = {"R0": 0.7, "R1": 1.0, "R2": 1.5, "R3": 1.0}.get(regime, 1.0)
+            adjusted = normalized * sell_mult
+
+        # Map to action
+        if adjusted > 60:
+            action = "STRONG_BUY"
+        elif adjusted > 25:
+            action = "BUY"
+        elif adjusted > -25:
+            action = "HOLD"
+        elif adjusted > -60:
+            action = "SELL"
+        else:
+            action = "STRONG_SELL"
+
+        confidence = min(abs(adjusted), 100)
+
+        # Signal summary
+        summary: dict[str, int] = {"bullish": 0, "bearish": 0, "neutral": 0}
+        for sig in active_signals:
+            d = sig.get("direction", "neutral")
+            if d in summary:
+                summary[d] += 1
+
+        # Top signals
+        top = sorted(active_signals, key=lambda s: s.get("strength", 0), reverse=True)[:3]
+
+        # Extract TrendPulse state if present
+        trend_pulse = self._extract_trend_pulse(indicator_state)
+
+        # Key levels
+        key_levels = self._extract_key_levels(indicator_state)
+
+        # Reasoning
+        reasoning = self._build_reasoning(action, summary, regime, confidence)
+
+        return EquityAdvice(
+            symbol=symbol,
+            sector=sector,
+            action=action,
+            confidence=round(confidence, 1),
+            regime=regime,
+            signal_summary=summary,
+            top_signals=top,
+            trend_pulse=trend_pulse,
+            key_levels=key_levels,
+            reasoning=reasoning,
+        )
+
+    def _extract_trend_pulse(self, state: dict) -> dict | None:
+        tp = state.get("trend_pulse")
+        if not tp:
+            return None
+        return {
+            "zig_state": tp.get("zig_state"),
+            "macd_state": tp.get("macd_state"),
+            "atr_trail": tp.get("atr_trail"),
+            "confidence_score": tp.get("confidence"),
+        }
+
+    def _extract_key_levels(self, state: dict) -> dict:
+        levels: dict[str, float] = {}
+        sr = state.get("support_resistance")
+        if sr:
+            if "support" in sr:
+                levels["support"] = sr["support"]
+            if "resistance" in sr:
+                levels["resistance"] = sr["resistance"]
+        tp = state.get("trend_pulse")
+        if tp and "atr_trail" in tp:
+            levels["atr_stop"] = tp["atr_trail"]
+        return levels
+
+    def _build_reasoning(
+        self, action: str, summary: dict, regime: str, confidence: float
+    ) -> list[str]:
+        reasons = []
+        bull, bear = summary.get("bullish", 0), summary.get("bearish", 0)
+        if bull > bear:
+            reasons.append(f"{bull} bullish vs {bear} bearish signals")
+        elif bear > bull:
+            reasons.append(f"{bear} bearish vs {bull} bullish signals")
+        else:
+            reasons.append("Mixed signals — equal bullish and bearish")
+
+        regime_names = {
+            "R0": "Healthy Uptrend — full sizing",
+            "R1": "Choppy — reduced sizing",
+            "R2": "Risk-Off — no new longs",
+            "R3": "Rebound — small defined-risk only",
+        }
+        reasons.append(f"Regime {regime}: {regime_names.get(regime, 'Unknown')}")
+
+        return reasons

--- a/src/domain/services/advisor/equity_advisor.py
+++ b/src/domain/services/advisor/equity_advisor.py
@@ -26,17 +26,23 @@ class EquityAdvisor:
         indicator_state: dict,
     ) -> EquityAdvice:
         if not active_signals:
+            # Extract key levels even when no signals are active
+            tp = self._extract_trend_pulse(indicator_state)
+            kl = self._extract_key_levels(indicator_state)
+            reasoning = ["No active signals — awaiting market data"]
+            if regime in ("R2", "R3"):
+                reasoning.append(f"Regime {regime}: elevated caution")
             return EquityAdvice(
                 symbol=symbol,
                 sector=sector,
                 action="HOLD",
-                confidence=5,
+                confidence=0,
                 regime=regime,
                 signal_summary={"bullish": 0, "bearish": 0, "neutral": 0},
                 top_signals=[],
-                trend_pulse=None,
-                key_levels={},
-                reasoning=["No active signals"],
+                trend_pulse=tp,
+                key_levels=kl,
+                reasoning=reasoning,
             )
 
         # Score each signal

--- a/src/domain/services/advisor/models.py
+++ b/src/domain/services/advisor/models.py
@@ -1,0 +1,98 @@
+"""Domain models for the Trading Advisor feature."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VRPResult:
+    """Volatility Risk Premium calculation result."""
+
+    iv30: float  # Implied vol (VIX close)
+    rv30: float  # 30-day realized vol (annualized)
+    vrp: float  # iv30 - rv30
+    vrp_zscore: float  # Z-scored over 252-day trailing window
+    iv_percentile: float  # VIX percentile rank (0-100)
+
+
+@dataclass(frozen=True)
+class LegTemplate:
+    """Template for constructing an option leg."""
+
+    side: str  # "buy" | "sell"
+    option_type: str  # "put" | "call"
+    delta_target: int  # Target delta (absolute, e.g. 25)
+    dte_target: int  # Target DTE
+
+
+@dataclass(frozen=True)
+class PremiumStrategyDef:
+    """Definition of a premium-selling strategy."""
+
+    name: str  # "short_put", "iron_condor", etc.
+    display_name: str  # "Short Put", "Iron Condor"
+    direction: str  # "bullish" | "bearish" | "neutral"
+    risk_profile: str  # "undefined" | "defined"
+    regime_fit: frozenset[str]  # {"R0", "R1"} -- suitable regimes
+    leg_templates: tuple[LegTemplate, ...]
+
+
+@dataclass(frozen=True)
+class LegSpec:
+    """Concrete option leg with estimated strike."""
+
+    side: str
+    option_type: str
+    target_delta: int
+    target_dte: int
+    estimated_strike: float
+
+
+@dataclass(frozen=True)
+class PremiumAdvice:
+    """Premium strategy recommendation for a symbol."""
+
+    symbol: str
+    action: str  # "SELL" | "HOLD" | "BLOCKED"
+    strategy: str | None  # Strategy name or None if blocked
+    display_name: str | None
+    confidence: float  # 0-100
+    legs: list[LegSpec]
+    vrp_zscore: float
+    iv_percentile: float
+    term_structure_ratio: float
+    regime: str
+    earnings_warning: str | None
+    reasoning: list[str]
+
+
+@dataclass(frozen=True)
+class EquityAdvice:
+    """Equity buy/sell recommendation for a symbol."""
+
+    symbol: str
+    sector: str
+    action: str  # "STRONG_BUY" | "BUY" | "HOLD" | "SELL" | "STRONG_SELL"
+    confidence: float  # 0-100
+    regime: str
+    signal_summary: dict[str, int]  # {"bullish": N, "bearish": N, "neutral": N}
+    top_signals: list[dict]  # Top 3 signals by strength
+    trend_pulse: dict | None  # TrendPulse-specific state
+    key_levels: dict[str, float]  # {"support": ..., "resistance": ...}
+    reasoning: list[str]
+
+
+@dataclass(frozen=True)
+class MarketContext:
+    """Market-level context shared by all advisor responses."""
+
+    regime: str
+    regime_name: str
+    regime_confidence: float
+    vix: float
+    vix_percentile: float
+    vrp_zscore: float
+    term_structure_ratio: float
+    term_structure_state: str  # "contango" | "flat" | "inverted"
+    timestamp: str

--- a/src/domain/services/advisor/premium_advisor.py
+++ b/src/domain/services/advisor/premium_advisor.py
@@ -1,0 +1,259 @@
+"""Premium strategy advisor — selects optimal sell-premium strategy.
+
+R2 gate is nuanced — blocks R3 completely, but R2 allows defined-risk bearish only.
+Strategy selection uses scoring (VRP fit + risk profile + direction match) instead of
+arbitrary first-match. Delta capped at 40 for sell legs.
+"""
+
+from __future__ import annotations
+
+from src.domain.services.advisor.models import LegSpec, PremiumAdvice, PremiumStrategyDef, VRPResult
+from src.domain.services.advisor.strategy_registry import get_strategies_for_regime
+from src.domain.services.advisor.vrp import estimate_strike_bsm
+
+
+class PremiumAdvisor:
+    """Selects optimal premium strategy based on VRP, regime, and market conditions."""
+
+    def advise(
+        self,
+        symbol: str,
+        spot: float,
+        regime: str,
+        vrp: VRPResult,
+        term_structure_ratio: float,
+        earnings_days_away: int | None,
+        trend_direction: str,
+    ) -> PremiumAdvice:
+        # Gate 1: R3 always blocked. R2 only allows defined-risk bearish (handled below).
+        if regime == "R3":
+            return self._make_advice(
+                symbol=symbol,
+                vrp=vrp,
+                term_structure_ratio=term_structure_ratio,
+                regime=regime,
+                action="BLOCKED",
+                reasoning=[f"Rebound regime ({regime}) — no premium selling"],
+            )
+
+        # Gate 2: VRP
+        if vrp.vrp_zscore < 0:
+            return self._make_advice(
+                symbol=symbol,
+                vrp=vrp,
+                term_structure_ratio=term_structure_ratio,
+                regime=regime,
+                action="BLOCKED",
+                reasoning=["Negative VRP — realized vol exceeds implied vol"],
+            )
+
+        # Gate 3: Term structure
+        if term_structure_ratio > 1.2:
+            return self._make_advice(
+                symbol=symbol,
+                vrp=vrp,
+                term_structure_ratio=term_structure_ratio,
+                regime=regime,
+                action="BLOCKED",
+                reasoning=["Inverted term structure (VIX/VIX3M > 1.2)"],
+            )
+
+        # Gate 4: Earnings proximity
+        if earnings_days_away is not None and -3 <= earnings_days_away <= 5:
+            return self._make_advice(
+                symbol=symbol,
+                vrp=vrp,
+                term_structure_ratio=term_structure_ratio,
+                regime=regime,
+                action="HOLD",
+                confidence=20,
+                earnings_warning=f"Earnings in {earnings_days_away} days",
+                reasoning=[f"Earnings proximity ({earnings_days_away} days) — hold off"],
+            )
+
+        # Select strategy
+        candidates = get_strategies_for_regime(regime)
+
+        # Filter by trend direction
+        if trend_direction == "up":
+            filtered = [s for s in candidates if s.direction in ("bullish", "neutral")]
+        elif trend_direction == "down":
+            filtered = [s for s in candidates if s.direction in ("bearish", "neutral")]
+        else:
+            filtered = candidates
+
+        # In R2, direction filtering is strict — don't fallback to mismatched direction.
+        # For other regimes, fall back to all regime-compatible strategies.
+        if not filtered and regime != "R2":
+            filtered = candidates
+
+        # Prefer defined-risk when IV is elevated
+        if vrp.iv_percentile > 75 and filtered:
+            defined = [s for s in filtered if s.risk_profile == "defined"]
+            if defined:
+                filtered = defined
+
+        if not filtered:
+            return self._make_advice(
+                symbol=symbol,
+                vrp=vrp,
+                term_structure_ratio=term_structure_ratio,
+                regime=regime,
+                action="HOLD",
+                confidence=10,
+                reasoning=["No strategy fits current conditions"],
+            )
+
+        # Score-based strategy selection instead of filtered[0]
+        strategy = self._rank_strategies(filtered, vrp, trend_direction)
+
+        # Delta adjustment by VRP z-score
+        if vrp.vrp_zscore > 1.0:
+            delta_adj = 10
+        elif vrp.vrp_zscore > 0.5:
+            delta_adj = 0
+        else:
+            delta_adj = -5
+
+        # Build legs with estimated strikes
+        iv_decimal = vrp.iv30 / 100.0
+        legs: list[LegSpec] = []
+        for tmpl in strategy.leg_templates:
+            adjusted_delta = max(5, tmpl.delta_target + delta_adj)
+            # Cap sell-leg delta at 40
+            if tmpl.side == "sell":
+                adjusted_delta = min(40, adjusted_delta)
+            est_strike = estimate_strike_bsm(
+                spot=spot,
+                iv=iv_decimal,
+                dte=tmpl.dte_target,
+                target_delta=adjusted_delta / 100.0,
+                option_type=tmpl.option_type,
+            )
+            legs.append(
+                LegSpec(
+                    side=tmpl.side,
+                    option_type=tmpl.option_type,
+                    target_delta=adjusted_delta,
+                    target_dte=tmpl.dte_target,
+                    estimated_strike=est_strike,
+                )
+            )
+
+        confidence = self._compute_confidence(vrp, term_structure_ratio, regime)
+        reasoning = self._build_reasoning(
+            vrp, term_structure_ratio, regime, trend_direction, strategy
+        )
+
+        return PremiumAdvice(
+            symbol=symbol,
+            vrp_zscore=vrp.vrp_zscore,
+            iv_percentile=vrp.iv_percentile,
+            term_structure_ratio=term_structure_ratio,
+            regime=regime,
+            action="SELL",
+            strategy=strategy.name,
+            display_name=strategy.display_name,
+            confidence=confidence,
+            legs=legs,
+            earnings_warning=None,
+            reasoning=reasoning,
+        )
+
+    @staticmethod
+    def _make_advice(
+        *,
+        symbol: str,
+        vrp: VRPResult,
+        term_structure_ratio: float,
+        regime: str,
+        action: str,
+        reasoning: list[str],
+        confidence: float = 0,
+        earnings_warning: str | None = None,
+    ) -> PremiumAdvice:
+        """Build a non-SELL PremiumAdvice (BLOCKED / HOLD) with common fields."""
+        return PremiumAdvice(
+            symbol=symbol,
+            vrp_zscore=vrp.vrp_zscore,
+            iv_percentile=vrp.iv_percentile,
+            term_structure_ratio=term_structure_ratio,
+            regime=regime,
+            action=action,
+            strategy=None,
+            display_name=None,
+            confidence=confidence,
+            legs=[],
+            earnings_warning=earnings_warning,
+            reasoning=reasoning,
+        )
+
+    def _rank_strategies(
+        self,
+        candidates: list[PremiumStrategyDef],
+        vrp: VRPResult,
+        trend: str,
+    ) -> PremiumStrategyDef:
+        """Score and rank strategies. Higher score = better fit."""
+
+        def score(s: PremiumStrategyDef) -> float:
+            sc = 0.0
+            if s.risk_profile == "defined" and vrp.iv_percentile > 60:
+                sc += 10
+            if trend == "up" and s.direction == "bullish":
+                sc += 5
+            elif trend == "down" and s.direction == "bearish":
+                sc += 5
+            elif trend == "sideways" and s.direction == "neutral":
+                sc += 5
+            if len(s.leg_templates) >= 2:
+                sc += 3
+            return sc
+
+        return max(candidates, key=score)
+
+    def _compute_confidence(self, vrp: VRPResult, ts_ratio: float, regime: str) -> float:
+        result = 50.0
+        result += min(vrp.vrp_zscore * 12.5, 25.0)
+        if ts_ratio < 0.9:
+            result += 15.0
+        elif ts_ratio < 1.0:
+            result += 10.0
+        if regime == "R0":
+            result += 10.0
+        elif regime == "R1":
+            result += 5.0
+        return min(max(result, 0), 100)
+
+    def _build_reasoning(
+        self,
+        vrp: VRPResult,
+        ts_ratio: float,
+        regime: str,
+        trend: str,
+        strategy: PremiumStrategyDef,
+    ) -> list[str]:
+        reasons: list[str] = []
+        if vrp.vrp_zscore > 1.0:
+            reasons.append(f"VRP z-score {vrp.vrp_zscore:.2f} — strong edge for selling premium")
+        elif vrp.vrp_zscore > 0.5:
+            reasons.append(f"VRP z-score {vrp.vrp_zscore:.2f} — moderate edge")
+        else:
+            reasons.append(f"VRP z-score {vrp.vrp_zscore:.2f} — marginal edge")
+
+        if ts_ratio < 1.0:
+            reasons.append(f"Term structure in contango ({ts_ratio:.2f}) — supportive")
+        else:
+            reasons.append(f"Term structure flat ({ts_ratio:.2f}) — caution")
+
+        regime_names = {"R0": "Healthy Uptrend", "R1": "Choppy/Extended", "R2": "Risk-Off"}
+        reasons.append(
+            f"Regime {regime} ({regime_names.get(regime, 'Unknown')})"
+            f" — {strategy.direction} strategies preferred"
+        )
+        reasons.append(
+            f"IV at {vrp.iv_percentile:.0f}th percentile"
+            f" — {'elevated' if vrp.iv_percentile > 60 else 'normal'}"
+        )
+
+        return reasons

--- a/src/domain/services/advisor/strategy_registry.py
+++ b/src/domain/services/advisor/strategy_registry.py
@@ -1,0 +1,84 @@
+"""Extensible registry of premium-selling strategies."""
+
+from __future__ import annotations
+
+from src.domain.services.advisor.models import LegTemplate, PremiumStrategyDef
+
+STRATEGY_REGISTRY: list[PremiumStrategyDef] = [
+    PremiumStrategyDef(
+        name="short_put",
+        display_name="Short Put",
+        direction="bullish",
+        risk_profile="undefined",
+        regime_fit=frozenset({"R0", "R1"}),
+        leg_templates=(
+            LegTemplate(side="sell", option_type="put", delta_target=25, dte_target=35),
+        ),
+    ),
+    PremiumStrategyDef(
+        name="short_call",
+        display_name="Short Call",
+        direction="bearish",
+        risk_profile="undefined",
+        regime_fit=frozenset({"R1"}),
+        leg_templates=(
+            LegTemplate(side="sell", option_type="call", delta_target=25, dte_target=35),
+        ),
+    ),
+    PremiumStrategyDef(
+        name="bull_put_spread",
+        display_name="Bull Put Spread",
+        direction="bullish",
+        risk_profile="defined",
+        regime_fit=frozenset({"R0", "R1"}),
+        leg_templates=(
+            LegTemplate(side="sell", option_type="put", delta_target=25, dte_target=35),
+            LegTemplate(side="buy", option_type="put", delta_target=10, dte_target=35),
+        ),
+    ),
+    PremiumStrategyDef(
+        name="bear_call_spread",
+        display_name="Bear Call Spread",
+        direction="bearish",
+        risk_profile="defined",
+        regime_fit=frozenset({"R1", "R2"}),
+        leg_templates=(
+            LegTemplate(side="sell", option_type="call", delta_target=25, dte_target=35),
+            LegTemplate(side="buy", option_type="call", delta_target=10, dte_target=35),
+        ),
+    ),
+    PremiumStrategyDef(
+        name="iron_condor",
+        display_name="Iron Condor",
+        direction="neutral",
+        risk_profile="defined",
+        regime_fit=frozenset({"R0", "R1"}),
+        leg_templates=(
+            LegTemplate(side="sell", option_type="put", delta_target=20, dte_target=35),
+            LegTemplate(side="buy", option_type="put", delta_target=10, dte_target=35),
+            LegTemplate(side="sell", option_type="call", delta_target=20, dte_target=35),
+            LegTemplate(side="buy", option_type="call", delta_target=10, dte_target=35),
+        ),
+    ),
+    PremiumStrategyDef(
+        name="short_strangle",
+        display_name="Short Strangle",
+        direction="neutral",
+        risk_profile="undefined",
+        regime_fit=frozenset({"R0"}),
+        leg_templates=(
+            LegTemplate(side="sell", option_type="put", delta_target=20, dte_target=35),
+            LegTemplate(side="sell", option_type="call", delta_target=20, dte_target=35),
+        ),
+    ),
+]
+
+
+def get_strategies_for_regime(regime: str) -> list[PremiumStrategyDef]:
+    """Return strategies that fit the given regime."""
+    return [s for s in STRATEGY_REGISTRY if regime in s.regime_fit]
+
+
+def get_strategies_by_direction(direction: str) -> list[PremiumStrategyDef]:
+    """Return strategies matching the given direction."""
+    return [s for s in STRATEGY_REGISTRY if s.direction == direction]

--- a/src/domain/services/advisor/vrp.py
+++ b/src/domain/services/advisor/vrp.py
@@ -39,8 +39,24 @@ def compute_vrp(
     log_returns = np.log(underlying_close / underlying_close.shift(1)).dropna()
     rv30 = log_returns.rolling(rv_window).std() * math.sqrt(252) * 100
 
-    # Align series
-    vrp = vix_close - rv30
+    # Align by date — strip timezone info and normalize to date-only
+    def _to_date_index(idx: pd.Index) -> pd.Index:
+        if isinstance(idx, pd.DatetimeIndex):
+            bare = idx.tz_localize(None) if idx.tz is not None else idx
+            return bare.normalize()
+        return idx
+
+    if isinstance(vix_close.index, pd.DatetimeIndex) and isinstance(
+        rv30.index, pd.DatetimeIndex
+    ):
+        vix_by_date = vix_close.copy()
+        vix_by_date.index = _to_date_index(vix_close.index)
+        rv30_by_date = rv30.copy()
+        rv30_by_date.index = _to_date_index(rv30.index)
+        common = vix_by_date.index.intersection(rv30_by_date.index)
+        vrp = vix_by_date.loc[common] - rv30_by_date.loc[common]
+    else:
+        vrp = vix_close - rv30
     vrp = vrp.dropna()
 
     if len(vrp) == 0:
@@ -48,6 +64,25 @@ def compute_vrp(
 
     if len(vrp) < zscore_window:
         current_vrp = vrp.iloc[-1]
+        # Use whatever window we have (min 30) for z-score instead of returning 0
+        usable = len(vrp)
+        if usable >= 30:
+            vrp_mean_val = vrp.mean()
+            vrp_std_val = vrp.std()
+            zscore_partial = (
+                float((current_vrp - vrp_mean_val) / vrp_std_val) if vrp_std_val > 0 else 0.0
+            )
+            vix_tail = vix_close.iloc[-usable:]
+            iv_pctile_partial = float(
+                (vix_tail < vix_close.iloc[-1]).sum() / len(vix_tail) * 100
+            )
+            return VRPResult(
+                iv30=float(vix_close.iloc[-1]),
+                rv30=float(rv30.dropna().iloc[-1]) if len(rv30.dropna()) > 0 else 0.0,
+                vrp=float(current_vrp),
+                vrp_zscore=zscore_partial,
+                iv_percentile=iv_pctile_partial,
+            )
         return VRPResult(
             iv30=float(vix_close.iloc[-1]),
             rv30=float(rv30.dropna().iloc[-1]) if len(rv30.dropna()) > 0 else 0.0,

--- a/src/domain/services/advisor/vrp.py
+++ b/src/domain/services/advisor/vrp.py
@@ -1,0 +1,117 @@
+"""VRP (Volatility Risk Premium) calculation and BSM strike estimation."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+
+from src.domain.services.advisor.models import VRPResult
+
+# Fallback when data is insufficient
+_FALLBACK = VRPResult(iv30=0.0, rv30=0.0, vrp=0.0, vrp_zscore=0.0, iv_percentile=50.0)
+
+
+def compute_vrp(
+    vix_close: pd.Series,
+    underlying_close: pd.Series,
+    rv_window: int = 30,
+    zscore_window: int = 252,
+) -> VRPResult:
+    """Compute Volatility Risk Premium.
+
+    VRP = IV30 (VIX) - RV30 (realized vol from underlying), z-scored.
+    """
+    if vix_close is None or underlying_close is None:
+        return _FALLBACK
+    if len(vix_close) < rv_window + 2 or len(underlying_close) < rv_window + 2:
+        return VRPResult(
+            iv30=float(vix_close.iloc[-1]) if len(vix_close) > 0 else 0.0,
+            rv30=0.0,
+            vrp=0.0,
+            vrp_zscore=0.0,
+            iv_percentile=50.0,
+        )
+
+    # Realized vol: annualized std of log returns over rv_window
+    log_returns = np.log(underlying_close / underlying_close.shift(1)).dropna()
+    rv30 = log_returns.rolling(rv_window).std() * math.sqrt(252) * 100
+
+    # Align series
+    vrp = vix_close - rv30
+    vrp = vrp.dropna()
+
+    if len(vrp) == 0:
+        return _FALLBACK
+
+    if len(vrp) < zscore_window:
+        current_vrp = vrp.iloc[-1]
+        return VRPResult(
+            iv30=float(vix_close.iloc[-1]),
+            rv30=float(rv30.dropna().iloc[-1]) if len(rv30.dropna()) > 0 else 0.0,
+            vrp=float(current_vrp),
+            vrp_zscore=0.0,
+            iv_percentile=50.0,
+        )
+
+    vrp_mean = vrp.rolling(zscore_window).mean()
+    vrp_std = vrp.rolling(zscore_window).std()
+
+    current_vrp = vrp.iloc[-1]
+    std_val = vrp_std.iloc[-1]
+    zscore = (current_vrp - vrp_mean.iloc[-1]) / std_val if std_val > 0 else 0.0
+
+    # IV percentile: rank of current VIX in trailing window
+    vix_tail = vix_close.iloc[-zscore_window:]
+    iv_pctile = float((vix_tail < vix_close.iloc[-1]).sum() / len(vix_tail) * 100)
+
+    return VRPResult(
+        iv30=float(vix_close.iloc[-1]),
+        rv30=float(rv30.iloc[-1]),
+        vrp=float(current_vrp),
+        vrp_zscore=float(zscore),
+        iv_percentile=iv_pctile,
+    )
+
+
+def compute_term_structure(vix: float, vix3m: float) -> tuple[float, str]:
+    """Compute VIX/VIX3M term structure ratio and state."""
+    if vix3m <= 0:
+        return 1.0, "flat"
+
+    ratio = vix / vix3m
+
+    if ratio > 1.2:
+        state = "inverted"
+    elif ratio > 1.0:
+        state = "flat"
+    else:
+        state = "contango"
+
+    return round(ratio, 3), state
+
+
+def estimate_strike_bsm(
+    spot: float,
+    iv: float,
+    dte: int,
+    target_delta: float,
+    option_type: str,
+) -> float:
+    """Estimate strike price for a target delta using BSM approximation.
+
+    DTE is clamped to min 1 to avoid division by zero.
+    """
+    t = max(dte, 1) / 365.0
+    vol_sqrt_t = iv * math.sqrt(t)
+
+    if option_type == "put":
+        d1 = norm.ppf(1 - target_delta)
+        strike = spot * math.exp(-vol_sqrt_t * d1 + 0.5 * iv * iv * t)
+    else:
+        d1 = norm.ppf(target_delta)
+        strike = spot * math.exp(-vol_sqrt_t * d1 + 0.5 * iv * iv * t)
+
+    return round(strike, 2)

--- a/src/domain/services/advisor/vrp.py
+++ b/src/domain/services/advisor/vrp.py
@@ -46,9 +46,7 @@ def compute_vrp(
             return bare.normalize()
         return idx
 
-    if isinstance(vix_close.index, pd.DatetimeIndex) and isinstance(
-        rv30.index, pd.DatetimeIndex
-    ):
+    if isinstance(vix_close.index, pd.DatetimeIndex) and isinstance(rv30.index, pd.DatetimeIndex):
         vix_by_date = vix_close.copy()
         vix_by_date.index = _to_date_index(vix_close.index)
         rv30_by_date = rv30.copy()
@@ -73,9 +71,7 @@ def compute_vrp(
                 float((current_vrp - vrp_mean_val) / vrp_std_val) if vrp_std_val > 0 else 0.0
             )
             vix_tail = vix_close.iloc[-usable:]
-            iv_pctile_partial = float(
-                (vix_tail < vix_close.iloc[-1]).sum() / len(vix_tail) * 100
-            )
+            iv_pctile_partial = float((vix_tail < vix_close.iloc[-1]).sum() / len(vix_tail) * 100)
             return VRPResult(
                 iv30=float(vix_close.iloc[-1]),
                 rv30=float(rv30.dropna().iloc[-1]) if len(rv30.dropna()) > 0 else 0.0,

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -19,6 +19,7 @@ from src.domain.services.regime.universe_loader import load_universe
 from src.server.config import load_server_config
 from src.server.persistence import ServerPersistence
 from src.server.pipeline import ServerPipeline
+from src.server.routes.advisor import create_advisor_router
 from src.server.routes.monitor import create_monitor_router
 from src.server.routes.screeners import create_screeners_router
 from src.server.routes.symbols import create_symbols_router
@@ -218,6 +219,77 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         logger.info("Bootstrap: %d symbol/tf pairs warmed in %.1fs", warmed, _time.monotonic() - t0)
 
+        # ── Fetch VIX + VIX3M for advisor ──
+        from datetime import datetime, timedelta, timezone
+
+        import pandas as pd
+
+        vix_data: dict[str, Any] = {}
+        for vix_sym in ("^VIX", "^VIX3M"):
+            try:
+                from src.infrastructure.adapters.yahoo.historical_adapter import (
+                    YahooHistoricalAdapter,
+                )
+
+                yahoo = YahooHistoricalAdapter()
+                end = datetime.now(timezone.utc)
+                start = end - timedelta(days=400)
+                bars = await yahoo.fetch_bars(vix_sym, "1d", start, end)
+                if bars:
+                    vix_data[vix_sym] = pd.Series(
+                        [b.close for b in bars],
+                        index=pd.DatetimeIndex([b.timestamp for b in bars]),
+                    )
+                    logger.info("Fetched %d bars for %s", len(bars), vix_sym)
+            except Exception:
+                logger.debug("Failed to fetch %s for advisor", vix_sym)
+        app.state.vix_data = vix_data
+
+        # ── Create AdvisorService ──
+        from src.domain.services.advisor.advisor_service import AdvisorService
+
+        etf_syms = ["SPY", "QQQ", "IWM", "DIA", "GLD", "SLV", "TLT"]
+
+        # Build sector map from universe
+        sector_map: dict[str, str] = {}
+        if universe:
+            sector_names = getattr(universe, "sector_names", {})
+            for sym in all_symbols:
+                sector_etf = universe.get_sector_for_symbol(sym)
+                if sector_etf and sector_etf in sector_names:
+                    sector_map[sym] = sector_names[sector_etf]
+                elif sector_etf:
+                    sector_map[sym] = sector_etf
+
+        def _get_vix():
+            vd = getattr(app.state, "vix_data", {})
+            return vd.get("^VIX"), vd.get("^VIX3M")
+
+        def _get_underlying(sym):
+            engine = pipeline._indicator_engine
+            bar_deque = engine._history.get((sym, "1d"))
+            if bar_deque and len(bar_deque) > 0:
+                closes = pd.Series(
+                    [b["close"] for b in bar_deque],
+                    index=pd.DatetimeIndex([b["timestamp"] for b in bar_deque]),
+                )
+                return closes
+            return None
+
+        advisor_svc = AdvisorService(
+            get_regime_states=pipeline.get_regime_states,
+            get_indicator_states=pipeline._indicator_engine.get_all_indicator_states,
+            get_vix_data=_get_vix,
+            get_underlying_close=_get_underlying,
+            get_recent_signals=pipeline.get_recent_signals,
+            etf_symbols=etf_syms,
+            universe_symbols=all_symbols,
+            sector_map=sector_map,
+        )
+        app.state.advisor_service = advisor_svc
+        pipeline.set_advisor_service(advisor_svc)
+        logger.info("AdvisorService created and wired to pipeline")
+
     bootstrap_task = asyncio.create_task(_bootstrap_pipeline())
 
     # ── Periodic flush task ──
@@ -309,6 +381,7 @@ def create_app(config_path: str = "config/server.yaml") -> FastAPI:
     app.include_router(create_symbols_router())
     app.include_router(create_screeners_router())
     app.include_router(create_monitor_router(hub=hub_placeholder))
+    app.include_router(create_advisor_router())
 
     # SPA catch-all: serve index.html for any non-API, non-WS GET request.
     # This enables direct navigation to /signals, /monitor, etc.
@@ -355,6 +428,7 @@ def create_test_app() -> FastAPI:
     app.include_router(create_symbols_router())
     app.include_router(create_screeners_router())
     app.include_router(create_monitor_router(hub=hub))
+    app.include_router(create_advisor_router())
 
     dist_path = Path("web/dist")
     if dist_path.is_dir():

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -261,11 +261,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 elif sector_etf:
                     sector_map[sym] = sector_etf
 
-        def _get_vix():
+        def _get_vix() -> tuple[pd.Series | None, pd.Series | None]:
             vd = getattr(app.state, "vix_data", {})
             return vd.get("^VIX"), vd.get("^VIX3M")
 
-        def _get_underlying(sym):
+        def _get_underlying(sym: str) -> pd.Series | None:
             # Prefer Yahoo-fetched data (longer history for VRP z-score)
             vd = getattr(app.state, "vix_data", {})
             if sym in vd:

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -225,7 +225,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         import pandas as pd
 
         vix_data: dict[str, Any] = {}
-        for vix_sym in ("^VIX", "^VIX3M"):
+        for vix_sym in ("^VIX", "^VIX3M", "SPY"):
             try:
                 from src.infrastructure.adapters.yahoo.historical_adapter import (
                     YahooHistoricalAdapter,
@@ -266,6 +266,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             return vd.get("^VIX"), vd.get("^VIX3M")
 
         def _get_underlying(sym):
+            # Prefer Yahoo-fetched data (longer history for VRP z-score)
+            vd = getattr(app.state, "vix_data", {})
+            if sym in vd:
+                return vd[sym]
+            # Fall back to indicator engine bar history
             engine = pipeline._indicator_engine
             bar_deque = engine._history.get((sym, "1d"))
             if bar_deque and len(bar_deque) > 0:

--- a/src/server/pipeline.py
+++ b/src/server/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from threading import RLock
 from typing import Any, Coroutine, Dict, List, Optional
 
 from src.domain.events.domain_events import (
@@ -66,6 +67,12 @@ class ServerPipeline:
         # Async event loop reference (set on start)
         self._loop: Optional[asyncio.AbstractEventLoop] = None
 
+        # Signal buffer for advisor (maps symbol -> list of recent signal dicts)
+        # Replaces broken get_evaluation_history() approach
+        self._signal_buffer: Dict[str, List[Dict[str, Any]]] = {}
+        self._signal_buffer_lock = RLock()
+        self._advisor_service: Any = None
+
     async def start(self) -> None:
         """Start the pipeline — subscribe to events and start engines."""
         if self._started:
@@ -103,6 +110,21 @@ class ServerPipeline:
         """Feed a tick into all BarAggregators."""
         for agg in self._aggregators.values():
             agg.on_tick(tick)
+
+    def set_advisor_service(self, svc: Any) -> None:
+        """Set the advisor service (called after bootstrap)."""
+        self._advisor_service = svc
+
+    def get_recent_signals(self, symbol: str | None = None) -> list[dict]:
+        """Get recent signals for advisor consumption.
+
+        Signals are collected from TradingSignalEvent with direction mapped
+        from SignalDirection (buy/sell/alert) to advisor labels (bullish/bearish/neutral).
+        """
+        with self._signal_buffer_lock:
+            if symbol:
+                return list(self._signal_buffer.get(symbol, []))
+            return [sig for sigs in self._signal_buffer.values() for sig in sigs]
 
     def inject_history(self, symbol: str, tf: str, bars: list) -> None:
         """Inject historical bars for indicator warmup."""
@@ -144,7 +166,7 @@ class ServerPipeline:
     # ── Event handlers (bridge events → WS hub) ────────────
 
     def _on_bar_close(self, event: BarCloseEvent) -> None:
-        """Forward bar close to WebSocket hub."""
+        """Forward bar close to WebSocket hub. Trigger advisor on daily close."""
         bar_dict = {
             "o": event.open,
             "h": event.high,
@@ -155,6 +177,20 @@ class ServerPipeline:
         }
         self._schedule_async(self._hub.broadcast_bar(event.symbol, event.timeframe, bar_dict))
 
+        # Trigger advisor recomputation on daily bar close, offloaded to thread
+        if event.timeframe == "1d" and self._advisor_service:
+            import concurrent.futures
+
+            def _compute_and_broadcast():
+                try:
+                    advice = self._advisor_service.compute_all()
+                    serialized = _serialize_advice(advice)
+                    self._schedule_async(self._hub.broadcast_advisor(serialized))
+                except Exception:
+                    logger.exception("Advisor broadcast failed")
+
+            concurrent.futures.ThreadPoolExecutor(max_workers=1).submit(_compute_and_broadcast)
+
     def _on_indicator_update(self, event: IndicatorUpdateEvent) -> None:
         """Forward indicator update to WebSocket hub."""
         self._schedule_async(
@@ -164,7 +200,7 @@ class ServerPipeline:
         )
 
     def _on_trading_signal(self, event: TradingSignalEvent) -> None:
-        """Forward trading signal to WebSocket hub."""
+        """Forward trading signal to WebSocket hub + buffer for advisor."""
         signal_dict = {
             "rule": event.indicator,
             "direction": event.direction,
@@ -173,6 +209,21 @@ class ServerPipeline:
         }
         self._schedule_async(self._hub.broadcast_signal(event.symbol, signal_dict))
 
+        # Buffer for advisor — map direction for advisor consumption
+        direction_map = {"buy": "bullish", "sell": "bearish", "alert": "neutral"}
+        advisor_sig = {
+            "rule": event.indicator,
+            "direction": direction_map.get(event.direction, "neutral"),
+            "strength": event.strength,
+        }
+        with self._signal_buffer_lock:
+            if event.symbol not in self._signal_buffer:
+                self._signal_buffer[event.symbol] = []
+            self._signal_buffer[event.symbol].append(advisor_sig)
+            # Keep only latest 50 signals per symbol
+            if len(self._signal_buffer[event.symbol]) > 50:
+                self._signal_buffer[event.symbol] = self._signal_buffer[event.symbol][-50:]
+
     def _schedule_async(self, coro: Coroutine[Any, Any, Any]) -> None:
         """Schedule a coroutine on the event loop (thread-safe)."""
         if self._loop and self._loop.is_running():
@@ -180,3 +231,14 @@ class ServerPipeline:
         else:
             # No loop available — close the coroutine to avoid warnings
             coro.close()
+
+
+def _serialize_advice(obj: Any) -> Any:
+    """Recursively convert dataclasses to dicts for JSON serialization."""
+    if hasattr(obj, "__dataclass_fields__"):
+        return {k: _serialize_advice(v) for k, v in obj.__dict__.items()}
+    if isinstance(obj, dict):
+        return {k: _serialize_advice(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize_advice(v) for v in obj]
+    return obj

--- a/src/server/pipeline.py
+++ b/src/server/pipeline.py
@@ -181,7 +181,7 @@ class ServerPipeline:
         if event.timeframe == "1d" and self._advisor_service:
             import concurrent.futures
 
-            def _compute_and_broadcast():
+            def _compute_and_broadcast() -> None:
                 try:
                     advice = self._advisor_service.compute_all()
                     serialized = _serialize_advice(advice)

--- a/src/server/routes/advisor.py
+++ b/src/server/routes/advisor.py
@@ -1,8 +1,8 @@
 """REST routes for /api/advisor (trading advisor).
 
-Follows the factory function pattern from other route modules
-(screeners.py, monitor.py, symbols.py): dependencies injected via
-constructor args, NOT via app.state.
+Follows the factory function pattern from other route modules.
+At request time, prefers ``request.app.state.advisor_service`` (set by
+lifespan bootstrap) over the constructor arg (used in tests).
 """
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 logger = logging.getLogger(__name__)
 
@@ -20,14 +20,16 @@ def create_advisor_router(advisor_service: Optional[Any] = None) -> APIRouter:
 
     @router.get("/advisor")
     async def get_all_advice(
+        request: Request,
         sector: str = Query(default=None),
         action: str = Query(default=None),
     ) -> dict[str, Any]:
         """Get advisor recommendations for all symbols."""
-        if advisor_service is None:
+        svc = getattr(request.app.state, "advisor_service", None) or advisor_service
+        if svc is None:
             raise HTTPException(status_code=503, detail="Advisor service not available")
 
-        result = advisor_service.compute_all()
+        result = svc.compute_all()
         result = _serialize(result)
 
         if sector:
@@ -38,12 +40,13 @@ def create_advisor_router(advisor_service: Optional[Any] = None) -> APIRouter:
         return result
 
     @router.get("/advisor/{symbol}")
-    async def get_symbol_advice(symbol: str) -> dict[str, Any]:
+    async def get_symbol_advice(request: Request, symbol: str) -> dict[str, Any]:
         """Get advisor recommendation for a single symbol."""
-        if advisor_service is None:
+        svc = getattr(request.app.state, "advisor_service", None) or advisor_service
+        if svc is None:
             raise HTTPException(status_code=503, detail="Advisor service not available")
 
-        result = advisor_service.compute_symbol(symbol.upper())
+        result = svc.compute_symbol(symbol.upper())
         return _serialize(result)
 
     return router

--- a/src/server/routes/advisor.py
+++ b/src/server/routes/advisor.py
@@ -37,7 +37,7 @@ def create_advisor_router(advisor_service: Optional[Any] = None) -> APIRouter:
         if action:
             result["equity"] = [e for e in result["equity"] if e.get("action") == action]
 
-        return result
+        return dict(result)
 
     @router.get("/advisor/{symbol}")
     async def get_symbol_advice(request: Request, symbol: str) -> dict[str, Any]:
@@ -47,7 +47,7 @@ def create_advisor_router(advisor_service: Optional[Any] = None) -> APIRouter:
             raise HTTPException(status_code=503, detail="Advisor service not available")
 
         result = svc.compute_symbol(symbol.upper())
-        return _serialize(result)
+        return dict(_serialize(result))
 
     return router
 

--- a/src/server/routes/advisor.py
+++ b/src/server/routes/advisor.py
@@ -1,0 +1,60 @@
+"""REST routes for /api/advisor (trading advisor).
+
+Follows the factory function pattern from other route modules
+(screeners.py, monitor.py, symbols.py): dependencies injected via
+constructor args, NOT via app.state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+logger = logging.getLogger(__name__)
+
+
+def create_advisor_router(advisor_service: Optional[Any] = None) -> APIRouter:
+    router = APIRouter(prefix="/api")
+
+    @router.get("/advisor")
+    async def get_all_advice(
+        sector: str = Query(default=None),
+        action: str = Query(default=None),
+    ) -> dict[str, Any]:
+        """Get advisor recommendations for all symbols."""
+        if advisor_service is None:
+            raise HTTPException(status_code=503, detail="Advisor service not available")
+
+        result = advisor_service.compute_all()
+        result = _serialize(result)
+
+        if sector:
+            result["equity"] = [e for e in result["equity"] if e.get("sector") == sector]
+        if action:
+            result["equity"] = [e for e in result["equity"] if e.get("action") == action]
+
+        return result
+
+    @router.get("/advisor/{symbol}")
+    async def get_symbol_advice(symbol: str) -> dict[str, Any]:
+        """Get advisor recommendation for a single symbol."""
+        if advisor_service is None:
+            raise HTTPException(status_code=503, detail="Advisor service not available")
+
+        result = advisor_service.compute_symbol(symbol.upper())
+        return _serialize(result)
+
+    return router
+
+
+def _serialize(obj: Any) -> Any:
+    """Recursively convert dataclasses to dicts."""
+    if hasattr(obj, "__dataclass_fields__"):
+        return {k: _serialize(v) for k, v in obj.__dict__.items()}
+    if isinstance(obj, dict):
+        return {k: _serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize(v) for v in obj]
+    return obj

--- a/src/server/ws_hub.py
+++ b/src/server/ws_hub.py
@@ -86,6 +86,18 @@ class WebSocketHub:
         for ws in dead:
             self.disconnect(ws)
 
+    async def broadcast_advisor(self, advice: dict) -> None:
+        """Send advisor update to ALL connected clients."""
+        msg = {"type": "advisor", **advice}
+        dead: list = []
+        for ws in list(self._clients):
+            try:
+                await ws.send_json(msg)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self.disconnect(ws)
+
     # ── Internal ────────────────────────────────────────────
 
     async def _send_to_symbol_subscribers(self, symbol: str, msg: dict) -> None:

--- a/tests/unit/server/test_routes_advisor.py
+++ b/tests/unit/server/test_routes_advisor.py
@@ -8,7 +8,6 @@ from fastapi.testclient import TestClient
 from src.domain.services.advisor.models import (
     EquityAdvice,
     MarketContext,
-    PremiumAdvice,
 )
 from src.server.routes.advisor import create_advisor_router
 

--- a/tests/unit/server/test_routes_advisor.py
+++ b/tests/unit/server/test_routes_advisor.py
@@ -1,0 +1,181 @@
+"""Tests for /api/advisor routes."""
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.domain.services.advisor.models import (
+    EquityAdvice,
+    MarketContext,
+    PremiumAdvice,
+)
+from src.server.routes.advisor import create_advisor_router
+
+
+def _make_mock_service():
+    """Create a mock AdvisorService."""
+    svc = MagicMock()
+    svc.compute_all.return_value = {
+        "market_context": MarketContext(
+            regime="R0",
+            regime_name="Healthy Uptrend",
+            regime_confidence=75,
+            vix=18.5,
+            vix_percentile=42,
+            vrp_zscore=0.82,
+            term_structure_ratio=0.92,
+            term_structure_state="contango",
+            timestamp="2026-02-27T14:30:00Z",
+        ),
+        "premium": [],
+        "equity": [],
+        "timestamp": "2026-02-27T14:30:00Z",
+    }
+    svc.compute_symbol.return_value = {
+        "market_context": svc.compute_all.return_value["market_context"],
+        "equity": EquityAdvice(
+            symbol="AAPL",
+            sector="Technology",
+            action="BUY",
+            confidence=72,
+            regime="R0",
+            signal_summary={"bullish": 3, "bearish": 1, "neutral": 0},
+            top_signals=[],
+            trend_pulse=None,
+            key_levels={},
+            reasoning=["3 bullish signals"],
+        ),
+        "timestamp": "2026-02-27T14:30:00Z",
+    }
+    return svc
+
+
+def _make_app(advisor_service=None):
+    app = FastAPI()
+    app.include_router(create_advisor_router(advisor_service=advisor_service))
+    return TestClient(app)
+
+
+class TestAdvisorListEndpoint:
+    def test_returns_200(self):
+        svc = _make_mock_service()
+        client = _make_app(advisor_service=svc)
+        resp = client.get("/api/advisor")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "market_context" in data
+        assert "premium" in data
+        assert "equity" in data
+
+    def test_503_when_no_service(self):
+        client = _make_app()
+        resp = client.get("/api/advisor")
+        assert resp.status_code == 503
+
+    def test_market_context_serialized(self):
+        svc = _make_mock_service()
+        client = _make_app(advisor_service=svc)
+        resp = client.get("/api/advisor")
+        ctx = resp.json()["market_context"]
+        assert ctx["regime"] == "R0"
+        assert ctx["vix"] == 18.5
+        assert ctx["term_structure_state"] == "contango"
+
+    def test_sector_filter(self):
+        svc = _make_mock_service()
+        svc.compute_all.return_value["equity"] = [
+            EquityAdvice(
+                symbol="AAPL",
+                sector="Technology",
+                action="BUY",
+                confidence=72,
+                regime="R0",
+                signal_summary={"bullish": 3, "bearish": 1, "neutral": 0},
+                top_signals=[],
+                trend_pulse=None,
+                key_levels={},
+                reasoning=["bullish"],
+            ),
+            EquityAdvice(
+                symbol="XOM",
+                sector="Energy",
+                action="HOLD",
+                confidence=50,
+                regime="R0",
+                signal_summary={"bullish": 1, "bearish": 1, "neutral": 2},
+                top_signals=[],
+                trend_pulse=None,
+                key_levels={},
+                reasoning=["neutral"],
+            ),
+        ]
+        client = _make_app(advisor_service=svc)
+        resp = client.get("/api/advisor?sector=Technology")
+        data = resp.json()
+        assert len(data["equity"]) == 1
+        assert data["equity"][0]["symbol"] == "AAPL"
+
+    def test_action_filter(self):
+        svc = _make_mock_service()
+        svc.compute_all.return_value["equity"] = [
+            EquityAdvice(
+                symbol="AAPL",
+                sector="Technology",
+                action="BUY",
+                confidence=72,
+                regime="R0",
+                signal_summary={"bullish": 3, "bearish": 1, "neutral": 0},
+                top_signals=[],
+                trend_pulse=None,
+                key_levels={},
+                reasoning=["bullish"],
+            ),
+            EquityAdvice(
+                symbol="XOM",
+                sector="Energy",
+                action="HOLD",
+                confidence=50,
+                regime="R0",
+                signal_summary={"bullish": 1, "bearish": 1, "neutral": 2},
+                top_signals=[],
+                trend_pulse=None,
+                key_levels={},
+                reasoning=["neutral"],
+            ),
+        ]
+        client = _make_app(advisor_service=svc)
+        resp = client.get("/api/advisor?action=HOLD")
+        data = resp.json()
+        assert len(data["equity"]) == 1
+        assert data["equity"][0]["symbol"] == "XOM"
+
+
+class TestAdvisorSymbolEndpoint:
+    def test_returns_200(self):
+        svc = _make_mock_service()
+        client = _make_app(advisor_service=svc)
+        resp = client.get("/api/advisor/AAPL")
+        assert resp.status_code == 200
+
+    def test_uppercases_symbol(self):
+        svc = _make_mock_service()
+        client = _make_app(advisor_service=svc)
+        client.get("/api/advisor/aapl")
+        svc.compute_symbol.assert_called_once_with("AAPL")
+
+    def test_503_when_no_service(self):
+        client = _make_app()
+        resp = client.get("/api/advisor/AAPL")
+        assert resp.status_code == 503
+
+    def test_equity_serialized(self):
+        svc = _make_mock_service()
+        client = _make_app(advisor_service=svc)
+        resp = client.get("/api/advisor/AAPL")
+        data = resp.json()
+        eq = data["equity"]
+        assert eq["symbol"] == "AAPL"
+        assert eq["action"] == "BUY"
+        assert eq["confidence"] == 72
+        assert eq["reasoning"] == ["3 bullish signals"]

--- a/tests/unit/services/advisor/test_advisor_service.py
+++ b/tests/unit/services/advisor/test_advisor_service.py
@@ -1,0 +1,100 @@
+"""Tests for AdvisorService orchestrator."""
+
+import pandas as pd
+
+from src.domain.services.advisor.advisor_service import AdvisorService
+
+
+def _make_vix_series(val=18.0, n=300):
+    """Create a mock VIX pandas Series."""
+    import numpy as np
+
+    return pd.Series(np.full(n, val), index=pd.date_range("2025-06-01", periods=n, freq="B"))
+
+
+def _make_underlying_series(val=500.0, n=300):
+    """Create a mock underlying close pandas Series."""
+    import numpy as np
+
+    np.random.seed(42)
+    returns = np.random.normal(0.0003, 0.01, n)
+    prices = val * (1 + pd.Series(returns)).cumprod()
+    prices.index = pd.date_range("2025-06-01", periods=n, freq="B")
+    return prices
+
+
+def _make_advisor_service(
+    regime_states=None,
+    indicator_states=None,
+    vix_val=18.0,
+    vix3m_val=20.0,
+    recent_signals=None,
+    etf_symbols=None,
+    universe_symbols=None,
+    sector_map=None,
+):
+    """Create AdvisorService with mock dependencies."""
+    vix_series = _make_vix_series(vix_val) if vix_val else None
+    vix3m_series = _make_vix_series(vix3m_val) if vix3m_val else None
+    underlying = _make_underlying_series()
+
+    return AdvisorService(
+        get_regime_states=lambda tf="1d": regime_states or {},
+        get_indicator_states=lambda sym=None, tf=None: indicator_states or {},
+        get_vix_data=lambda: (vix_series, vix3m_series),
+        get_underlying_close=lambda sym: underlying,
+        get_recent_signals=lambda sym=None: (recent_signals or {}).get(sym, []) if sym else [],
+        etf_symbols=etf_symbols or ["QQQ", "SPY"],
+        universe_symbols=universe_symbols or ["AAPL", "NVDA"],
+        sector_map=sector_map or {"AAPL": "Technology", "NVDA": "Semiconductors"},
+    )
+
+
+class TestAdvisorServiceBasic:
+    def test_compute_all_returns_structure(self):
+        svc = _make_advisor_service()
+        result = svc.compute_all()
+        assert "market_context" in result
+        assert "premium" in result
+        assert "equity" in result
+        assert "timestamp" in result
+
+    def test_compute_symbol_returns_structure(self):
+        svc = _make_advisor_service(universe_symbols=["AAPL"])
+        result = svc.compute_symbol("AAPL")
+        assert "equity" in result
+        assert result["equity"].symbol == "AAPL"
+
+    def test_premium_only_for_etfs(self):
+        svc = _make_advisor_service(
+            etf_symbols=["QQQ"],
+            universe_symbols=["AAPL"],
+        )
+        result = svc.compute_all()
+        premium_syms = {a.symbol for a in result["premium"]}
+        equity_syms = {a.symbol for a in result["equity"]}
+        assert "QQQ" in premium_syms
+        assert "AAPL" not in premium_syms
+        assert "AAPL" in equity_syms
+
+    def test_missing_vix_returns_defaults(self):
+        """No VIX data should not crash."""
+        svc = _make_advisor_service(vix_val=None, vix3m_val=None)
+        result = svc.compute_all()
+        assert result["market_context"].vix == 0
+
+    def test_compute_all_with_signals(self):
+        """Verify signals are passed through to equity advisor."""
+        svc = _make_advisor_service(
+            universe_symbols=["AAPL"],
+            recent_signals={
+                "AAPL": [
+                    {"rule": "supertrend_bullish", "direction": "bullish", "strength": 75},
+                    {"rule": "ema_golden_cross", "direction": "bullish", "strength": 65},
+                ],
+            },
+        )
+        result = svc.compute_all()
+        aapl = [e for e in result["equity"] if e.symbol == "AAPL"]
+        assert len(aapl) == 1
+        assert aapl[0].action in ("BUY", "STRONG_BUY", "HOLD")

--- a/tests/unit/services/advisor/test_equity_advisor.py
+++ b/tests/unit/services/advisor/test_equity_advisor.py
@@ -1,0 +1,99 @@
+"""Tests for equity signal synthesis."""
+
+from src.domain.services.advisor.equity_advisor import EquityAdvisor
+
+
+def _signal(rule, direction, strength):
+    """Create a signal dict. Direction uses "bullish"/"bearish"/"neutral"."""
+    return {"rule": rule, "direction": direction, "strength": strength}
+
+
+class TestEquityAdvisor:
+    def setup_method(self):
+        self.advisor = EquityAdvisor()
+
+    def test_strong_buy_many_bullish(self):
+        signals = [
+            _signal("trend_pulse_entry", "bullish", 85),
+            _signal("dual_macd_dip_buy", "bullish", 80),
+            _signal("supertrend_bullish", "bullish", 75),
+            _signal("ema_golden_cross", "bullish", 65),
+            _signal("volume_spike", "bullish", 60),
+        ]
+        advice = self.advisor.synthesize("NVDA", "Semiconductors", signals, "R0", {})
+        assert advice.action in ("STRONG_BUY", "BUY")
+        assert advice.confidence > 60
+
+    def test_strong_sell_many_bearish(self):
+        signals = [
+            _signal("trend_pulse_sell", "bearish", 80),
+            _signal("macd_bearish_cross", "bearish", 60),
+            _signal("supertrend_bearish", "bearish", 75),
+            _signal("ema_death_cross", "bearish", 65),
+        ]
+        advice = self.advisor.synthesize("GME", "Speculative", signals, "R2", {})
+        assert advice.action in ("STRONG_SELL", "SELL")
+
+    def test_hold_mixed_signals(self):
+        signals = [
+            _signal("supertrend_bullish", "bullish", 75),
+            _signal("macd_bearish_cross", "bearish", 60),
+        ]
+        advice = self.advisor.synthesize("AAPL", "Technology", signals, "R1", {})
+        assert advice.action == "HOLD"
+
+    def test_hold_no_signals(self):
+        advice = self.advisor.synthesize("AAPL", "Technology", [], "R0", {})
+        assert advice.action == "HOLD"
+        assert advice.confidence < 20
+
+    def test_r2_blocks_buy(self):
+        signals = [
+            _signal("supertrend_bullish", "bullish", 75),
+            _signal("ema_golden_cross", "bullish", 65),
+        ]
+        advice = self.advisor.synthesize("AAPL", "Technology", signals, "R2", {})
+        assert advice.action in ("HOLD", "SELL", "STRONG_SELL")
+
+    def test_r2_amplifies_sell(self):
+        signals = [
+            _signal("supertrend_bearish", "bearish", 75),
+            _signal("macd_bearish_cross", "bearish", 60),
+        ]
+        r0_advice = self.advisor.synthesize("AAPL", "Technology", signals, "R0", {})
+        r2_advice = self.advisor.synthesize("AAPL", "Technology", signals, "R2", {})
+        assert r2_advice.confidence >= r0_advice.confidence
+
+    def test_trend_pulse_weighted_higher(self):
+        tp_signals = [_signal("trend_pulse_entry", "bullish", 70)]
+        other_signals = [_signal("ema_golden_cross", "bullish", 70)]
+        tp_advice = self.advisor.synthesize("AAPL", "Technology", tp_signals, "R0", {})
+        other_advice = self.advisor.synthesize("AAPL", "Technology", other_signals, "R0", {})
+        assert tp_advice.confidence >= other_advice.confidence
+
+    def test_single_signal_not_strong(self):
+        """Single signal should not produce STRONG_BUY/STRONG_SELL."""
+        signals = [_signal("supertrend_bearish", "bearish", 80)]
+        advice = self.advisor.synthesize("AAPL", "Technology", signals, "R0", {})
+        assert advice.action in ("HOLD", "SELL")  # NOT STRONG_SELL
+
+    def test_top_signals_limited_to_3(self):
+        signals = [_signal(f"rule_{i}", "bullish", 80 - i) for i in range(10)]
+        advice = self.advisor.synthesize("AAPL", "Technology", signals, "R0", {})
+        assert len(advice.top_signals) <= 3
+
+    def test_signal_summary_counts(self):
+        signals = [
+            _signal("a", "bullish", 70),
+            _signal("b", "bullish", 60),
+            _signal("c", "bearish", 50),
+        ]
+        advice = self.advisor.synthesize("AAPL", "Technology", signals, "R0", {})
+        assert advice.signal_summary["bullish"] == 2
+        assert advice.signal_summary["bearish"] == 1
+
+    def test_works_for_full_universe(self):
+        signals = [_signal("rsi_oversold_exit", "bullish", 70)]
+        for sym in ("AAPL", "RIVN", "XOM", "NEE", "SPY"):
+            advice = self.advisor.synthesize(sym, "Test", signals, "R0", {})
+            assert advice.symbol == sym

--- a/tests/unit/services/advisor/test_models.py
+++ b/tests/unit/services/advisor/test_models.py
@@ -1,0 +1,123 @@
+"""Tests for advisor domain models."""
+
+import pytest
+
+from src.domain.services.advisor.models import (
+    EquityAdvice,
+    LegSpec,
+    LegTemplate,
+    MarketContext,
+    PremiumAdvice,
+    PremiumStrategyDef,
+    VRPResult,
+)
+
+
+class TestVRPResult:
+    def test_creation(self):
+        vrp = VRPResult(iv30=18.5, rv30=15.2, vrp=3.3, vrp_zscore=0.82, iv_percentile=55.0)
+        assert vrp.iv30 == 18.5
+        assert vrp.vrp == pytest.approx(3.3)
+
+    def test_is_negative(self):
+        vrp = VRPResult(iv30=14.0, rv30=18.0, vrp=-4.0, vrp_zscore=-1.2, iv_percentile=30.0)
+        assert vrp.vrp < 0
+
+
+class TestPremiumStrategyDef:
+    def test_regime_fit_filtering(self):
+        strat = PremiumStrategyDef(
+            name="short_put",
+            display_name="Short Put",
+            direction="bullish",
+            risk_profile="undefined",
+            regime_fit=frozenset({"R0", "R1"}),
+            leg_templates=(
+                LegTemplate(side="sell", option_type="put", delta_target=25, dte_target=35),
+            ),
+        )
+        assert "R0" in strat.regime_fit
+        assert "R2" not in strat.regime_fit
+
+
+class TestLegSpec:
+    def test_creation(self):
+        leg = LegSpec(
+            side="sell",
+            option_type="put",
+            target_delta=25,
+            target_dte=35,
+            estimated_strike=485.0,
+        )
+        assert leg.estimated_strike == 485.0
+
+
+class TestPremiumAdvice:
+    def test_blocked(self):
+        advice = PremiumAdvice(
+            symbol="QQQ",
+            action="BLOCKED",
+            strategy=None,
+            display_name=None,
+            confidence=0,
+            legs=[],
+            vrp_zscore=-0.5,
+            iv_percentile=30.0,
+            term_structure_ratio=1.3,
+            regime="R2",
+            earnings_warning=None,
+            reasoning=["Risk-off regime"],
+        )
+        assert advice.action == "BLOCKED"
+        assert advice.strategy is None
+
+    def test_sell(self):
+        advice = PremiumAdvice(
+            symbol="SPY",
+            action="SELL",
+            strategy="short_put",
+            display_name="Short Put",
+            confidence=78,
+            legs=[LegSpec("sell", "put", 25, 35, 485.0)],
+            vrp_zscore=0.82,
+            iv_percentile=55.0,
+            term_structure_ratio=0.92,
+            regime="R0",
+            earnings_warning=None,
+            reasoning=["VRP elevated"],
+        )
+        assert advice.action == "SELL"
+        assert len(advice.legs) == 1
+
+
+class TestEquityAdvice:
+    def test_creation(self):
+        advice = EquityAdvice(
+            symbol="AAPL",
+            sector="Technology",
+            action="BUY",
+            confidence=72,
+            regime="R0",
+            signal_summary={"bullish": 5, "bearish": 2, "neutral": 1},
+            top_signals=[],
+            trend_pulse=None,
+            key_levels={"support": 180.0, "resistance": 195.0},
+            reasoning=["5 bullish signals active"],
+        )
+        assert advice.action == "BUY"
+
+
+class TestMarketContext:
+    def test_contango(self):
+        ctx = MarketContext(
+            regime="R0",
+            regime_name="Healthy Uptrend",
+            regime_confidence=75.0,
+            vix=18.5,
+            vix_percentile=42.0,
+            vrp_zscore=0.82,
+            term_structure_ratio=0.92,
+            term_structure_state="contango",
+            timestamp="2026-02-27T14:30:00Z",
+        )
+        assert ctx.term_structure_state == "contango"

--- a/tests/unit/services/advisor/test_premium_advisor.py
+++ b/tests/unit/services/advisor/test_premium_advisor.py
@@ -1,0 +1,110 @@
+"""Tests for premium strategy selection logic."""
+
+import pytest
+
+from src.domain.services.advisor.models import VRPResult
+from src.domain.services.advisor.premium_advisor import PremiumAdvisor
+
+
+@pytest.fixture
+def advisor():
+    return PremiumAdvisor()
+
+
+@pytest.fixture
+def high_vrp():
+    return VRPResult(iv30=22.0, rv30=14.0, vrp=8.0, vrp_zscore=1.2, iv_percentile=72.0)
+
+
+@pytest.fixture
+def normal_vrp():
+    return VRPResult(iv30=18.0, rv30=15.0, vrp=3.0, vrp_zscore=0.6, iv_percentile=45.0)
+
+
+@pytest.fixture
+def negative_vrp():
+    return VRPResult(iv30=14.0, rv30=20.0, vrp=-6.0, vrp_zscore=-1.5, iv_percentile=20.0)
+
+
+class TestPremiumAdvisorBlocking:
+    def test_blocked_r2_regime(self, advisor, high_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R2", high_vrp, 0.9, None, "up")
+        # R2 allows defined-risk bearish only — since trend is "up", no bearish candidates
+        assert advice.action in ("BLOCKED", "HOLD")
+
+    def test_blocked_r3_regime(self, advisor, high_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R3", high_vrp, 0.9, None, "up")
+        assert advice.action == "BLOCKED"
+
+    def test_blocked_negative_vrp(self, advisor, negative_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", negative_vrp, 0.9, None, "up")
+        assert advice.action == "BLOCKED"
+        assert "realized" in advice.reasoning[0].lower() or "vrp" in advice.reasoning[0].lower()
+
+    def test_blocked_inverted_term_structure(self, advisor, high_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", high_vrp, 1.3, None, "up")
+        assert advice.action == "BLOCKED"
+
+    def test_hold_near_earnings(self, advisor, high_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", high_vrp, 0.9, 2, "up")
+        assert advice.action == "HOLD"
+        assert "earnings" in advice.reasoning[0].lower()
+
+
+class TestPremiumAdvisorSell:
+    def test_sell_bullish_r0(self, advisor, normal_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", normal_vrp, 0.9, None, "up")
+        assert advice.action == "SELL"
+        assert advice.strategy is not None
+        assert len(advice.legs) >= 1
+
+    def test_bullish_strategy_in_uptrend(self, advisor, normal_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", normal_vrp, 0.9, None, "up")
+        assert advice.strategy in ("short_put", "bull_put_spread", "short_strangle", "iron_condor")
+
+    def test_bearish_strategy_in_downtrend(self, advisor, normal_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R1", normal_vrp, 0.9, None, "down")
+        assert advice.strategy in ("short_call", "bear_call_spread", "iron_condor")
+
+    def test_r2_downtrend_defined_risk_only(self, advisor, normal_vrp):
+        """R2 downtrend should only recommend defined-risk bearish (bear_call_spread)."""
+        advice = advisor.advise("QQQ", 500.0, "R2", normal_vrp, 0.9, None, "down")
+        if advice.action == "SELL":
+            assert advice.strategy == "bear_call_spread"
+
+    def test_defined_risk_in_high_iv(self, advisor):
+        """When IV percentile > 75, prefer defined-risk strategies."""
+        high_iv_vrp = VRPResult(iv30=28.0, rv30=18.0, vrp=10.0, vrp_zscore=1.5, iv_percentile=85.0)
+        advice = advisor.advise("QQQ", 500.0, "R0", high_iv_vrp, 0.9, None, "up")
+        assert advice.action == "SELL"
+        if advice.strategy == "bull_put_spread":
+            assert len(advice.legs) == 2
+
+    def test_high_vrp_closer_delta(self, advisor, high_vrp):
+        """High VRP z-score -> sell closer to money (higher delta)."""
+        advice = advisor.advise("QQQ", 500.0, "R0", high_vrp, 0.9, None, "up")
+        sell_legs = [leg for leg in advice.legs if leg.side == "sell"]
+        assert sell_legs[0].target_delta >= 30
+
+    def test_delta_capped_at_40(self, advisor):
+        """Delta should never exceed 40 for sell legs."""
+        extreme_vrp = VRPResult(iv30=35.0, rv30=15.0, vrp=20.0, vrp_zscore=3.0, iv_percentile=95.0)
+        advice = advisor.advise("QQQ", 500.0, "R0", extreme_vrp, 0.9, None, "up")
+        for leg in advice.legs:
+            if leg.side == "sell":
+                assert leg.target_delta <= 40
+
+    def test_legs_have_estimated_strikes(self, advisor, normal_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", normal_vrp, 0.9, None, "up")
+        for leg in advice.legs:
+            assert leg.estimated_strike > 0
+
+    def test_confidence_range(self, advisor, normal_vrp):
+        advice = advisor.advise("QQQ", 500.0, "R0", normal_vrp, 0.9, None, "up")
+        assert 0 <= advice.confidence <= 100
+
+    def test_works_for_any_etf(self, advisor, normal_vrp):
+        for sym in ("QQQ", "SPY", "IWM", "DIA", "GLD"):
+            advice = advisor.advise(sym, 500.0, "R0", normal_vrp, 0.9, None, "up")
+            assert advice.symbol == sym
+            assert advice.action in ("SELL", "HOLD", "BLOCKED")

--- a/tests/unit/services/advisor/test_strategy_registry.py
+++ b/tests/unit/services/advisor/test_strategy_registry.py
@@ -1,0 +1,63 @@
+"""Tests for premium strategy registry."""
+
+from src.domain.services.advisor.strategy_registry import (
+    STRATEGY_REGISTRY,
+    get_strategies_by_direction,
+    get_strategies_for_regime,
+)
+
+
+class TestStrategyRegistry:
+    def test_registry_not_empty(self):
+        assert len(STRATEGY_REGISTRY) >= 6
+
+    def test_no_duplicate_names(self):
+        names = [s.name for s in STRATEGY_REGISTRY]
+        assert len(names) == len(set(names))
+
+    def test_all_have_legs(self):
+        for s in STRATEGY_REGISTRY:
+            assert len(s.leg_templates) >= 1, f"{s.name} has no legs"
+
+    def test_regime_fit_valid(self):
+        valid = {"R0", "R1", "R2", "R3"}
+        for s in STRATEGY_REGISTRY:
+            assert s.regime_fit.issubset(valid), f"{s.name} has invalid regime_fit"
+
+
+class TestGetStrategiesForRegime:
+    def test_r0_includes_bullish(self):
+        strats = get_strategies_for_regime("R0")
+        names = {s.name for s in strats}
+        assert "short_put" in names
+
+    def test_r0_includes_iron_condor(self):
+        strats = get_strategies_for_regime("R0")
+        names = {s.name for s in strats}
+        assert "iron_condor" in names
+
+    def test_r2_only_defined_risk_bearish(self):
+        strats = get_strategies_for_regime("R2")
+        for s in strats:
+            assert s.risk_profile == "defined", f"{s.name} in R2 should be defined-risk"
+            assert s.direction == "bearish", f"{s.name} in R2 should be bearish"
+
+    def test_r2_includes_bear_call_spread(self):
+        strats = get_strategies_for_regime("R2")
+        names = {s.name for s in strats}
+        assert "bear_call_spread" in names
+
+    def test_r2_excludes_short_call(self):
+        strats = get_strategies_for_regime("R2")
+        names = {s.name for s in strats}
+        assert "short_call" not in names
+
+
+class TestGetStrategiesByDirection:
+    def test_bullish(self):
+        strats = get_strategies_by_direction("bullish")
+        assert all(s.direction == "bullish" for s in strats)
+
+    def test_neutral(self):
+        strats = get_strategies_by_direction("neutral")
+        assert all(s.direction == "neutral" for s in strats)

--- a/tests/unit/services/advisor/test_vrp.py
+++ b/tests/unit/services/advisor/test_vrp.py
@@ -1,0 +1,143 @@
+"""Tests for VRP calculation and BSM strike estimation."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.domain.services.advisor.vrp import (
+    compute_term_structure,
+    compute_vrp,
+    estimate_strike_bsm,
+)
+
+
+class TestComputeVRP:
+    def test_positive_vrp(self):
+        """When IV > RV, VRP should be positive."""
+        np.random.seed(42)
+        n = 300
+        vix = pd.Series(np.random.normal(20, 2, n).clip(10, 40))
+        returns = pd.Series(np.random.normal(0.0003, 0.009, n))
+        underlying = (1 + returns).cumprod() * 500
+
+        result = compute_vrp(vix, underlying)
+        assert result.iv30 == pytest.approx(vix.iloc[-1], abs=0.01)
+        assert result.vrp > 0
+
+    def test_negative_vrp(self):
+        """When RV > IV (stress), VRP should be negative."""
+        np.random.seed(42)
+        n = 300
+        vix = pd.Series(np.full(n, 12.0))
+        returns = pd.Series(np.random.normal(-0.001, 0.016, n))
+        underlying = (1 + returns).cumprod() * 500
+
+        result = compute_vrp(vix, underlying)
+        assert result.vrp < 0
+
+    def test_vrp_zscore_range(self):
+        """Z-score should be finite and reasonable."""
+        np.random.seed(42)
+        n = 300
+        vix = pd.Series(np.random.normal(18, 3, n).clip(10, 40))
+        returns = pd.Series(np.random.normal(0.0003, 0.01, n))
+        underlying = (1 + returns).cumprod() * 500
+
+        result = compute_vrp(vix, underlying)
+        assert math.isfinite(result.vrp_zscore)
+        assert -5 < result.vrp_zscore < 5
+
+    def test_iv_percentile_range(self):
+        np.random.seed(42)
+        n = 300
+        vix = pd.Series(np.random.normal(18, 3, n).clip(10, 40))
+        returns = pd.Series(np.random.normal(0.0003, 0.01, n))
+        underlying = (1 + returns).cumprod() * 500
+
+        result = compute_vrp(vix, underlying)
+        assert 0 <= result.iv_percentile <= 100
+
+    def test_insufficient_data_fallback(self):
+        """Short series should return safe defaults, not crash."""
+        vix = pd.Series([18.0, 19.0, 17.5])
+        underlying = pd.Series([500.0, 501.0, 499.0])
+
+        result = compute_vrp(vix, underlying)
+        assert result.vrp_zscore == 0.0
+        assert result.iv_percentile == 50.0
+
+    def test_empty_series_returns_fallback(self):
+        """Empty series should return safe defaults."""
+        vix = pd.Series(dtype=float)
+        underlying = pd.Series(dtype=float)
+
+        result = compute_vrp(vix, underlying)
+        assert result.vrp_zscore == 0.0
+
+
+class TestComputeTermStructure:
+    def test_contango(self):
+        ratio, state = compute_term_structure(vix=18.0, vix3m=20.0)
+        assert ratio < 1.0
+        assert state == "contango"
+
+    def test_inverted(self):
+        ratio, state = compute_term_structure(vix=25.0, vix3m=18.0)
+        assert ratio > 1.2
+        assert state == "inverted"
+
+    def test_flat(self):
+        ratio, state = compute_term_structure(vix=19.5, vix3m=19.0)
+        assert state == "flat"
+
+    def test_zero_vix3m(self):
+        ratio, state = compute_term_structure(vix=18.0, vix3m=0.0)
+        assert ratio == 1.0
+        assert state == "flat"
+
+
+class TestEstimateStrikeBSM:
+    def test_put_below_spot(self):
+        strike = estimate_strike_bsm(
+            spot=500, iv=0.18, dte=35, target_delta=0.25, option_type="put"
+        )
+        assert strike < 500
+        assert strike > 400
+
+    def test_call_above_spot(self):
+        strike = estimate_strike_bsm(
+            spot=500, iv=0.18, dte=35, target_delta=0.25, option_type="call"
+        )
+        assert strike > 500
+        assert strike < 600
+
+    def test_higher_iv_wider_strike(self):
+        strike_low = estimate_strike_bsm(
+            spot=500, iv=0.15, dte=35, target_delta=0.25, option_type="put"
+        )
+        strike_high = estimate_strike_bsm(
+            spot=500, iv=0.30, dte=35, target_delta=0.25, option_type="put"
+        )
+        assert strike_high < strike_low
+
+    def test_longer_dte_wider_strike(self):
+        strike_short = estimate_strike_bsm(
+            spot=500, iv=0.18, dte=14, target_delta=0.25, option_type="put"
+        )
+        strike_long = estimate_strike_bsm(
+            spot=500, iv=0.18, dte=60, target_delta=0.25, option_type="put"
+        )
+        assert strike_long < strike_short
+
+    def test_50_delta_near_atm(self):
+        strike = estimate_strike_bsm(
+            spot=500, iv=0.18, dte=35, target_delta=0.50, option_type="put"
+        )
+        assert abs(strike - 500) < 10
+
+    def test_zero_dte_clamped(self):
+        """DTE=0 should not crash (clamped to 1)."""
+        strike = estimate_strike_bsm(spot=500, iv=0.18, dte=0, target_delta=0.25, option_type="put")
+        assert 400 < strike < 500

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Screeners } from "@/pages/Screeners"
 import { Regime } from "@/pages/Regime"
 import { Backtest } from "@/pages/Backtest"
 import { Monitor } from "@/pages/Monitor"
+import { Advisor } from "@/pages/Advisor"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -29,6 +30,7 @@ function App() {
             <Route path="regime" element={<Regime />} />
             <Route path="backtest" element={<Backtest />} />
             <Route path="monitor" element={<Monitor />} />
+            <Route path="advisor" element={<Advisor />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { to: "/regime", label: "Regime" },
   { to: "/monitor", label: "Monitor" },
   { to: "/backtest", label: "Backtest" },
+  { to: "/advisor", label: "Advisor" },
 ]
 
 function WsIndicator() {

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -58,6 +58,9 @@ function doConnect() {
         case "status":
           s.setProviders(msg.providers)
           break
+        case "advisor":
+          s.updateAdvisor(msg.market_context, msg.premium ?? [], msg.equity ?? [])
+          break
       }
     } catch {
       // ignore malformed messages

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import type { AdvisorMarketContext, PremiumAdvice, EquityAdvice } from "./ws"
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url)
@@ -7,6 +8,13 @@ async function fetchJson<T>(url: string): Promise<T> {
 }
 
 // ── Types ──────────────────────────────────────────────
+
+export interface AdvisorResponse {
+  market_context: AdvisorMarketContext
+  premium: PremiumAdvice[]
+  equity: EquityAdvice[]
+  timestamp: string
+}
 
 export interface SymbolsResponse {
   symbols: Record<string, SymbolInfo>
@@ -71,6 +79,8 @@ export const api = {
   scoreHistory: () => fetchJson<Record<string, unknown>>("/api/score-history"),
   indicators: () => fetchJson<Record<string, unknown>>("/api/indicators"),
   universe: () => fetchJson<Record<string, unknown>>("/api/universe"),
+  advisor: () => fetchJson<AdvisorResponse>("/api/advisor"),
+  advisorSymbol: (symbol: string) => fetchJson<Record<string, unknown>>(`/api/advisor/${symbol}`),
 }
 
 // ── Query hooks ────────────────────────────────────────
@@ -130,4 +140,8 @@ export function useIndicators() {
 
 export function useUniverse() {
   return useQuery({ queryKey: ["universe"], queryFn: api.universe, staleTime: 5 * 60_000 })
+}
+
+export function useAdvisor() {
+  return useQuery({ queryKey: ["advisor"], queryFn: api.advisor, staleTime: 30_000 })
 }

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -13,6 +13,7 @@ export type WsMessage =
   | { type: "indicator"; symbol: string; timeframe: string; name: string; value: number }
   | { type: "signal"; data: SignalData }
   | { type: "status"; providers: ProviderStatus[] }
+  | { type: "advisor"; market_context: AdvisorMarketContext; premium: PremiumAdvice[]; equity: EquityAdvice[] }
 
 export interface QuoteData {
   last: number
@@ -45,4 +46,52 @@ export interface ProviderStatus {
   connected: boolean
   symbols: number
   subscribed_symbols?: string[]
+}
+
+export interface AdvisorMarketContext {
+  regime: string
+  regime_name: string
+  regime_confidence: number
+  vix: number
+  vix_percentile: number
+  vrp_zscore: number
+  term_structure_ratio: number
+  term_structure_state: string
+  timestamp: string
+}
+
+export interface PremiumAdvice {
+  symbol: string
+  action: string
+  strategy: string | null
+  display_name: string | null
+  confidence: number
+  legs: LegSpec[]
+  vrp_zscore: number
+  iv_percentile: number
+  term_structure_ratio: number
+  regime: string
+  earnings_warning: string | null
+  reasoning: string[]
+}
+
+export interface LegSpec {
+  side: string
+  option_type: string
+  target_delta: number
+  target_dte: number
+  estimated_strike: number
+}
+
+export interface EquityAdvice {
+  symbol: string
+  sector: string
+  action: string
+  confidence: number
+  regime: string
+  signal_summary: Record<string, number>
+  top_signals: { rule: string; direction: string; strength: number }[]
+  trend_pulse: Record<string, unknown> | null
+  key_levels: Record<string, number>
+  reasoning: string[]
 }

--- a/web/src/pages/Advisor.tsx
+++ b/web/src/pages/Advisor.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import { Fragment, useState, useMemo } from "react"
 import { useAdvisor } from "@/lib/api"
 import { useMarketStore } from "@/stores/market"
 import type { AdvisorMarketContext, PremiumAdvice, EquityAdvice } from "@/lib/ws"
@@ -21,6 +21,14 @@ const regimeColor: Record<string, string> = {
   R3: "bg-blue-500/20 text-blue-400",
 }
 
+const directionIcon: Record<string, string> = {
+  bullish: "text-emerald-400",
+  bearish: "text-red-400",
+  neutral: "text-zinc-400",
+}
+
+type SortKey = "confidence" | "symbol" | "sector" | "action" | "regime"
+
 function Badge({ label, className }: { label: string; className?: string }) {
   return (
     <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${className ?? ""}`}>
@@ -42,41 +50,57 @@ function ConfidenceBar({ value }: { value: number }) {
   )
 }
 
+function formatTimestamp(ts: string | undefined | null): string {
+  if (!ts) return "—"
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
 // ── Market Context Bar ──────────────────────────────
 
 function MarketContextBar({ ctx }: { ctx: AdvisorMarketContext | null }) {
   if (!ctx) return null
   return (
-    <div className="mb-6 grid grid-cols-2 gap-4 rounded-lg border border-border bg-card p-4 sm:grid-cols-4 lg:grid-cols-7">
-      <div>
-        <div className="text-xs text-muted-foreground">Regime</div>
-        <Badge label={`${ctx.regime} — ${ctx.regime_name}`} className={regimeColor[ctx.regime] ?? "bg-zinc-700 text-zinc-300"} />
-      </div>
-      <div>
-        <div className="text-xs text-muted-foreground">Confidence</div>
-        <span className="text-sm font-medium">{ctx.regime_confidence}%</span>
-      </div>
-      <div>
-        <div className="text-xs text-muted-foreground">VIX</div>
-        <span className="text-sm font-medium">{ctx.vix?.toFixed(1) ?? "—"}</span>
-      </div>
-      <div>
-        <div className="text-xs text-muted-foreground">VIX %ile</div>
-        <span className="text-sm font-medium">{ctx.vix_percentile ?? "—"}%</span>
-      </div>
-      <div>
-        <div className="text-xs text-muted-foreground">VRP Z-Score</div>
-        <span className={`text-sm font-medium ${(ctx.vrp_zscore ?? 0) > 0 ? "text-emerald-400" : "text-red-400"}`}>
-          {ctx.vrp_zscore?.toFixed(2) ?? "—"}
-        </span>
-      </div>
-      <div>
-        <div className="text-xs text-muted-foreground">Term Structure</div>
-        <span className="text-sm font-medium capitalize">{ctx.term_structure_state ?? "—"}</span>
-      </div>
-      <div>
-        <div className="text-xs text-muted-foreground">TS Ratio</div>
-        <span className="text-sm font-medium">{ctx.term_structure_ratio?.toFixed(3) ?? "—"}</span>
+    <div className="mb-6 rounded-lg border border-border bg-card p-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+        <div>
+          <div className="text-xs text-muted-foreground">Regime</div>
+          <div className="mt-1 flex items-center gap-2">
+            <Badge label={ctx.regime} className={regimeColor[ctx.regime] ?? "bg-zinc-700 text-zinc-300"} />
+            <span className="text-sm">{ctx.regime_name}</span>
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">Confidence: {ctx.regime_confidence}%</div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">VIX</div>
+          <div className="mt-1 text-lg font-semibold">{ctx.vix?.toFixed(1) ?? "—"}</div>
+          <div className="text-xs text-muted-foreground">{Math.round(ctx.vix_percentile ?? 0)}th percentile</div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">VRP</div>
+          <div className={`mt-1 text-lg font-semibold ${(ctx.vrp_zscore ?? 0) > 0 ? "text-emerald-400" : "text-red-400"}`}>
+            z={ctx.vrp_zscore?.toFixed(2) ?? "—"}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {(ctx.vrp_zscore ?? 0) > 0.5 ? "Premium rich" : (ctx.vrp_zscore ?? 0) < -0.5 ? "Premium cheap" : "Fair value"}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Term Structure</div>
+          <div className="mt-1 text-lg font-semibold">{ctx.term_structure_ratio?.toFixed(3) ?? "—"}</div>
+          <div className="text-xs text-muted-foreground capitalize">
+            {ctx.term_structure_state ?? "—"}
+            {ctx.term_structure_state === "contango" && " ✓"}
+            {ctx.term_structure_state === "inverted" && " ⚠"}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Last Updated</div>
+          <div className="mt-1 text-sm font-medium">{formatTimestamp(ctx.timestamp)}</div>
+        </div>
       </div>
     </div>
   )
@@ -87,61 +111,173 @@ function MarketContextBar({ ctx }: { ctx: AdvisorMarketContext | null }) {
 function PremiumCard({ advice }: { advice: PremiumAdvice }) {
   const [expanded, setExpanded] = useState(false)
   return (
-    <div className="rounded-lg border border-border bg-card p-4">
+    <div
+      className="cursor-pointer rounded-lg border border-border bg-card p-4 transition-colors hover:border-primary/30"
+      onClick={() => setExpanded(!expanded)}
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="text-sm font-bold">{advice.symbol}</span>
+          <span className="text-base font-bold">{advice.symbol}</span>
           <Badge label={advice.action} className={actionColor[advice.action] ?? actionColor.HOLD} />
         </div>
         <ConfidenceBar value={advice.confidence} />
       </div>
 
       {advice.strategy && (
-        <div className="mt-2 text-sm text-muted-foreground">
-          Strategy: <span className="text-foreground">{advice.display_name ?? advice.strategy}</span>
+        <div className="mt-2 text-sm">
+          <span className="text-muted-foreground">Strategy: </span>
+          <span className="font-medium">{advice.display_name ?? advice.strategy}</span>
         </div>
       )}
 
-      <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
-        <span>VRP Z: {advice.vrp_zscore?.toFixed(2)}</span>
-        <span>IV %ile: {advice.iv_percentile}%</span>
-        <span>Regime: {advice.regime}</span>
+      {/* Quick metrics row */}
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span>VRP Z: <span className={(advice.vrp_zscore ?? 0) > 0 ? "text-emerald-400" : "text-red-400"}>{advice.vrp_zscore?.toFixed(2)}</span></span>
+        <span>IV %ile: {Math.round(advice.iv_percentile)}%</span>
+        <span>TS: {advice.term_structure_ratio?.toFixed(3)}</span>
+        <span>Regime: <Badge label={advice.regime} className={`${regimeColor[advice.regime] ?? ""} !py-0 !text-[10px]`} /></span>
       </div>
 
       {advice.earnings_warning && (
-        <div className="mt-2 text-xs text-amber-400">Warning: {advice.earnings_warning}</div>
+        <div className="mt-2 rounded bg-amber-500/10 px-2 py-1 text-xs text-amber-400">⚠ {advice.earnings_warning}</div>
       )}
 
-      {advice.legs.length > 0 && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="mt-2 text-xs text-primary hover:underline"
-        >
-          {expanded ? "Hide" : "Show"} legs ({advice.legs.length})
-        </button>
-      )}
-
-      {expanded && advice.legs.length > 0 && (
-        <div className="mt-2 space-y-1">
-          {advice.legs.map((leg, i) => (
-            <div key={i} className="rounded bg-zinc-800/50 px-2 py-1 text-xs">
-              <span className={leg.side === "sell" ? "text-red-400" : "text-emerald-400"}>
-                {leg.side.toUpperCase()}
-              </span>{" "}
-              {leg.option_type.toUpperCase()} | Delta: {leg.target_delta} | DTE: {leg.target_dte} |
-              Strike: ${leg.estimated_strike?.toFixed(2)}
+      {/* Expanded: legs + reasoning */}
+      {expanded && (
+        <div className="mt-3 border-t border-border/50 pt-3">
+          {advice.legs.length > 0 && (
+            <div className="mb-3">
+              <div className="mb-1 text-xs font-semibold text-muted-foreground uppercase">Legs</div>
+              <div className="space-y-1">
+                {advice.legs.map((leg, i) => (
+                  <div key={i} className="flex items-center gap-3 rounded bg-zinc-800/50 px-3 py-1.5 text-xs">
+                    <span className={`font-semibold ${leg.side === "sell" ? "text-red-400" : "text-emerald-400"}`}>
+                      {leg.side.toUpperCase()}
+                    </span>
+                    <span className="font-medium">{leg.option_type.toUpperCase()}</span>
+                    <span className="text-muted-foreground">Δ{leg.target_delta}</span>
+                    <span className="text-muted-foreground">{leg.target_dte}d</span>
+                    <span className="font-medium">~${leg.estimated_strike?.toFixed(2)}</span>
+                  </div>
+                ))}
+              </div>
             </div>
-          ))}
+          )}
+
+          {advice.reasoning.length > 0 && (
+            <div>
+              <div className="mb-1 text-xs font-semibold text-muted-foreground uppercase">Reasoning</div>
+              <ul className="space-y-0.5">
+                {advice.reasoning.map((r, i) => (
+                  <li key={i} className="text-xs text-muted-foreground">&bull; {r}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Equity Detail Panel (expanded row) ──────────────
+
+function EquityDetail({ row }: { row: EquityAdvice }) {
+  const kl = row.key_levels ?? {}
+  const tp = row.trend_pulse
+  const hasKeyLevels = Object.keys(kl).length > 0
+  const hasTopSignals = (row.top_signals ?? []).length > 0
+  const hasReasoning = (row.reasoning ?? []).length > 0
+
+  return (
+    <div className="grid gap-4 px-4 pb-4 pt-2 sm:grid-cols-2 lg:grid-cols-4">
+      {/* Top signals */}
+      {hasTopSignals && (
+        <div>
+          <div className="mb-1.5 text-xs font-semibold text-muted-foreground uppercase">Top Signals</div>
+          <div className="space-y-1">
+            {row.top_signals.map((sig, i) => (
+              <div key={i} className="flex items-center gap-2 text-xs">
+                <span className={`${directionIcon[sig.direction] ?? "text-zinc-400"}`}>
+                  {sig.direction === "bullish" ? "▲" : sig.direction === "bearish" ? "▼" : "─"}
+                </span>
+                <span className="font-medium">{sig.rule}</span>
+                <span className="text-muted-foreground">({(sig.strength * 100).toFixed(0)}%)</span>
+              </div>
+            ))}
+          </div>
         </div>
       )}
 
-      {advice.reasoning.length > 0 && (
-        <div className="mt-2 space-y-0.5">
-          {advice.reasoning.map((r, i) => (
-            <div key={i} className="text-xs text-muted-foreground">
-              &bull; {r}
-            </div>
-          ))}
+      {/* Key levels */}
+      {hasKeyLevels && (
+        <div>
+          <div className="mb-1.5 text-xs font-semibold text-muted-foreground uppercase">Key Levels</div>
+          <div className="space-y-1 text-xs">
+            {kl.resistance != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Resistance</span>
+                <span className="font-medium text-red-400">${Number(kl.resistance).toFixed(2)}</span>
+              </div>
+            )}
+            {kl.support != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Support</span>
+                <span className="font-medium text-emerald-400">${Number(kl.support).toFixed(2)}</span>
+              </div>
+            )}
+            {kl.atr_stop != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">ATR Stop</span>
+                <span className="font-medium text-amber-400">${Number(kl.atr_stop).toFixed(2)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* TrendPulse state */}
+      {tp && Object.keys(tp).length > 0 && (
+        <div>
+          <div className="mb-1.5 text-xs font-semibold text-muted-foreground uppercase">TrendPulse</div>
+          <div className="space-y-1 text-xs">
+            {tp.zig_state != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Zig State</span>
+                <span className="font-medium">{String(tp.zig_state)}</span>
+              </div>
+            )}
+            {tp.macd_state != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">MACD State</span>
+                <span className="font-medium">{String(tp.macd_state)}</span>
+              </div>
+            )}
+            {tp.atr_trail != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">ATR Trail</span>
+                <span className="font-medium">${Number(tp.atr_trail).toFixed(2)}</span>
+              </div>
+            )}
+            {tp.confidence_score != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Confidence</span>
+                <span className="font-medium">{Number(tp.confidence_score).toFixed(0)}%</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Reasoning */}
+      {hasReasoning && (
+        <div className={tp && Object.keys(tp).length > 0 ? "" : "lg:col-span-2"}>
+          <div className="mb-1.5 text-xs font-semibold text-muted-foreground uppercase">Reasoning</div>
+          <ul className="space-y-0.5">
+            {row.reasoning.map((r, i) => (
+              <li key={i} className="text-xs text-muted-foreground">&bull; {r}</li>
+            ))}
+          </ul>
         </div>
       )}
     </div>
@@ -154,60 +290,142 @@ function EquityTable({
   rows,
   sectorFilter,
   actionFilter,
+  sortKey,
+  sortDesc,
+  onToggleSort,
+  searchQuery,
 }: {
   rows: EquityAdvice[]
   sectorFilter: string
   actionFilter: string
+  sortKey: SortKey
+  sortDesc: boolean
+  onToggleSort: (key: SortKey) => void
+  searchQuery: string
 }) {
+  const [expandedSymbol, setExpandedSymbol] = useState<string | null>(null)
+
   const filtered = useMemo(() => {
     let result = rows
     if (sectorFilter) result = result.filter((r) => r.sector === sectorFilter)
     if (actionFilter) result = result.filter((r) => r.action === actionFilter)
-    return result.sort((a, b) => b.confidence - a.confidence)
-  }, [rows, sectorFilter, actionFilter])
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(
+        (r) => r.symbol.toLowerCase().includes(q) || (r.sector ?? "").toLowerCase().includes(q),
+      )
+    }
+    return [...result].sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case "confidence":
+          cmp = a.confidence - b.confidence
+          break
+        case "symbol":
+          cmp = a.symbol.localeCompare(b.symbol)
+          break
+        case "sector":
+          cmp = (a.sector ?? "").localeCompare(b.sector ?? "")
+          break
+        case "action":
+          cmp = a.action.localeCompare(b.action)
+          break
+        case "regime":
+          cmp = a.regime.localeCompare(b.regime)
+          break
+      }
+      return sortDesc ? -cmp : cmp
+    })
+  }, [rows, sectorFilter, actionFilter, searchQuery, sortKey, sortDesc])
 
   if (filtered.length === 0) {
     return <div className="py-8 text-center text-sm text-muted-foreground">No equity recommendations available</div>
   }
 
+  const columns: { key: SortKey; label: string; className?: string }[] = [
+    { key: "symbol", label: "Symbol" },
+    { key: "sector", label: "Sector" },
+    { key: "action", label: "Action" },
+    { key: "confidence", label: "Confidence" },
+    { key: "regime", label: "Regime" },
+  ]
+
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto rounded-lg border border-border">
       <table className="w-full text-sm">
-        <thead>
+        <thead className="bg-card">
           <tr className="border-b border-border text-left text-xs text-muted-foreground">
-            <th className="pb-2 pr-4">Symbol</th>
-            <th className="pb-2 pr-4">Sector</th>
-            <th className="pb-2 pr-4">Action</th>
-            <th className="pb-2 pr-4">Confidence</th>
-            <th className="pb-2 pr-4">Regime</th>
-            <th className="pb-2 pr-4">Signals</th>
-            <th className="pb-2">Top Signal</th>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                onClick={() => onToggleSort(col.key)}
+                className="cursor-pointer select-none px-3 py-2 hover:text-foreground"
+              >
+                <div className="flex items-center gap-1">
+                  {col.label}
+                  {sortKey === col.key && (sortDesc ? " ↓" : " ↑")}
+                </div>
+              </th>
+            ))}
+            <th className="px-3 py-2">Signals</th>
+            <th className="px-3 py-2">Top Signal</th>
           </tr>
         </thead>
         <tbody>
-          {filtered.map((row) => (
-            <tr key={row.symbol} className="border-b border-border/50 hover:bg-zinc-800/30">
-              <td className="py-2 pr-4 font-medium">{row.symbol}</td>
-              <td className="py-2 pr-4 text-muted-foreground">{row.sector || "—"}</td>
-              <td className="py-2 pr-4">
-                <Badge label={row.action} className={actionColor[row.action] ?? actionColor.HOLD} />
-              </td>
-              <td className="py-2 pr-4">
-                <ConfidenceBar value={row.confidence} />
-              </td>
-              <td className="py-2 pr-4">
-                <Badge label={row.regime} className={regimeColor[row.regime] ?? "bg-zinc-700 text-zinc-300"} />
-              </td>
-              <td className="py-2 pr-4 text-xs text-muted-foreground">
-                {row.signal_summary
-                  ? `${row.signal_summary.bullish ?? 0}↑ ${row.signal_summary.bearish ?? 0}↓ ${row.signal_summary.neutral ?? 0}—`
-                  : "—"}
-              </td>
-              <td className="py-2 text-xs text-muted-foreground">{row.top_signals?.[0]?.rule ?? "—"}</td>
-            </tr>
-          ))}
+          {filtered.map((row) => {
+            const isExpanded = expandedSymbol === row.symbol
+            return (
+              <Fragment key={row.symbol}>
+                <tr
+                  onClick={() => setExpandedSymbol(isExpanded ? null : row.symbol)}
+                  className={`cursor-pointer border-b transition-colors ${
+                    isExpanded ? "border-primary/30 bg-zinc-800/40" : "border-border/50 hover:bg-zinc-800/30"
+                  }`}
+                >
+                  <td className="px-3 py-2 font-medium">
+                    <div className="flex items-center gap-1.5">
+                      <span className={`text-[10px] transition-transform ${isExpanded ? "" : "-rotate-90"}`}>▼</span>
+                      {row.symbol}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{row.sector || "—"}</td>
+                  <td className="px-3 py-2">
+                    <Badge label={row.action} className={actionColor[row.action] ?? actionColor.HOLD} />
+                  </td>
+                  <td className="px-3 py-2">
+                    <ConfidenceBar value={row.confidence} />
+                  </td>
+                  <td className="px-3 py-2">
+                    <Badge label={row.regime} className={regimeColor[row.regime] ?? "bg-zinc-700 text-zinc-300"} />
+                  </td>
+                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                    <span className="text-emerald-400">{row.signal_summary?.bullish ?? 0}↑</span>{" "}
+                    <span className="text-red-400">{row.signal_summary?.bearish ?? 0}↓</span>{" "}
+                    <span>{row.signal_summary?.neutral ?? 0}─</span>
+                  </td>
+                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                    {row.top_signals?.[0] ? (
+                      <span className={directionIcon[row.top_signals[0].direction] ?? ""}>
+                        {row.top_signals[0].rule}
+                      </span>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                </tr>
+                {isExpanded && (
+                  <tr className="border-b border-primary/20 bg-zinc-800/30">
+                    <td colSpan={7}>
+                      <EquityDetail row={row} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
         </tbody>
       </table>
+      <div className="px-3 py-1.5 text-xs text-muted-foreground">{filtered.length} rows</div>
     </div>
   )
 }
@@ -229,10 +447,31 @@ export function Advisor() {
 
   const [sectorFilter, setSectorFilter] = useState("")
   const [actionFilter, setActionFilter] = useState("")
+  const [searchQuery, setSearchQuery] = useState("")
+  const [sortKey, setSortKey] = useState<SortKey>("confidence")
+  const [sortDesc, setSortDesc] = useState(true)
 
   // Derive unique sectors and actions for filters
   const sectors = useMemo(() => [...new Set(equity.map((e) => e.sector).filter(Boolean))].sort(), [equity])
   const actions = useMemo(() => [...new Set(equity.map((e) => e.action).filter(Boolean))].sort(), [equity])
+
+  // Counts by action for summary bar
+  const actionCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const e of equity) {
+      counts[e.action] = (counts[e.action] ?? 0) + 1
+    }
+    return counts
+  }, [equity])
+
+  const handleToggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDesc(!sortDesc)
+    } else {
+      setSortKey(key)
+      setSortDesc(key === "confidence") // default desc for confidence, asc for others
+    }
+  }
 
   if (isLoading) {
     return <div className="py-12 text-center text-muted-foreground">Loading advisor data...</div>
@@ -253,6 +492,28 @@ export function Advisor() {
       {/* Market Context */}
       <MarketContextBar ctx={ctx} />
 
+      {/* Action summary bar */}
+      {equity.length > 0 && (
+        <div className="mb-4 flex flex-wrap gap-3">
+          {["STRONG_BUY", "BUY", "HOLD", "SELL", "STRONG_SELL"].map((act) =>
+            actionCounts[act] ? (
+              <button
+                key={act}
+                onClick={() => setActionFilter(actionFilter === act ? "" : act)}
+                className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                  actionFilter === act ? "ring-2 ring-primary" : ""
+                } ${actionColor[act] ?? ""}`}
+              >
+                {act.replace("_", " ")} ({actionCounts[act]})
+              </button>
+            ) : null,
+          )}
+          <span className="flex items-center text-xs text-muted-foreground">
+            {equity.length} total
+          </span>
+        </div>
+      )}
+
       {/* Premium Strategies */}
       {premium.length > 0 && (
         <section className="mb-6">
@@ -267,13 +528,31 @@ export function Advisor() {
         </section>
       )}
 
+      {premium.length === 0 && ctx?.regime === "R2" && (
+        <section className="mb-6">
+          <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Premium Strategies
+          </h2>
+          <div className="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            Premium selling blocked — regime is <Badge label="R2" className={regimeColor.R2} /> Risk-Off
+          </div>
+        </section>
+      )}
+
       {/* Equity Recommendations */}
       <section>
-        <div className="mb-3 flex items-center justify-between">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
             Equity Recommendations ({equity.length})
           </h2>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
+            <input
+              type="text"
+              placeholder="Search symbol..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-40 rounded border border-border bg-card px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
             <select
               value={sectorFilter}
               onChange={(e) => setSectorFilter(e.target.value)}
@@ -298,9 +577,33 @@ export function Advisor() {
                 </option>
               ))}
             </select>
+            <select
+              value={`${sortKey}:${sortDesc ? "desc" : "asc"}`}
+              onChange={(e) => {
+                const [k, d] = e.target.value.split(":")
+                setSortKey(k as SortKey)
+                setSortDesc(d === "desc")
+              }}
+              className="rounded border border-border bg-card px-2 py-1 text-xs text-foreground"
+            >
+              <option value="confidence:desc">Sort: Conf ↓</option>
+              <option value="confidence:asc">Sort: Conf ↑</option>
+              <option value="symbol:asc">Sort: Symbol A-Z</option>
+              <option value="symbol:desc">Sort: Symbol Z-A</option>
+              <option value="sector:asc">Sort: Sector A-Z</option>
+              <option value="regime:asc">Sort: Regime</option>
+            </select>
           </div>
         </div>
-        <EquityTable rows={equity} sectorFilter={sectorFilter} actionFilter={actionFilter} />
+        <EquityTable
+          rows={equity}
+          sectorFilter={sectorFilter}
+          actionFilter={actionFilter}
+          sortKey={sortKey}
+          sortDesc={sortDesc}
+          onToggleSort={handleToggleSort}
+          searchQuery={searchQuery}
+        />
       </section>
     </div>
   )

--- a/web/src/pages/Advisor.tsx
+++ b/web/src/pages/Advisor.tsx
@@ -1,0 +1,307 @@
+import { useState, useMemo } from "react"
+import { useAdvisor } from "@/lib/api"
+import { useMarketStore } from "@/stores/market"
+import type { AdvisorMarketContext, PremiumAdvice, EquityAdvice } from "@/lib/ws"
+
+// ── Helpers ─────────────────────────────────────────
+
+const actionColor: Record<string, string> = {
+  STRONG_BUY: "bg-emerald-600 text-white",
+  BUY: "bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/30",
+  HOLD: "bg-amber-500/20 text-amber-400 ring-1 ring-amber-500/30",
+  SELL: "bg-red-500/20 text-red-400 ring-1 ring-red-500/30",
+  STRONG_SELL: "bg-red-600 text-white",
+  BLOCKED: "bg-zinc-700 text-zinc-400 ring-1 ring-zinc-600",
+}
+
+const regimeColor: Record<string, string> = {
+  R0: "bg-emerald-500/20 text-emerald-400",
+  R1: "bg-amber-500/20 text-amber-400",
+  R2: "bg-red-500/20 text-red-400",
+  R3: "bg-blue-500/20 text-blue-400",
+}
+
+function Badge({ label, className }: { label: string; className?: string }) {
+  return (
+    <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${className ?? ""}`}>
+      {label}
+    </span>
+  )
+}
+
+function ConfidenceBar({ value }: { value: number }) {
+  const clamped = Math.max(0, Math.min(100, value))
+  const color = clamped >= 60 ? "bg-emerald-500" : clamped >= 30 ? "bg-amber-500" : "bg-red-500"
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 rounded-full bg-zinc-700">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${clamped}%` }} />
+      </div>
+      <span className="text-xs text-muted-foreground">{Math.round(clamped)}%</span>
+    </div>
+  )
+}
+
+// ── Market Context Bar ──────────────────────────────
+
+function MarketContextBar({ ctx }: { ctx: AdvisorMarketContext | null }) {
+  if (!ctx) return null
+  return (
+    <div className="mb-6 grid grid-cols-2 gap-4 rounded-lg border border-border bg-card p-4 sm:grid-cols-4 lg:grid-cols-7">
+      <div>
+        <div className="text-xs text-muted-foreground">Regime</div>
+        <Badge label={`${ctx.regime} — ${ctx.regime_name}`} className={regimeColor[ctx.regime] ?? "bg-zinc-700 text-zinc-300"} />
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">Confidence</div>
+        <span className="text-sm font-medium">{ctx.regime_confidence}%</span>
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">VIX</div>
+        <span className="text-sm font-medium">{ctx.vix?.toFixed(1) ?? "—"}</span>
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">VIX %ile</div>
+        <span className="text-sm font-medium">{ctx.vix_percentile ?? "—"}%</span>
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">VRP Z-Score</div>
+        <span className={`text-sm font-medium ${(ctx.vrp_zscore ?? 0) > 0 ? "text-emerald-400" : "text-red-400"}`}>
+          {ctx.vrp_zscore?.toFixed(2) ?? "—"}
+        </span>
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">Term Structure</div>
+        <span className="text-sm font-medium capitalize">{ctx.term_structure_state ?? "—"}</span>
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">TS Ratio</div>
+        <span className="text-sm font-medium">{ctx.term_structure_ratio?.toFixed(3) ?? "—"}</span>
+      </div>
+    </div>
+  )
+}
+
+// ── Premium Strategy Cards ──────────────────────────
+
+function PremiumCard({ advice }: { advice: PremiumAdvice }) {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-bold">{advice.symbol}</span>
+          <Badge label={advice.action} className={actionColor[advice.action] ?? actionColor.HOLD} />
+        </div>
+        <ConfidenceBar value={advice.confidence} />
+      </div>
+
+      {advice.strategy && (
+        <div className="mt-2 text-sm text-muted-foreground">
+          Strategy: <span className="text-foreground">{advice.display_name ?? advice.strategy}</span>
+        </div>
+      )}
+
+      <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
+        <span>VRP Z: {advice.vrp_zscore?.toFixed(2)}</span>
+        <span>IV %ile: {advice.iv_percentile}%</span>
+        <span>Regime: {advice.regime}</span>
+      </div>
+
+      {advice.earnings_warning && (
+        <div className="mt-2 text-xs text-amber-400">Warning: {advice.earnings_warning}</div>
+      )}
+
+      {advice.legs.length > 0 && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-2 text-xs text-primary hover:underline"
+        >
+          {expanded ? "Hide" : "Show"} legs ({advice.legs.length})
+        </button>
+      )}
+
+      {expanded && advice.legs.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {advice.legs.map((leg, i) => (
+            <div key={i} className="rounded bg-zinc-800/50 px-2 py-1 text-xs">
+              <span className={leg.side === "sell" ? "text-red-400" : "text-emerald-400"}>
+                {leg.side.toUpperCase()}
+              </span>{" "}
+              {leg.option_type.toUpperCase()} | Delta: {leg.target_delta} | DTE: {leg.target_dte} |
+              Strike: ${leg.estimated_strike?.toFixed(2)}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {advice.reasoning.length > 0 && (
+        <div className="mt-2 space-y-0.5">
+          {advice.reasoning.map((r, i) => (
+            <div key={i} className="text-xs text-muted-foreground">
+              &bull; {r}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Equity Table ────────────────────────────────────
+
+function EquityTable({
+  rows,
+  sectorFilter,
+  actionFilter,
+}: {
+  rows: EquityAdvice[]
+  sectorFilter: string
+  actionFilter: string
+}) {
+  const filtered = useMemo(() => {
+    let result = rows
+    if (sectorFilter) result = result.filter((r) => r.sector === sectorFilter)
+    if (actionFilter) result = result.filter((r) => r.action === actionFilter)
+    return result.sort((a, b) => b.confidence - a.confidence)
+  }, [rows, sectorFilter, actionFilter])
+
+  if (filtered.length === 0) {
+    return <div className="py-8 text-center text-sm text-muted-foreground">No equity recommendations available</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th className="pb-2 pr-4">Symbol</th>
+            <th className="pb-2 pr-4">Sector</th>
+            <th className="pb-2 pr-4">Action</th>
+            <th className="pb-2 pr-4">Confidence</th>
+            <th className="pb-2 pr-4">Regime</th>
+            <th className="pb-2 pr-4">Signals</th>
+            <th className="pb-2">Top Signal</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((row) => (
+            <tr key={row.symbol} className="border-b border-border/50 hover:bg-zinc-800/30">
+              <td className="py-2 pr-4 font-medium">{row.symbol}</td>
+              <td className="py-2 pr-4 text-muted-foreground">{row.sector || "—"}</td>
+              <td className="py-2 pr-4">
+                <Badge label={row.action} className={actionColor[row.action] ?? actionColor.HOLD} />
+              </td>
+              <td className="py-2 pr-4">
+                <ConfidenceBar value={row.confidence} />
+              </td>
+              <td className="py-2 pr-4">
+                <Badge label={row.regime} className={regimeColor[row.regime] ?? "bg-zinc-700 text-zinc-300"} />
+              </td>
+              <td className="py-2 pr-4 text-xs text-muted-foreground">
+                {row.signal_summary
+                  ? `${row.signal_summary.bullish ?? 0}↑ ${row.signal_summary.bearish ?? 0}↓ ${row.signal_summary.neutral ?? 0}—`
+                  : "—"}
+              </td>
+              <td className="py-2 text-xs text-muted-foreground">{row.top_signals?.[0]?.rule ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ── Main Page ───────────────────────────────────────
+
+export function Advisor() {
+  const { data, isLoading, error } = useAdvisor()
+
+  // Live WS data (may be newer than REST)
+  const wsCtx = useMarketStore((s) => s.advisorContext)
+  const wsPremium = useMarketStore((s) => s.advisorPremium)
+  const wsEquity = useMarketStore((s) => s.advisorEquity)
+
+  // Prefer WS data when available
+  const ctx = wsCtx ?? data?.market_context ?? null
+  const premium = wsPremium.length > 0 ? wsPremium : data?.premium ?? []
+  const equity = wsEquity.length > 0 ? wsEquity : data?.equity ?? []
+
+  const [sectorFilter, setSectorFilter] = useState("")
+  const [actionFilter, setActionFilter] = useState("")
+
+  // Derive unique sectors and actions for filters
+  const sectors = useMemo(() => [...new Set(equity.map((e) => e.sector).filter(Boolean))].sort(), [equity])
+  const actions = useMemo(() => [...new Set(equity.map((e) => e.action).filter(Boolean))].sort(), [equity])
+
+  if (isLoading) {
+    return <div className="py-12 text-center text-muted-foreground">Loading advisor data...</div>
+  }
+
+  if (error) {
+    return (
+      <div className="py-12 text-center text-muted-foreground">
+        Advisor service not available — data loads after market open
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h1 className="mb-4 text-lg font-bold">Trading Advisor</h1>
+
+      {/* Market Context */}
+      <MarketContextBar ctx={ctx} />
+
+      {/* Premium Strategies */}
+      {premium.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Premium Strategies
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {premium.map((p) => (
+              <PremiumCard key={p.symbol} advice={p} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Equity Recommendations */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Equity Recommendations ({equity.length})
+          </h2>
+          <div className="flex gap-2">
+            <select
+              value={sectorFilter}
+              onChange={(e) => setSectorFilter(e.target.value)}
+              className="rounded border border-border bg-card px-2 py-1 text-xs text-foreground"
+            >
+              <option value="">All Sectors</option>
+              {sectors.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+            <select
+              value={actionFilter}
+              onChange={(e) => setActionFilter(e.target.value)}
+              className="rounded border border-border bg-card px-2 py-1 text-xs text-foreground"
+            >
+              <option value="">All Actions</option>
+              {actions.map((a) => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <EquityTable rows={equity} sectorFilter={sectorFilter} actionFilter={actionFilter} />
+      </section>
+    </div>
+  )
+}

--- a/web/src/stores/market.ts
+++ b/web/src/stores/market.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand"
-import type { QuoteData, OHLCV, SignalData, ProviderStatus } from "@/lib/ws"
+import type { QuoteData, OHLCV, SignalData, ProviderStatus, AdvisorMarketContext, PremiumAdvice, EquityAdvice } from "@/lib/ws"
 
 const MAX_SIGNALS = 200
 
@@ -13,6 +13,9 @@ interface MarketState {
   signals: SignalData[]
   providers: ProviderStatus[]
   wsStatus: "connecting" | "connected" | "disconnected"
+  advisorContext: AdvisorMarketContext | null
+  advisorPremium: PremiumAdvice[]
+  advisorEquity: EquityAdvice[]
 
   updateQuote: (symbol: string, quote: QuoteData) => void
   appendBar: (symbol: string, tf: string, bar: OHLCV) => void
@@ -20,6 +23,7 @@ interface MarketState {
   addSignal: (signal: SignalData) => void
   setProviders: (providers: ProviderStatus[]) => void
   setWsStatus: (status: MarketState["wsStatus"]) => void
+  updateAdvisor: (ctx: AdvisorMarketContext, premium: PremiumAdvice[], equity: EquityAdvice[]) => void
 }
 
 export const useMarketStore = create<MarketState>((set) => ({
@@ -29,6 +33,9 @@ export const useMarketStore = create<MarketState>((set) => ({
   signals: [],
   providers: [],
   wsStatus: "disconnected",
+  advisorContext: null,
+  advisorPremium: [],
+  advisorEquity: [],
 
   updateQuote: (symbol, quote) =>
     set((state) => ({
@@ -73,4 +80,6 @@ export const useMarketStore = create<MarketState>((set) => ({
   setProviders: (providers) => set({ providers }),
 
   setWsStatus: (wsStatus) => set({ wsStatus }),
+
+  updateAdvisor: (ctx, premium, equity) => set({ advisorContext: ctx, advisorPremium: premium, advisorEquity: equity }),
 }))


### PR DESCRIPTION
## Summary

- **Domain layer**: VRP calculator (BSM strike estimation), equity signal synthesis with count-dampened scoring, premium strategy registry with scoring + VRP gating
- **Backend**: AdvisorService orchestrator with signal buffer, REST endpoints (`/api/advisor`), WebSocket integration for real-time advisor data, VIX bootstrap on server startup
- **Frontend**: `/advisor` page with premium strategy cards, equity table with sector filter, symbol search, expandable rows showing trend pulse + key levels
- **Tests**: Unit tests for all domain models, VRP, equity advisor, premium advisor, strategy registry, advisor service, and route handlers

## Test plan

- [ ] `make test` — unit tests pass (includes new advisor tests)
- [ ] `make type-check` — mypy clean
- [ ] `make quality` — lint + format pass
- [ ] Manual: start server, navigate to `/advisor`, verify premium cards render
- [ ] Manual: verify equity table loads, search/filter works, rows expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)