### PR TITLE
[codex] fix r2 universe null sector handling

### DIFF
--- a/scripts/r2_universe_builder.py
+++ b/scripts/r2_universe_builder.py
@@ -475,7 +475,7 @@ def merge_curated(
         if sym in curated_set:
             continue
 
-        sector = stock.get("sector", "").lower().replace(" ", "_") or "other"
+        sector = str(stock.get("sector") or "").lower().replace(" ", "_") or "other"
         final.append(
             {
                 "symbol": sym,

--- a/tests/unit/scripts/test_r2_universe_builder.py
+++ b/tests/unit/scripts/test_r2_universe_builder.py
@@ -227,14 +227,19 @@ class TestMergeCurated:
             "timeframes": ["1d", "1w"],
         }
 
-    def _make_screened(self, symbol: str, dollar_volume: float = 50_000_000) -> dict[str, Any]:
+    def _make_screened(
+        self,
+        symbol: str,
+        dollar_volume: float = 50_000_000,
+        sector: Any = "Technology",
+    ) -> dict[str, Any]:
         return {
             "symbol": symbol,
             "name": f"{symbol} Corp.",
             "marketCap": 2_000_000_000,
             "dollar_volume": dollar_volume,
             "turnover_rate": 0.05,
-            "sector": "Technology",
+            "sector": sector,
         }
 
     def test_curated_always_kept(self) -> None:
@@ -275,6 +280,19 @@ class TestMergeCurated:
         assert symbols.count("AAPL") == 1
         assert "MSFT" in symbols
         assert stats["screened_added"] == 1  # only MSFT added
+
+    def test_screened_null_sector_defaults_to_other(self) -> None:
+        """FMP can return null sectors for screened stocks."""
+        tickers, stats = builder.merge_curated(
+            screened=[self._make_screened("NULLSEC", sector=None)],
+            curated=[],
+            screener_metadata={},
+        )
+
+        assert stats["screened_added"] == 1
+        assert tickers[0]["tier"] == "other"
+        assert tickers[0]["sector"] == "other"
+        assert tickers[0]["sectors"] == ["other"]
 
 
 # ── TestLoadCuratedFromYaml ──────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Normalize screened stock `sector` values in `scripts/r2_universe_builder.py` before deriving the output tier.
- Treat missing/null sectors as `other` instead of crashing.
- Added a regression test for `sector=None` during curated/screened merge.

## Root cause

The scheduled R2 pipeline hit a new nullable FMP field: a screened stock had `sector=None`, and `merge_curated()` called `.lower()` directly on that value.

## Validation

- `uv run pytest --no-cov tests/unit/scripts/test_r2_universe_builder.py` -> 20 passed
- `uv run black --check scripts/r2_universe_builder.py tests/unit/scripts/test_r2_universe_builder.py` -> passed
- `uv run isort --check-only scripts/r2_universe_builder.py tests/unit/scripts/test_r2_universe_builder.py` -> passed
- `uv run flake8 scripts/r2_universe_builder.py tests/unit/scripts/test_r2_universe_builder.py` -> passed