### PR TITLE
feat(ib): wire real reqMktData in IbLiveAdapter.subscribe_quotes

### DIFF
--- a/src/infrastructure/adapters/ib/live_adapter.py
+++ b/src/infrastructure/adapters/ib/live_adapter.py
@@ -64,6 +64,12 @@ class IbLiveAdapter(IbBaseAdapter, QuoteProvider, PositionProvider, AccountProvi
         self._subscribed_symbols: List[str] = []
         self._quote_callback: Optional[Callable[[QuoteTick], None]] = None
 
+        # Symbol-streaming subscriptions (symbol -> ticker, id(ticker) -> symbol)
+        self._active_tickers: Dict[str, Any] = {}
+        self._ticker_to_symbol: Dict[int, str] = {}
+        self._streaming_lock: Lock = Lock()
+        self._streaming_active: bool = False
+
         # Position cache
         self._position_cache: Optional[List[Position]] = None
         self._position_cache_time: Optional[datetime] = None
@@ -265,6 +271,25 @@ class IbLiveAdapter(IbBaseAdapter, QuoteProvider, PositionProvider, AccountProvi
 
     async def _on_disconnecting(self) -> None:
         """Clean up before disconnect."""
+        # Cancel all symbol-streaming subscriptions
+        with self._streaming_lock:
+            if self._streaming_active and self.ib:
+                try:
+                    self.ib.pendingTickersEvent -= self._on_pending_tickers
+                except Exception:
+                    pass
+                self._streaming_active = False
+            tickers_to_cancel = list(self._active_tickers.values())
+            self._active_tickers.clear()
+            self._ticker_to_symbol.clear()
+
+        if self.ib:
+            for ticker in tickers_to_cancel:
+                try:
+                    self.ib.cancelMktData(ticker.contract)
+                except Exception:
+                    pass
+
         if self._market_data_fetcher:
             self._market_data_fetcher.cleanup()
             self._market_data_fetcher = None
@@ -283,18 +308,63 @@ class IbLiveAdapter(IbBaseAdapter, QuoteProvider, PositionProvider, AccountProvi
     # -------------------------------------------------------------------------
 
     async def subscribe_quotes(self, symbols: List[str]) -> None:
-        """Subscribe to real-time quotes."""
-        if not self.is_connected():
+        """Subscribe to real-time quotes via IB reqMktData."""
+        if not self.is_connected() or self.ib is None:
             raise ConnectionError("Not connected to IB")
 
-        self._subscribed_symbols.extend(symbols)
-        logger.info(f"Subscribed to {len(symbols)} symbols")
+        from ib_async import Stock
+
+        new_symbols = [s for s in symbols if s not in self._active_tickers]
+        if not new_symbols:
+            return
+
+        contracts = [Stock(sym, "SMART", "USD") for sym in new_symbols]
+        try:
+            qualified_raw = await self.ib.qualifyContractsAsync(*contracts)
+        except Exception as e:
+            logger.error(f"Failed to qualify contracts for {new_symbols}: {e}")
+            return
+
+        qualified = [c for c in qualified_raw if c is not None and getattr(c, "conId", None)]
+        if not qualified:
+            logger.warning(f"No contracts qualified for {new_symbols}")
+            return
+
+        with self._streaming_lock:
+            if not self._streaming_active:
+                self.ib.pendingTickersEvent += self._on_pending_tickers
+                self._streaming_active = True
+
+        for qc in qualified:
+            sym = qc.symbol
+            with self._streaming_lock:
+                if sym in self._active_tickers:
+                    continue
+                ticker = self.ib.reqMktData(qc, "", False, False)
+                self._active_tickers[sym] = ticker
+                self._ticker_to_symbol[id(ticker)] = sym
+            if sym not in self._subscribed_symbols:
+                self._subscribed_symbols.append(sym)
+
+        logger.info(f"Subscribed to {len(qualified)} symbols via reqMktData")
 
     async def unsubscribe_quotes(self, symbols: List[str]) -> None:
-        """Unsubscribe from quotes."""
-        for symbol in symbols:
-            if symbol in self._subscribed_symbols:
-                self._subscribed_symbols.remove(symbol)
+        """Unsubscribe from quotes and cancel IB market data."""
+        for sym in symbols:
+            with self._streaming_lock:
+                ticker = self._active_tickers.pop(sym, None)
+                if ticker:
+                    self._ticker_to_symbol.pop(id(ticker), None)
+
+            if ticker and self.ib:
+                try:
+                    self.ib.cancelMktData(ticker.contract)
+                except Exception as e:
+                    logger.warning(f"Error cancelling market data for {sym}: {e}")
+
+            if sym in self._subscribed_symbols:
+                self._subscribed_symbols.remove(sym)
+
         logger.info(f"Unsubscribed from {len(symbols)} symbols")
 
     def set_quote_callback(self, callback: Optional[Callable[[QuoteTick], None]]) -> None:
@@ -348,6 +418,44 @@ class IbLiveAdapter(IbBaseAdapter, QuoteProvider, PositionProvider, AccountProvi
         if self._quote_callback:
             quote_tick = self._market_data_to_quote_tick(market_data)
             self._quote_callback(quote_tick)
+
+    def _on_pending_tickers(self, tickers: Any) -> None:
+        """Route IB pendingTickersEvent to _quote_callback for subscribed symbols."""
+        if not self._quote_callback:
+            return
+
+        for ticker in tickers:
+            sym = self._ticker_to_symbol.get(id(ticker))
+            if not sym:
+                continue
+            try:
+                md = self._ticker_to_market_data(sym, ticker)
+                self._handle_streaming_update(sym, md)
+            except Exception as e:
+                logger.warning(f"Error processing tick for {sym}: {e}")
+
+    def _ticker_to_market_data(self, symbol: str, ticker: Any) -> MarketData:
+        """Convert an IB ticker snapshot to MarketData."""
+
+        def safe(val: Any) -> Optional[float]:
+            try:
+                f = float(val)
+                return None if isnan(f) else f
+            except (TypeError, ValueError):
+                return None
+
+        bid = safe(ticker.bid)
+        ask = safe(ticker.ask)
+        last = safe(ticker.last)
+        mid = float((bid + ask) / 2) if bid and ask else None
+        return MarketData(
+            symbol=symbol,
+            bid=bid,
+            ask=ask,
+            last=last,
+            mid=mid,
+            timestamp=datetime.now(),
+        )
 
     # -------------------------------------------------------------------------
     # PositionProvider Implementation
@@ -693,7 +801,7 @@ class IbLiveAdapter(IbBaseAdapter, QuoteProvider, PositionProvider, AccountProvi
                     timeout=15.0,
                 )
             except asyncio.TimeoutError:
-                logger.error(f"Timeout fetching market data after 15s")
+                logger.error("Timeout fetching market data after 15s")
                 return []
 
             for md in market_data_list:

--- a/tests/unit/infrastructure/adapters/ib/test_live_adapter_subscribe.py
+++ b/tests/unit/infrastructure/adapters/ib/test_live_adapter_subscribe.py
@@ -1,0 +1,276 @@
+"""
+Tests for IbLiveAdapter.subscribe_quotes / unsubscribe_quotes real IB wiring.
+
+Verifies that:
+- qualifyContractsAsync and reqMktData are called per symbol on subscribe
+- cancelMktData is called per symbol on unsubscribe
+- _quote_callback fires when a fake pendingTickersEvent is dispatched
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass
+from math import nan
+from threading import Lock
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out heavy transitive imports before importing live_adapter
+# ---------------------------------------------------------------------------
+
+for _mod in [
+    "scipy",
+    "scipy.stats",
+    "futu",
+    "futu.api",
+    "openssl",
+    "redis",
+    "aiohttp",
+    "talib",
+    "pandas_market_calendars",
+    "exchange_calendars",
+    "psycopg2",
+    "asyncpg",
+    "sqlalchemy",
+    "alembic",
+    "boto3",
+    "botocore",
+    "anthropic",
+    "openai",
+    "matplotlib",
+    "seaborn",
+    "plotly",
+    "sklearn",
+    "ta",
+    "mplfinance",
+    "rich",
+    "textual",
+]:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+# Stub out entire backtest package to avoid scipy/pandas_market_calendars deps
+_backtest_stub = MagicMock()
+for _mod in [
+    "src.backtest",
+    "src.backtest.data",
+    "src.backtest.data.calendar",
+    "src.backtest.analysis",
+]:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = _backtest_stub
+
+# Stub out futu adapter package
+for _mod in [
+    "src.infrastructure.adapters.futu",
+    "src.infrastructure.adapters.futu.adapter",
+    "src.infrastructure.adapters.futu.order_fetcher",
+    "src.infrastructure.adapters.futu.converters",
+]:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+# Now we can safely import the module under test
+from src.infrastructure.adapters.ib.live_adapter import IbLiveAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTicker:
+    """Simulates an ib_async Ticker returned by reqMktData."""
+
+    contract: Any = None
+    bid: float = 100.0
+    ask: float = 101.0
+    last: float = 100.5
+
+
+@dataclass
+class FakeContract:
+    """Simulates a qualified ib_async Contract."""
+
+    symbol: str
+    conId: int
+    secType: str = "STK"
+
+
+def _make_adapter() -> IbLiveAdapter:
+    """Return an IbLiveAdapter with minimal state, bypassing real network init."""
+    adapter = IbLiveAdapter.__new__(IbLiveAdapter)
+    adapter._connected = True
+    adapter._event_bus = None
+    # Replicate __init__ state
+    adapter._market_data_fetcher = None
+    adapter._market_data_cache = OrderedDict()
+    adapter._market_data_cache_max_size = 1000
+    adapter._market_data_cache_lock = Lock()
+    adapter._subscribed_symbols = []
+    adapter._quote_callback = None
+    adapter._active_tickers = {}
+    adapter._ticker_to_symbol = {}
+    adapter._streaming_lock = Lock()
+    adapter._streaming_active = False
+    adapter._position_cache = None
+    adapter._position_cache_time = None
+    adapter._position_cache_ttl_sec = 10
+    adapter._position_callback = None
+    adapter._position_subscription_active = False
+    adapter._account_cache = None
+    adapter._account_cache_time = None
+    adapter._account_cache_ttl_sec = 10
+    adapter._account_callback = None
+    adapter._previous_close_cache = {}
+    adapter._previous_close_cache_ttl_sec = 3600
+    adapter._qual_service = None
+    adapter._qualified_contract_cache = {}
+    adapter._contract_cache_lock = Lock()
+    return adapter
+
+
+def _attach_mock_ib(adapter: IbLiveAdapter, symbols: List[str]) -> MagicMock:
+    """Attach a mock IB that returns fake qualified contracts and tickers."""
+    mock_ib = MagicMock()
+    mock_ib.isConnected.return_value = True
+
+    qualified = [FakeContract(symbol=sym, conId=i + 1) for i, sym in enumerate(symbols)]
+    mock_ib.qualifyContractsAsync = AsyncMock(return_value=qualified)
+
+    def _req_mkt_data(contract, *args, **kwargs):
+        return FakeTicker(contract=contract)
+
+    mock_ib.reqMktData.side_effect = _req_mkt_data
+    mock_ib.pendingTickersEvent = MagicMock()
+
+    adapter.ib = mock_ib
+    return mock_ib
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscribe_calls_qualify_and_reqmktdata():
+    """subscribe_quotes must qualify each symbol and call reqMktData once per symbol."""
+    adapter = _make_adapter()
+    symbols = ["AAPL", "MSFT"]
+    mock_ib = _attach_mock_ib(adapter, symbols)
+
+    await adapter.subscribe_quotes(symbols)
+
+    mock_ib.qualifyContractsAsync.assert_called_once()
+    call_args = mock_ib.qualifyContractsAsync.call_args[0]
+    assert len(call_args) == 2
+    assert {c.symbol for c in call_args} == {"AAPL", "MSFT"}
+
+    assert mock_ib.reqMktData.call_count == 2
+    assert set(adapter._active_tickers.keys()) == {"AAPL", "MSFT"}
+    assert set(adapter._subscribed_symbols) == {"AAPL", "MSFT"}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_skips_already_subscribed():
+    """subscribe_quotes must not re-qualify or re-subscribe an already-active symbol."""
+    adapter = _make_adapter()
+    mock_ib = _attach_mock_ib(adapter, ["AAPL"])
+
+    await adapter.subscribe_quotes(["AAPL"])
+    first_count = mock_ib.reqMktData.call_count
+
+    await adapter.subscribe_quotes(["AAPL"])
+
+    assert mock_ib.reqMktData.call_count == first_count
+
+
+@pytest.mark.asyncio
+async def test_subscribe_registers_pending_tickers_event_once():
+    """pendingTickersEvent handler must be registered exactly once across multiple subscribes."""
+    adapter = _make_adapter()
+    mock_ib = _attach_mock_ib(adapter, ["AAPL", "TSLA"])
+
+    # Capture the original mock before += reassigns the attribute
+    original_event = mock_ib.pendingTickersEvent
+
+    await adapter.subscribe_quotes(["AAPL"])
+    # Re-attach returns new qualified list for TSLA
+    mock_ib.qualifyContractsAsync = AsyncMock(
+        return_value=[FakeContract(symbol="TSLA", conId=99)]
+    )
+    await adapter.subscribe_quotes(["TSLA"])
+
+    # += calls __iadd__ on the original event object exactly once
+    assert original_event.__iadd__.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_calls_cancel_mkt_data():
+    """unsubscribe_quotes must call cancelMktData for each unsubscribed symbol."""
+    adapter = _make_adapter()
+    mock_ib = _attach_mock_ib(adapter, ["AAPL", "MSFT"])
+
+    await adapter.subscribe_quotes(["AAPL", "MSFT"])
+    await adapter.unsubscribe_quotes(["AAPL"])
+
+    mock_ib.cancelMktData.assert_called_once()
+    assert "AAPL" not in adapter._active_tickers
+    assert "AAPL" not in adapter._subscribed_symbols
+    assert "MSFT" in adapter._active_tickers
+
+
+@pytest.mark.asyncio
+async def test_quote_callback_fires_on_pending_tickers_event():
+    """When _on_pending_tickers fires with a subscribed ticker, _quote_callback must be called."""
+    adapter = _make_adapter()
+    _attach_mock_ib(adapter, ["AAPL"])
+    await adapter.subscribe_quotes(["AAPL"])
+
+    received: List[Any] = []
+    adapter.set_quote_callback(received.append)
+
+    aapl_ticker = adapter._active_tickers["AAPL"]
+    adapter._on_pending_tickers([aapl_ticker])
+
+    assert len(received) == 1
+    tick = received[0]
+    assert tick.symbol == "AAPL"
+    assert tick.bid == pytest.approx(100.0)
+    assert tick.ask == pytest.approx(101.0)
+    assert tick.last == pytest.approx(100.5)
+
+
+@pytest.mark.asyncio
+async def test_unknown_ticker_does_not_raise():
+    """_on_pending_tickers must silently ignore tickers not in _ticker_to_symbol."""
+    adapter = _make_adapter()
+    adapter.ib = MagicMock()
+
+    received: List[Any] = []
+    adapter.set_quote_callback(received.append)
+
+    alien_ticker = FakeTicker()
+    adapter._on_pending_tickers([alien_ticker])
+
+    assert received == []
+
+
+def test_nan_fields_coerced_to_none():
+    """_ticker_to_market_data must convert NaN float fields to None."""
+    adapter = _make_adapter()
+
+    nan_ticker = FakeTicker(bid=nan, ask=nan, last=nan)
+    md = adapter._ticker_to_market_data("AAPL", nan_ticker)
+
+    assert md.bid is None
+    assert md.ask is None
+    assert md.last is None
+    assert md.mid is None


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `IbLiveAdapter.subscribe_quotes()` was a stub that only appended to `_subscribed_symbols` without calling IB's `reqMktData`, so no ticks ever flowed → `bars` table never populated → `apex_regime` NOTIFY never fired.
- **`subscribe_quotes(symbols)`** now builds `Stock(sym, "SMART", "USD")` contracts, qualifies them via `qualifyContractsAsync`, calls `reqMktData` per qualified contract, stores handles in `_active_tickers`, and registers `pendingTickersEvent` once to route ticks through the existing `_quote_callback` pipeline.
- **`unsubscribe_quotes(symbols)`** calls `cancelMktData` per handle and cleans up the tracking dicts.
- **`_on_disconnecting`** cancels all active subscriptions and deregisters the event handler on teardown.

## Key design decisions

- Uses the same `_active_tickers: Dict[str, Any]` / `_ticker_to_symbol: Dict[int, str]` pattern as `MarketDataFetcher` for O(1) symbol lookup in the hot callback path.
- `pendingTickersEvent` handler is registered once (guarded by `_streaming_active` flag + lock) regardless of how many times `subscribe_quotes` is called.
- Routes through the existing `_handle_streaming_update → _quote_callback` path — no changes to `signal_service.py` needed.

## Files changed

| File | Change |
|------|--------|
| `src/infrastructure/adapters/ib/live_adapter.py` | Replace stub with real subscription logic; add `_on_pending_tickers`, `_ticker_to_market_data`, disconnect cleanup |
| `tests/unit/infrastructure/adapters/ib/test_live_adapter_subscribe.py` | 7 new unit tests (mocked IB) — all passing |

## Test results

```
7 passed in 0.22s
```

## ⚠️ Live tick verification requires IB Gateway on local machine

Manual smoke test post-merge:
1. Start IB Gateway (paper or live) on `localhost:7497`
2. `make signal-service`
3. Subscribe a few symbols and verify PG tables populate:
   ```sql
   SELECT * FROM bars ORDER BY ts DESC LIMIT 10;
   SELECT * FROM summary ORDER BY updated_at DESC LIMIT 5;
   SELECT * FROM score_history ORDER BY created_at DESC LIMIT 5;
   ```

https://claude.ai/code/session_012ypDBQAR3u8fVg26Qjd1rf

---
_Generated by [Claude Code](https://claude.ai/code/session_012ypDBQAR3u8fVg26Qjd1rf)_