### PR TITLE
Chart read surface: bars + compute-on-read indicators + confluence (stateless argon)

### DIFF
--- a/config/verification/schemas/bars_payload.schema.json
+++ b/config/verification/schemas/bars_payload.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apex.trading/schemas/bars_payload.schema.json",
+  "title": "BarsPayload",
+  "description": "OHLCV bar series for chart rendering (sourced from livewire)",
+  "type": "object",
+  "required": ["symbol", "timeframe", "bars", "generated_at"],
+  "properties": {
+    "symbol": { "type": "string", "minLength": 1 },
+    "timeframe": {
+      "type": "string",
+      "enum": ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w"]
+    },
+    "count": { "type": "integer", "minimum": 0 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "bars": { "type": "array", "items": { "$ref": "#/$defs/bar" } }
+  },
+  "$defs": {
+    "bar": {
+      "type": "object",
+      "required": ["time", "open", "high", "low", "close"],
+      "properties": {
+        "time": { "type": "string", "format": "date-time" },
+        "open": { "type": "number" },
+        "high": { "type": "number" },
+        "low": { "type": "number" },
+        "close": { "type": "number" },
+        "volume": { "type": ["integer", "number", "null"] },
+        "vwap": { "type": ["number", "null"] }
+      }
+    }
+  }
+}

--- a/config/verification/schemas/confluence_payload.schema.json
+++ b/config/verification/schemas/confluence_payload.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apex.trading/schemas/confluence_payload.schema.json",
+  "title": "ConfluencePayload",
+  "description": "Multi-timeframe confluence score series (DB-backed: depth = persisted history)",
+  "type": "object",
+  "required": ["symbol", "timeframe", "points", "generated_at"],
+  "properties": {
+    "symbol": { "type": "string", "minLength": 1 },
+    "timeframe": {
+      "type": "string",
+      "enum": ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w"]
+    },
+    "count": { "type": "integer", "minimum": 0 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "points": { "type": "array", "items": { "$ref": "#/$defs/point" } }
+  },
+  "$defs": {
+    "point": {
+      "type": "object",
+      "required": [
+        "time",
+        "alignment_score",
+        "bullish_count",
+        "bearish_count",
+        "neutral_count",
+        "total_indicators"
+      ],
+      "properties": {
+        "time": { "type": "string", "format": "date-time" },
+        "alignment_score": { "type": "number" },
+        "bullish_count": { "type": "integer", "minimum": 0 },
+        "bearish_count": { "type": "integer", "minimum": 0 },
+        "neutral_count": { "type": "integer", "minimum": 0 },
+        "total_indicators": { "type": "integer", "minimum": 0 },
+        "dominant_direction": {
+          "type": ["string", "null"],
+          "enum": ["bullish", "bearish", "neutral", null]
+        }
+      }
+    }
+  }
+}

--- a/config/verification/schemas/indicator_series_payload.schema.json
+++ b/config/verification/schemas/indicator_series_payload.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apex.trading/schemas/indicator_series_payload.schema.json",
+  "title": "IndicatorSeriesPayload",
+  "description": "Per-bar indicator value series (compute-on-read) for chart overlays/oscillators",
+  "type": "object",
+  "required": ["symbol", "timeframe", "indicator", "points", "generated_at"],
+  "properties": {
+    "symbol": { "type": "string", "minLength": 1 },
+    "timeframe": {
+      "type": "string",
+      "enum": ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w"]
+    },
+    "indicator": { "type": "string", "minLength": 1 },
+    "count": { "type": "integer", "minimum": 0 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "points": { "type": "array", "items": { "$ref": "#/$defs/point" } }
+  },
+  "$defs": {
+    "point": {
+      "type": "object",
+      "required": ["time", "state"],
+      "properties": {
+        "time": { "type": "string", "format": "date-time" },
+        "state": {
+          "type": "object",
+          "description": "Indicator state dict (shape varies per indicator, e.g. {value, zone})",
+          "additionalProperties": true
+        },
+        "bar_close": { "type": ["number", "null"] }
+      }
+    }
+  }
+}

--- a/docs/argon-apex-api.md
+++ b/docs/argon-apex-api.md
@@ -1,0 +1,206 @@
+# apex API reference (for argon)
+
+Everything argon needs to consume apex: the WebSocket signal stream and the REST read surface
+(signals backfill + chart bars/indicators/confluence). **argon stores nothing** — it pulls all
+state from apex on demand.
+
+> **Doc roles.** This file is the **API reference** (endpoints, params, status codes, shapes).
+> For the narrative guide with **real captured frames**, runnable copy-paste examples, and the
+> contract deep-dive, see [argon-signal-consumption.md](argon-signal-consumption.md). The
+> **contract source of truth** is the JSON Schemas in `config/verification/schemas/` — apex runs
+> `validate_payload()` on **every** frame before sending, so argon can trust the shape.
+
+---
+
+## 1. Connect
+
+| | |
+|---|---|
+| Base URL | `http://<host>:8322` (HTTP) / `ws://<host>:8322` (WS). Port = `APEX_API_PORT`, default `8322`. |
+| Run apex | `uv run python -m src.api.server` |
+| Health | `GET /health` → `{ "status": "ok", "uptime": <s>, "service": "apex-signal-server", "pg_connected": <bool> }` |
+
+apex's data sources are env-gated, which determines what's available:
+
+| Feature | Requires | If unset |
+|---|---|---|
+| Live signal push + chart bars/indicators warmup | `APEX_LIVEWIRE_ROOT` (see [livewire doc](livewire-apex-integration.md)) | `/ws/signals` connects but stays silent; `/bars`,`/indicators` → `503` |
+| Signal snapshot/backfill + confluence | `APEX_PG_URL` (Postgres) | `/signals`,`/confluence` → `503`; live WS push still works |
+| Live ticks | `APEX_XENON_WS_URL` (default `ws://127.0.0.1:8765`) | no live frames; snapshot/REST still work |
+
+All timestamps in every response are **UTC** ISO-8601.
+
+---
+
+## 2. WebSocket — `GET /ws/signals` (live signals)
+
+Bidirectional. argon sends action frames; apex replies with acks, an initial snapshot, then live
+signal frames as rules fire.
+
+**argon → apex**
+
+```json
+{ "action": "subscribe",   "ticker": "AAPL" }
+{ "action": "unsubscribe", "ticker": "AAPL" }
+```
+
+**apex → argon**
+
+1. **Ack** — `{ "status": "subscribed", "ticker": "AAPL" }` (or `"unsubscribed"`).
+2. **Initial snapshot** (only on subscribe, only if `APEX_PG_URL` set) — a `signal_service_payload`
+   of recent persisted signals for that ticker, so argon can render immediately on load/reconnect.
+   Empty `signals: []` if none yet.
+3. **Live frames** — a one-signal `signal_service_payload` each time a rule fires for a subscribed
+   ticker.
+4. Bad frame → `{ "status": "error", "detail": "bad frame" }`.
+
+**Semantics**
+
+- Signals fire **per closed bar**, not per tick (a live tick is stitched into the in-progress
+  bar; indicators + rules run only when the bar closes). Quiet markets produce **no frames** —
+  don't treat silence as a disconnect; rely on the WS ping/pong.
+- Many argon clients can subscribe to the same ticker — apex computes once and fans out
+  (ref-counted). Unsubscribe/disconnect decrements; compute stops at zero.
+
+---
+
+## 3. REST endpoints
+
+| Method · Path | Purpose | Backed by | Key errors |
+|---|---|---|---|
+| `GET /signals/{ticker}` | Signal backfill (load / reconnect / `?since=`) | PG `ta_signals` | `503` no PG |
+| `GET /bars/{ticker}` | OHLCV candles | livewire bronze (DuckDB) | `400` bad tf · `503` no provider |
+| `GET /indicators/{ticker}` | Per-bar indicator series (compute-on-read) | `indicator.calculate()` | `404` unknown indicator · `400` bad tf · `503` no provider |
+| `GET /confluence/{ticker}` | Multi-timeframe confluence | PG `confluence_scores` | `503` no PG |
+
+### `GET /signals/{ticker}`
+Query: `since` (optional ISO-8601 — only signals at/after it). → `signal_service_payload`.
+
+```
+GET /signals/AAPL
+GET /signals/AAPL?since=2026-06-14T00:00:00Z
+```
+
+### `GET /bars/{ticker}`
+Query: `timeframe` (default `1d`), `start`, `end` (optional ISO-8601). → `bars_payload`.
+
+- **Omit `start`/`end`** → the **most recent 500 bars** (apex over-fetches calendar lookback and
+  tail-slices to 500, so market closures don't shrink the result).
+- Provide `start` (± `end`) → that exact range, **uncapped** (trusted-network service).
+- Timeframes: `1m`,`5m`,`30m`,`1h`,`1d`. Others (`15m`,`4h`,`1w`) → `400`.
+
+```
+GET /bars/AAPL?timeframe=1d
+GET /bars/AAPL?timeframe=1h&start=2026-06-01T00:00:00Z&end=2026-06-12T00:00:00Z
+```
+
+### `GET /indicators/{ticker}`
+Query: `indicator` (**required**), `timeframe` (default `1d`), `start`, `end`. → `indicator_series_payload`.
+
+- **Compute-on-read**: recomputed from livewire bars on every request → full depth, gap-free,
+  always aligned to the candles. Uses apex's **default params, identical to the live engine**, so
+  chart lines match fired signals.
+- Same window rules as `/bars` (no-arg → last 500).
+- `indicator` is any of apex's **48 registered indicators** by name (`rsi`, `macd`, `bollinger`,
+  `supertrend`, `obv`, `atr`, `ema`, `sma`, `ichimoku`, `adx`, `vwap`, `cci`, `stochastic`, …).
+  Unknown name → `404`. The `state` object's shape **varies per indicator**.
+
+```
+GET /indicators/AAPL?timeframe=1d&indicator=rsi
+GET /indicators/AAPL?timeframe=1d&indicator=macd&start=2026-05-01T00:00:00Z
+```
+
+### `GET /confluence/{ticker}`
+Query: `timeframe` (default `1d`), `start`, `end`, `limit` (default `500`, `1..5000`).
+→ `confluence_payload`.
+
+- PG-backed, so it accepts **any** timeframe that has persisted rows.
+- Depth = persisted history (only from when apex began computing it for that symbol/timeframe).
+- `limit` is explicit and **not** silently capped at the repo default.
+
+```
+GET /confluence/AAPL?timeframe=1d
+GET /confluence/AAPL?timeframe=1d&limit=2000
+```
+
+---
+
+## 4. Payload shapes
+
+All chart payloads share an envelope: `symbol`, `timeframe`, `count`, `generated_at` (UTC), plus
+the data array. Validated on egress against `config/verification/schemas/`.
+
+**`signal_service_payload`** (`/signals`, WS snapshot + live) — `signals[]`, `timestamp`,
+`symbol_count`. Each signal: `signal_id` (`{category}:{indicator}:{symbol}:{timeframe}`),
+`symbol`, `category` (`momentum|trend|volatility|volume|pattern|regime`), `indicator`,
+`direction` (**`buy|sell|alert`**, normalized from the DB's `LONG/SHORT/FLAT`), `strength`
+(0–100), `priority` (`high|medium|low`), `timeframe`, `trigger_rule`, `current_value`,
+`timestamp`, optional `threshold`/`previous_value`/`message`/`metadata`. Full field table: §8 of
+the [consumption guide](argon-signal-consumption.md).
+
+**`bars_payload`** — `bars[]` of `{ time, open, high, low, close, volume|null, vwap|null }`.
+
+**`indicator_series_payload`** — `points[]` of `{ time, state (object, shape per indicator),
+bar_close (number|null — close at that bar, to align an oscillator to price) }`.
+
+**`confluence_payload`** — `points[]` of `{ time, alignment_score (−1..+1), bullish_count,
+bearish_count, neutral_count, total_indicators, dominant_direction (bullish|bearish|neutral|null) }`,
+oldest-first.
+
+---
+
+## 5. Status codes
+
+| Code | When |
+|---|---|
+| `200` | OK |
+| `400` | Unsupported timeframe on `/bars` or `/indicators` (livewire warehouses `1m/5m/30m/1h/1d`) |
+| `404` | Unknown indicator name on `/indicators` |
+| `503` | Required source not configured: no `APEX_LIVEWIRE_ROOT` (`/bars`,`/indicators`) or no `APEX_PG_URL` (`/signals`,`/confluence`) |
+
+---
+
+## 6. Minimal examples
+
+**Browser / TypeScript — live + chart**
+
+```ts
+// live signals
+const ws = new WebSocket("ws://localhost:8322/ws/signals");
+ws.onopen = () => ws.send(JSON.stringify({ action: "subscribe", ticker: "AAPL" }));
+ws.onmessage = (e) => {
+  const msg = JSON.parse(e.data);
+  if (msg.status) return;                 // ack
+  for (const s of msg.signals ?? []) renderSignal(s);   // snapshot + live frames
+};
+
+// chart on load (stateless: re-fetch whatever you need to draw)
+const tf = "1d";
+const [bars, rsi, conf] = await Promise.all([
+  fetch(`http://localhost:8322/bars/AAPL?timeframe=${tf}`).then(r => r.json()),
+  fetch(`http://localhost:8322/indicators/AAPL?timeframe=${tf}&indicator=rsi`).then(r => r.json()),
+  fetch(`http://localhost:8322/confluence/AAPL?timeframe=${tf}`).then(r => r.json()),
+]);
+drawCandles(bars.bars); drawOscillator(rsi.points); drawConfluence(conf.points);
+```
+
+**Python smoke test**
+
+```python
+import httpx
+b = httpx.get("http://localhost:8322/bars/AAPL", params={"timeframe": "1d"}).json()
+print(b["count"], b["bars"][-1])
+```
+
+---
+
+## 7. Notes & current limitations
+
+- Chart data is **REST-only (poll)** today — there is no live WS push for bars/indicators/
+  confluence. Live **signals** stream over `/ws/signals`; re-pull `/bars` + `/indicators` on
+  timeframe-switch / scroll-back.
+- Indicators are **compute-on-read** (uncached, recomputed per request in a worker thread so they
+  never stall the signal stream).
+- Signal **lifecycle** (`status`/`invalidated_*`) is not yet persisted — treat signals as
+  append-only and `active`.
+- Per-bar cadence, not per-tick (§2).

--- a/docs/argon-signal-consumption.md
+++ b/docs/argon-signal-consumption.md
@@ -358,7 +358,7 @@ the single source.
 |---|---|---|---|
 | Candles | GET | `/bars/{ticker}?timeframe=&start=&end=` | livewire bronze parquet (read on the fly) |
 | Indicator series | GET | `/indicators/{ticker}?timeframe=&indicator=&start=&end=` | **compute-on-read** (recomputed from bars) |
-| Confluence | GET | `/confluence/{ticker}?timeframe=&start=&end=` | Postgres `confluence_scores` (persisted) |
+| Confluence | GET | `/confluence/{ticker}?timeframe=&start=&end=&limit=` | Postgres `confluence_scores` (persisted) |
 
 **Storage model.** Nothing is cached on argon's side. On apex's side it is a deliberate mix:
 
@@ -368,7 +368,13 @@ the single source.
 | indicators | recomputed per request | **compute-on-read** — full depth, gap-free, always matches the candles |
 | confluence | `confluence_scores` PG table | served from storage (depth = persisted history) |
 
-- `start`/`end` are optional ISO-8601; **omit them for the most recent ~500 bars**.
+- `start`/`end` are optional ISO-8601; **omit them for the most recent 500 bars** (apex
+  over-fetches the calendar lookback and tail-slices to 500, so closures don't shrink it).
+- **Supported timeframes for `/bars` + `/indicators`: `1m`, `5m`, `30m`, `1h`, `1d`** (what
+  livewire warehouses). `15m`/`4h`/`1w` → **`400`**. `/confluence` accepts any timeframe that
+  has persisted rows.
+- `/confluence` takes an optional `limit` (default `500`) so you can pull more than the
+  repository default — it is **not** silently capped.
 - All timestamps are emitted in **UTC** (matching the signal contract).
 - Indicators are computed with apex's **default parameters — identical to the live engine**,
   so chart lines line up with the fired signals.
@@ -548,7 +554,8 @@ indicator**, e.g. `{value, zone}` for rsi, `{macd, signal, histogram, direction}
   is available.
 - **Chart data is REST-only (poll).** There is no live WS push for bars/indicators/confluence
   yet — argon polls `/bars` + `/indicators` (and gets live *signals* over `/ws/signals`).
-- **Chart indicators are compute-on-read** (CPU per request, uncached); confluence history is
+- **Chart indicators are compute-on-read** (recomputed per request, uncached — run off the
+  event loop in a worker thread so they don't block the signal stream); confluence history is
   limited to what is persisted in `confluence_scores`.
 - **livewire bronze `COLUMN_MAP` is unverified against real data** — the §10 capture used a
   synthetic bronze fixture. Confirm the real parquet column names before production charting.

--- a/docs/argon-signal-consumption.md
+++ b/docs/argon-signal-consumption.md
@@ -1,15 +1,21 @@
 # Consuming APEX TA Signals from argon
 
 How argon connects to a running **apex** instance to receive live technical-analysis
-signals, with **real, captured** request/response frames (not hand-written examples).
+signals **and to fetch everything needed to render a full chart** (candles, indicator
+overlays/oscillators, confluence) — with **real, captured** request/response frames
+(not hand-written examples).
 
 > Audience: argon (the UI). apex is the TA brain; it ingests bars (from livewire) and
 > live ticks (from xenon), computes indicators on each closed bar, runs the rule engine,
 > and emits `signal_service_payload` frames. argon subscribes per ticker and renders them.
 >
-> Everything in §7 ("Verified end-to-end") was captured from a running apex wired to the
-> **live local xenon (`ws://127.0.0.1:8765`)** and **Postgres (`apex_signals`)** — see that
-> section for the exact bytes.
+> **argon stores nothing** — it pulls signals (§4–§9) *and* all chart data (§10) from apex
+> on demand. apex is the single source: bars from livewire, indicator lines recomputed on
+> read, confluence + signals from Postgres.
+>
+> Everything in §7 and §10 ("Verified end-to-end") was captured from a running apex wired to
+> the **live local xenon (`ws://127.0.0.1:8765`)** and **Postgres (`apex_signals`)** — see
+> those sections for the exact bytes.
 
 ---
 
@@ -29,6 +35,9 @@ apex exposes two consumer surfaces over one HTTP server:
 |---|---|---|---|
 | **Live push** | WebSocket | `/ws/signals` | Subscribe per ticker; receive signals as they fire. **Primary path.** |
 | Backfill pull | HTTP GET | `/signals/{ticker}?since=<iso8601>` | Fetch persisted signals on load/reconnect (requires Postgres). |
+| Chart: candles | HTTP GET | `/bars/{ticker}` | OHLCV bars for the chart body (from livewire). **See §10.** |
+| Chart: indicators | HTTP GET | `/indicators/{ticker}` | Per-bar indicator series (compute-on-read) for overlays/oscillators. **See §10.** |
+| Chart: confluence | HTTP GET | `/confluence/{ticker}` | Multi-timeframe confluence scores (from Postgres). **See §10.** |
 | Health | HTTP GET | `/health` | Liveness + `pg_connected`. |
 
 Default listen address: `0.0.0.0:8322` (override with `APEX_API_PORT`).
@@ -45,7 +54,7 @@ is set**; live ticks flow from xenon automatically (the URL is baked in — see 
 |---|---|---|
 | `APEX_LIVEWIRE_ROOT` | *(unset)* | Bronze parquet root for historical bars. **Required** to build the pipeline. Unset → `/ws/signals` connects but emits nothing. |
 | `APEX_XENON_WS_URL` | `ws://127.0.0.1:8765` | xenon tick-feed WS URL. **Baked into apex** (matches xenon's `DEFAULT_IB_REALTIME_PORT`); only set this to override. Connects automatically once the pipeline is built. |
-| `APEX_TIMEFRAMES` | `1d` | Comma-separated timeframes to compute, e.g. `1m,5m,1d`. Drives the live cadence (§11). |
+| `APEX_TIMEFRAMES` | `1d` | Comma-separated timeframes to compute, e.g. `1m,5m,1d`. Drives the live cadence (§6). |
 | `APEX_API_PORT` | `8322` | HTTP/WS listen port. |
 | `APEX_PG_URL` | *(unset)* | Postgres DSN. Enables persistence, the WS initial snapshot, and REST backfill (§4, §9). |
 
@@ -282,7 +291,7 @@ so argon can render immediately on load and backfill the gap.
 
 Every payload apex sends — snapshot, live, or REST — is validated against
 `config/verification/schemas/signal_service_payload.schema.json` before it leaves the
-server (see §12), so argon can trust the shape.
+server (see §11), so argon can trust the shape.
 
 **Envelope**
 
@@ -338,7 +347,183 @@ is contiguous); without `since` it returns the most recent signals (newest-first
 
 ---
 
-## 10. Contract verification
+## 10. Chart read surface (bars + indicators + confluence)
+
+So argon can render a **full chart** — candles, indicator overlays/oscillators, and the
+multi-timeframe confluence blocks — while **storing nothing itself**, apex exposes three REST
+read endpoints. argon GETs what it needs on load / scroll-back / timeframe-switch; apex is
+the single source.
+
+| Surface | Method | Path | Backed by |
+|---|---|---|---|
+| Candles | GET | `/bars/{ticker}?timeframe=&start=&end=` | livewire bronze parquet (read on the fly) |
+| Indicator series | GET | `/indicators/{ticker}?timeframe=&indicator=&start=&end=` | **compute-on-read** (recomputed from bars) |
+| Confluence | GET | `/confluence/{ticker}?timeframe=&start=&end=` | Postgres `confluence_scores` (persisted) |
+
+**Storage model.** Nothing is cached on argon's side. On apex's side it is a deliberate mix:
+
+| Layer | apex source | How |
+|---|---|---|
+| bars | livewire parquet | read on the fly — **no apex storage** |
+| indicators | recomputed per request | **compute-on-read** — full depth, gap-free, always matches the candles |
+| confluence | `confluence_scores` PG table | served from storage (depth = persisted history) |
+
+- `start`/`end` are optional ISO-8601; **omit them for the most recent ~500 bars**.
+- All timestamps are emitted in **UTC** (matching the signal contract).
+- Indicators are computed with apex's **default parameters — identical to the live engine**,
+  so chart lines line up with the fired signals.
+- `/bars` and `/indicators` need `APEX_LIVEWIRE_ROOT` (the bar source) → **`503`** without it.
+  `/confluence` needs `APEX_PG_URL` → **`503`** without it.
+
+**Indicator catalog.** Any of apex's **48 registered indicators** by name — `rsi`, `macd`,
+`bollinger`, `supertrend`, `obv`, `atr`, `ema`, `sma`, `ichimoku`, `adx`, `vwap`, `cci`,
+`stochastic`, … The `state` object's shape varies per indicator (see frames below). An
+unknown name → **`404`**.
+
+```text
+GET /bars/AAPL?timeframe=1d
+GET /bars/AAPL?timeframe=1d&start=2026-01-01T00:00:00Z&end=2026-06-12T00:00:00Z
+GET /indicators/AAPL?timeframe=1d&indicator=rsi
+GET /indicators/AAPL?timeframe=1d&indicator=macd&start=2026-05-01T00:00:00Z&end=2026-06-12T00:00:00Z
+GET /confluence/AAPL?timeframe=1d
+```
+
+### Verified end-to-end (real capture)
+
+Captured on **2026-06-14** from a running apex (real FastAPI lifespan → `LivewireOhlcProvider`
+reads a bronze parquet via DuckDB → compute-on-read → `validate_payload` → JSON; confluence is
+a real Postgres round-trip on `apex_signals`). **Caveat:** the bar *data* below is a synthetic
+bronze fixture — the real livewire bronze tree was not reachable in the capture env — so the
+*values* are illustrative; the **code path, payload shapes, and schema validation are real**.
+Arrays are trimmed to first-2 + last for readability.
+
+**Startup:**
+
+```json
+{ "pg_connected": true, "ohlc_provider_built": true, "signal_repo_built": true, "indicator_registry_size": 48 }
+```
+
+**`GET /bars/AAPL?timeframe=1d`** → `200`
+
+```json
+{
+  "symbol": "AAPL",
+  "timeframe": "1d",
+  "bars": [
+    { "time": "2025-10-06T00:00:00+00:00", "open": 149.4,  "high": 151.3,  "low": 148.6,  "close": 150.0,  "volume": 1000000, "vwap": null },
+    { "time": "2025-10-07T00:00:00+00:00", "open": 151.13, "high": 153.03, "low": 150.33, "close": 151.73, "volume": 1001000, "vwap": null },
+    "… (250 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "open": 255.85, "high": 257.75, "low": 255.05, "close": 256.45, "volume": 1249000, "vwap": null }
+  ],
+  "count": 250,
+  "generated_at": "2026-06-14T09:48:03.216789+00:00"
+}
+```
+
+**`GET /indicators/AAPL?timeframe=1d&indicator=rsi`** → `200`
+
+```json
+{
+  "symbol": "AAPL",
+  "timeframe": "1d",
+  "indicator": "rsi",
+  "points": [
+    { "time": "2025-10-06T00:00:00+00:00", "state": { "value": 50.0, "zone": "neutral" }, "bar_close": 150.0 },
+    { "time": "2025-10-07T00:00:00+00:00", "state": { "value": 50.0, "zone": "neutral" }, "bar_close": 151.73 },
+    "… (250 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "state": { "value": 77.6491899411675, "zone": "overbought" }, "bar_close": 256.45 }
+  ],
+  "count": 250,
+  "generated_at": "2026-06-14T09:48:03.234453+00:00"
+}
+```
+
+**`GET /indicators/AAPL?timeframe=1d&indicator=macd`** → `200` (multi-field `state`)
+
+```json
+{
+  "symbol": "AAPL", "timeframe": "1d", "indicator": "macd",
+  "points": [
+    { "time": "2025-10-06T00:00:00+00:00", "state": { "macd": 0, "signal": 0, "histogram": 0, "direction": "neutral" }, "bar_close": 150.0 },
+    "… (250 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "state": { "macd": 5.0589, "signal": 6.0116, "histogram": -1.9052, "direction": "bearish" }, "bar_close": 256.45 }
+  ],
+  "count": 250,
+  "generated_at": "2026-06-14T09:48:03.250441+00:00"
+}
+```
+
+**`GET /indicators/AAPL?timeframe=1d&indicator=bollinger`** → `200`
+
+```json
+{
+  "symbol": "AAPL", "timeframe": "1d", "indicator": "bollinger",
+  "points": [
+    { "time": "2025-10-06T00:00:00+00:00", "state": { "upper": 0, "middle": 0, "lower": 0, "bandwidth": 0, "percent_b": 50, "zone": "neutral", "squeeze": false }, "bar_close": 150.0 },
+    "… (250 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "state": { "upper": 262.5457, "middle": 255.4425, "lower": 248.3393, "bandwidth": 5.5615, "percent_b": 57.0919, "zone": "neutral", "squeeze": true }, "bar_close": 256.45 }
+  ],
+  "count": 250,
+  "generated_at": "2026-06-14T09:48:03.266679+00:00"
+}
+```
+
+> The leading bars carry neutral/zero `state` until the indicator's warmup window fills —
+> see "Warmup & history depth" below.
+
+**`GET /confluence/AAPL?timeframe=1d`** → `200` (one row written via apex's persistence API,
+then read back through the endpoint — a real PG round-trip)
+
+```json
+{
+  "symbol": "AAPL",
+  "timeframe": "1d",
+  "points": [
+    { "time": "2026-06-12T00:00:00+00:00", "alignment_score": 0.42, "bullish_count": 4,
+      "bearish_count": 1, "neutral_count": 2, "total_indicators": 7, "dominant_direction": "bullish" }
+  ],
+  "count": 1,
+  "generated_at": "2026-06-14T09:48:03.274114+00:00"
+}
+```
+
+**Unknown indicator** → `404`
+
+```json
+{ "detail": "unknown indicator: nope" }
+```
+
+### Chart payload shapes
+
+All three payloads share an envelope (`symbol`, `timeframe`, `count`, `generated_at` UTC) and
+are validated on egress against their schemas under `config/verification/schemas/`
+(`bars_payload`, `indicator_series_payload`, `confluence_payload`).
+
+**bar** (`bars[]`): `time` (date-time), `open`/`high`/`low`/`close` (number, required),
+`volume` (integer\|null), `vwap` (number\|null).
+
+**indicator point** (`points[]`): `time` (date-time), `state` (object — **shape per
+indicator**, e.g. `{value, zone}` for rsi, `{macd, signal, histogram, direction}` for macd),
+`bar_close` (number\|null — the close at that bar, for aligning an oscillator to price).
+
+**confluence point** (`points[]`): `time`, `alignment_score` (number, −1..+1), `bullish_count`,
+`bearish_count`, `neutral_count`, `total_indicators` (integers), `dominant_direction`
+(`bullish`\|`bearish`\|`neutral`\|null).
+
+### Warmup & history depth
+
+- **Compute-on-read uses a warmup lead.** apex fetches extra bars *before* your requested
+  `start` (≈ the indicator's warmup × 3) so the visible window has valid values. When the
+  window starts at the very beginning of livewire's data (no lead available), the first
+  ~warmup bars carry neutral/zero `state` — visible in the bollinger frame above. A request
+  *inside* a longer history returns fully-populated lines.
+- **Bars have full history** (livewire); **indicator lines have full depth too** because they
+  are recomputed from those bars on every request. **Confluence depth = persisted history**
+  (`confluence_scores`), i.e. only from when apex began computing it for that symbol/timeframe.
+
+---
+
+## 11. Contract verification
 
 - **Single source of truth:** `config/verification/schemas/signal_service_payload.schema.json`
   (JSON Schema 2020-12).
@@ -353,7 +538,7 @@ is contiguous); without `since` it returns the most recent signals (newest-first
 
 ---
 
-## 11. Current limitations
+## 12. Current limitations
 
 - **Signal lifecycle** (`status`/`invalidated_*`) is not yet persisted; signals are
   effectively append-only and `active`.
@@ -361,3 +546,9 @@ is contiguous); without `since` it returns the most recent signals (newest-first
 - apex must be started with `APEX_LIVEWIRE_ROOT` or `/ws/signals` connects but stays silent.
 - The snapshot/REST backfill require `APEX_PG_URL` (§3); without it, only the live WS push
   is available.
+- **Chart data is REST-only (poll).** There is no live WS push for bars/indicators/confluence
+  yet — argon polls `/bars` + `/indicators` (and gets live *signals* over `/ws/signals`).
+- **Chart indicators are compute-on-read** (CPU per request, uncached); confluence history is
+  limited to what is persisted in `confluence_scores`.
+- **livewire bronze `COLUMN_MAP` is unverified against real data** — the §10 capture used a
+  synthetic bronze fixture. Confirm the real parquet column names before production charting.

--- a/docs/argon-signal-consumption.md
+++ b/docs/argon-signal-consumption.md
@@ -397,11 +397,13 @@ GET /confluence/AAPL?timeframe=1d
 ### Verified end-to-end (real capture)
 
 Captured on **2026-06-14** from a running apex (real FastAPI lifespan → `LivewireOhlcProvider`
-reads a bronze parquet via DuckDB → compute-on-read → `validate_payload` → JSON; confluence is
-a real Postgres round-trip on `apex_signals`). **Caveat:** the bar *data* below is a synthetic
-bronze fixture — the real livewire bronze tree was not reachable in the capture env — so the
-*values* are illustrative; the **code path, payload shapes, and schema validation are real**.
-Arrays are trimmed to first-2 + last for readability.
+reads the **real livewire bronze data lake** via DuckDB → compute-on-read → `validate_payload`
+→ JSON; confluence is a real Postgres round-trip on `apex_signals`). The bars are **real AAPL
+daily bars** from the data lake, the indicator lines are recomputed from them, and the
+confluence row was written via apex's persistence API and read back — every frame passed
+`validate_payload` before it was sent. (Reading the real lake relies on the bronze schema fix
+in PR #135, which this branch builds on.) Arrays are trimmed to first-2 + last for readability;
+floats are verbatim.
 
 **Startup:**
 
@@ -416,13 +418,13 @@ Arrays are trimmed to first-2 + last for readability.
   "symbol": "AAPL",
   "timeframe": "1d",
   "bars": [
-    { "time": "2025-10-06T00:00:00+00:00", "open": 149.4,  "high": 151.3,  "low": 148.6,  "close": 150.0,  "volume": 1000000, "vwap": null },
-    { "time": "2025-10-07T00:00:00+00:00", "open": 151.13, "high": 153.03, "low": 150.33, "close": 151.73, "volume": 1001000, "vwap": null },
-    "… (250 total) …",
-    { "time": "2026-06-12T00:00:00+00:00", "open": 255.85, "high": 257.75, "low": 255.05, "close": 256.45, "volume": 1249000, "vwap": null }
+    { "time": "2024-06-14T00:00:00+00:00", "open": 213.81, "high": 215.17, "low": 211.3,  "close": 212.49, "volume": 45295827, "vwap": null },
+    { "time": "2024-06-17T00:00:00+00:00", "open": 213.36, "high": 218.95, "low": 212.72, "close": 216.67, "volume": 63750025, "vwap": null },
+    "… (500 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "open": 296.03, "high": 297.14, "low": 289.62, "close": 291.13, "volume": 38784790, "vwap": null }
   ],
-  "count": 250,
-  "generated_at": "2026-06-14T09:48:03.216789+00:00"
+  "count": 500,
+  "generated_at": "2026-06-14T12:52:21.266353+00:00"
 }
 ```
 
@@ -434,13 +436,13 @@ Arrays are trimmed to first-2 + last for readability.
   "timeframe": "1d",
   "indicator": "rsi",
   "points": [
-    { "time": "2025-10-06T00:00:00+00:00", "state": { "value": 50.0, "zone": "neutral" }, "bar_close": 150.0 },
-    { "time": "2025-10-07T00:00:00+00:00", "state": { "value": 50.0, "zone": "neutral" }, "bar_close": 151.73 },
-    "… (250 total) …",
-    { "time": "2026-06-12T00:00:00+00:00", "state": { "value": 77.6491899411675, "zone": "overbought" }, "bar_close": 256.45 }
+    { "time": "2024-06-14T00:00:00+00:00", "state": { "value": 75.79481014475162, "zone": "overbought" }, "bar_close": 212.49 },
+    { "time": "2024-06-17T00:00:00+00:00", "state": { "value": 78.37764571243576, "zone": "overbought" }, "bar_close": 216.67 },
+    "… (500 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "state": { "value": 42.69399117765261, "zone": "neutral" }, "bar_close": 291.13 }
   ],
-  "count": 250,
-  "generated_at": "2026-06-14T09:48:03.234453+00:00"
+  "count": 500,
+  "generated_at": "2026-06-14T12:52:21.349853+00:00"
 }
 ```
 
@@ -450,12 +452,12 @@ Arrays are trimmed to first-2 + last for readability.
 {
   "symbol": "AAPL", "timeframe": "1d", "indicator": "macd",
   "points": [
-    { "time": "2025-10-06T00:00:00+00:00", "state": { "macd": 0, "signal": 0, "histogram": 0, "direction": "neutral" }, "bar_close": 150.0 },
-    "… (250 total) …",
-    { "time": "2026-06-12T00:00:00+00:00", "state": { "macd": 5.0589, "signal": 6.0116, "histogram": -1.9052, "direction": "bearish" }, "bar_close": 256.45 }
+    { "time": "2024-06-14T00:00:00+00:00", "state": { "macd": 7.344795778178678, "signal": 5.59932029100524, "histogram": 3.4909509743468767, "direction": "bullish" }, "bar_close": 212.49 },
+    "… (500 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "state": { "macd": 2.1210869267071644, "signal": 5.866075222112672, "histogram": -7.489976590811015, "direction": "bearish" }, "bar_close": 291.13 }
   ],
-  "count": 250,
-  "generated_at": "2026-06-14T09:48:03.250441+00:00"
+  "count": 500,
+  "generated_at": "2026-06-14T12:52:21.433597+00:00"
 }
 ```
 
@@ -465,17 +467,19 @@ Arrays are trimmed to first-2 + last for readability.
 {
   "symbol": "AAPL", "timeframe": "1d", "indicator": "bollinger",
   "points": [
-    { "time": "2025-10-06T00:00:00+00:00", "state": { "upper": 0, "middle": 0, "lower": 0, "bandwidth": 0, "percent_b": 50, "zone": "neutral", "squeeze": false }, "bar_close": 150.0 },
-    "… (250 total) …",
-    { "time": "2026-06-12T00:00:00+00:00", "state": { "upper": 262.5457, "middle": 255.4425, "lower": 248.3393, "bandwidth": 5.5615, "percent_b": 57.0919, "zone": "neutral", "squeeze": true }, "bar_close": 256.45 }
+    { "time": "2024-06-14T00:00:00+00:00", "state": { "upper": 212.54451958471378, "middle": 196.02649999999957, "lower": 179.50848041528536, "bandwidth": 16.852843451996794, "percent_b": 99.83496936653282, "zone": "neutral", "squeeze": false }, "bar_close": 212.49 },
+    "… (500 total) …",
+    { "time": "2026-06-12T00:00:00+00:00", "state": { "upper": 319.7833280779816, "middle": 304.10824999999966, "lower": 288.4331719220177, "bandwidth": 10.308880523946296, "percent_b": 8.602279569408926, "zone": "neutral", "squeeze": false }, "bar_close": 291.13 }
   ],
-  "count": 250,
-  "generated_at": "2026-06-14T09:48:03.266679+00:00"
+  "count": 500,
+  "generated_at": "2026-06-14T12:52:21.522975+00:00"
 }
 ```
 
-> The leading bars carry neutral/zero `state` until the indicator's warmup window fills —
-> see "Warmup & history depth" below.
+> Here the default window includes a warmup lead, so **every visible bar carries a populated
+> `state`** (no leading zeros) — note the very first bar already has a real RSI/MACD/Bollinger
+> value. Only when the window starts at the very beginning of livewire's history (no lead
+> available) do the first ~warmup bars read neutral/zero. See "Warmup & history depth" below.
 
 **`GET /confluence/AAPL?timeframe=1d`** → `200` (one row written via apex's persistence API,
 then read back through the endpoint — a real PG round-trip)
@@ -489,7 +493,7 @@ then read back through the endpoint — a real PG round-trip)
       "bearish_count": 1, "neutral_count": 2, "total_indicators": 7, "dominant_direction": "bullish" }
   ],
   "count": 1,
-  "generated_at": "2026-06-14T09:48:03.274114+00:00"
+  "generated_at": "2026-06-14T12:52:21.535493+00:00"
 }
 ```
 
@@ -557,5 +561,7 @@ indicator**, e.g. `{value, zone}` for rsi, `{macd, signal, histogram, direction}
 - **Chart indicators are compute-on-read** (recomputed per request, uncached — run off the
   event loop in a worker thread so they don't block the signal stream); confluence history is
   limited to what is persisted in `confluence_scores`.
-- **livewire bronze `COLUMN_MAP` is unverified against real data** — the §10 capture used a
-  synthetic bronze fixture. Confirm the real parquet column names before production charting.
+- **§10 sample values are a point-in-time capture** (2026-06-14) from the **real** livewire
+  bronze data lake — the schema is matched to livewire's writers and smoke-tested against real
+  bytes (PR #135; intraday `TIMESTAMPTZ` is normalized to UTC on read). The payload *shapes*
+  are stable; the *numbers* move as livewire ingests new bars.

--- a/docs/livewire-apex-integration.md
+++ b/docs/livewire-apex-integration.md
@@ -1,0 +1,189 @@
+# livewire → apex: bronze data-lake integration
+
+How **apex** reads market bars from **livewire**, and the exact data contract apex depends on.
+Audience: livewire maintainers (don't break this contract) and apex operators (point apex at
+the lake). This is the *read* side; livewire owns *writing* the bronze tree.
+
+> **Source of truth.** The contract below was confirmed against livewire's own writers —
+> `clients/bronze_client.py`, `clients/intraday_bronze_client.py`, `clients/symbol_paths.py` —
+> and smoke-tested against the real lake on 2026-06-14. apex's side lives in
+> `src/infrastructure/adapters/livewire/{paths.py,ohlc_provider.py}`.
+
+---
+
+## 1. Model
+
+- livewire is the **warehouse**: it writes per-symbol, per-timeframe **Parquet** files into a
+  Hive-partitioned *bronze* tree.
+- apex is a **read-only, on-demand** consumer. It **stores nothing**. For each
+  `(symbol, timeframe, time-range)` it needs, it runs one ephemeral **DuckDB**
+  `read_parquet(...)` query against a single file and returns the rows. It never scans the
+  whole universe and never copies the lake.
+- apex reads bronze in two places: the streaming **warmup seed** (`SubscriptionManager`
+  preloads history before live ticks) and the **chart read surface** (`GET /bars`,
+  `GET /indicators` — see [argon-apex-api.md](argon-apex-api.md)).
+
+```
+livewire writers ──▶  data-lake/bronze/ (Parquet)  ◀── apex (DuckDB read_parquet, on demand)
+                                                          └─▶ argon (/bars, /indicators)
+```
+
+---
+
+## 2. Directory layout (the partition contract)
+
+```
+<APEX_LIVEWIRE_ROOT>/
+  asset_class=equity/
+    symbol=<encode_symbol(TICKER)>/
+      1d.parquet        # daily
+      1m.parquet        # intraday
+      5m.parquet
+      30m.parquet
+      1h.parquet
+```
+
+- `<APEX_LIVEWIRE_ROOT>` is livewire's `data-lake/bronze` directory.
+- `asset_class=equity` is the only class apex reads today.
+- One Parquet file **per timeframe** per symbol. apex resolves the path with
+  `parquet_path(root, symbol, timeframe)` and reads that file directly — **no globbing, no
+  manifest**. A missing file is treated as "no data" (apex returns an empty list, never errors).
+
+### Timeframes apex reads
+
+`1m`, `5m`, `30m`, `1h`, `1d` (`SUPPORTED_TIMEFRAMES` in `paths.py`). Any other timeframe is
+rejected before touching disk. This is **narrower** than argon's signal-contract timeframe enum
+(which also lists `15m`/`4h`/`1w`); apex's chart endpoints return `400` for those because
+livewire does not warehouse them.
+
+### Symbol encoding (`encode_symbol`) — must match livewire 1:1
+
+The partition directory name is `symbol=<encode_symbol(TICKER)>`, not the raw ticker. apex
+mirrors livewire's `clients/symbol_paths.py` byte-for-byte:
+
+- Keep these characters **literal**: `A–Z`, `0–9`, `.`, `_`, `-`.
+- Percent-encode **every other** character as its UTF-8 bytes, uppercase hex: `%XX` per byte.
+
+| Ticker | Partition dir |
+|---|---|
+| `AAPL` | `symbol=AAPL` |
+| `BRK.B` | `symbol=BRK.B` |
+| `BF-A` | `symbol=BF-A` |
+| `RDS/A` | `symbol=RDS%2FA` (`/` → `%2F`) |
+| `T+E` | `symbol=T%2BE` (`+` → `%2B`) |
+
+> Tickers are uppercase, so the literal set is intentionally case-safe (no lowercasing) — safe
+> on case-insensitive filesystems. If livewire ever changes this encoding, apex's `encode_symbol`
+> must change in lockstep or reads silently miss.
+
+---
+
+## 3. Column schema (per timeframe)
+
+apex reads columns **by name** and **ignores any extras**, so livewire may carry additional
+columns freely. The names and types apex requires:
+
+### Daily — `1d.parquet`
+
+| Column | Type | apex uses it? | Notes |
+|---|---|---|---|
+| `trade_date` | `DATE` (date32) | ✅ **timestamp key** | The bar's calendar date. apex maps it to a UTC midnight instant. |
+| `open` `high` `low` `close` | `DOUBLE` | ✅ | OHLC. apex uses **raw `close`**, not `adj_close`. |
+| `volume` | `BIGINT` | ✅ | Cast to int; null tolerated. |
+| `vwap` | `DOUBLE` | ⚪ optional | Read if present, else `null` in the payload. |
+| `adj_close` | `DOUBLE` | ❌ ignored | apex charts use raw OHLC, not split/dividend-adjusted. |
+| `symbol_id` | `BIGINT` | ❌ ignored | Symbol comes from the partition, not a column. |
+| `asset_class`, `symbol` | `VARCHAR` | ❌ ignored | Redundant with the partition. |
+
+### Intraday — `1m.parquet` / `5m.parquet` / `30m.parquet` / `1h.parquet`
+
+| Column | Type | apex uses it? | Notes |
+|---|---|---|---|
+| `bar_timestamp` | `TIMESTAMP WITH TIME ZONE` (µs, UTC) | ✅ **timestamp key** | Bar open instant. See timezone note. |
+| `open` `high` `low` `close` | `DOUBLE` | ✅ | OHLC. |
+| `volume` | `BIGINT` | ✅ | Cast to int; null tolerated. |
+| `vwap` | `DOUBLE` | ⚪ optional | Read if present, else `null`. |
+| `symbol_id` | `BIGINT` | ❌ ignored | |
+| `asset_class`, `symbol` | `VARCHAR` | ❌ ignored | |
+
+> Intraday has **no `adj_close`** (and apex wouldn't use it anyway).
+
+### Timezone (important)
+
+`bar_timestamp` is stored as `TIMESTAMPTZ`. DuckDB returns `TIMESTAMPTZ` values in the **session
+timezone**, not UTC — e.g. on an `Asia/Hong_Kong` box DuckDB hands back `+08:00`-labelled
+datetimes. The *instant* is correct; the *label* is the machine's locale. **apex normalizes
+every bar timestamp to UTC** (`_to_utc_datetime` → `astimezone(timezone.utc)`) so downstream
+code, payloads, and the indicator engine see one consistent offset. livewire does not need to do
+anything here — just keep writing UTC `TIMESTAMPTZ`.
+
+---
+
+## 4. How apex queries (for reference)
+
+Per request, in a worker thread (off the event loop), against an in-memory DuckDB connection:
+
+```sql
+-- intraday: bind the tz-aware datetimes directly
+SELECT * FROM read_parquet('<file>')
+WHERE bar_timestamp >= ? AND bar_timestamp <= ?
+ORDER BY bar_timestamp ASC;          -- params: [start, end]
+
+-- daily: bind CALENDAR DATES so DATE-vs-TIMESTAMPTZ comparison is tz-agnostic
+SELECT * FROM read_parquet('<file>')
+WHERE trade_date >= ? AND trade_date <= ?
+ORDER BY trade_date ASC;             -- params: [start.date(), end.date()]
+```
+
+Each returned row becomes a `BarData` with `bar_start = bar_end - <timeframe duration>` derived,
+`timestamp = bar_start` (event time, never wall-clock), and `source = "livewire"`.
+
+---
+
+## 5. Configuration
+
+| Env var | Meaning |
+|---|---|
+| `APEX_LIVEWIRE_ROOT` | Absolute path to livewire's `data-lake/bronze`. **Required** for `/bars`, `/indicators`, and the streaming warmup seed — without it those return `503` / stay silent. |
+
+Example (local external volume, 20,389 symbols):
+
+```bash
+export APEX_LIVEWIRE_ROOT=/Volumes/DATA_LAKE/livewire/data-lake/bronze
+```
+
+R2 backup: livewire also mirrors bronze to R2 (`R2_*` creds + `sync_to_r2.py --download` pulls
+the full tree, no symbol filter). For apex, point `APEX_LIVEWIRE_ROOT` at any local copy with the
+layout above.
+
+---
+
+## 6. Contract stability — what livewire must not break
+
+apex reads silently miss (empty results, no error) if any of these change without a matching
+apex change:
+
+1. **Partition layout** `asset_class=equity/symbol=<encode_symbol>/<tf>.parquet`.
+2. **`encode_symbol` rules** (literal `[A-Z0-9._-]`, else `%XX` UTF-8).
+3. **Timestamp column names**: `trade_date` (daily), `bar_timestamp` (intraday).
+4. **OHLCV column names**: `open`, `high`, `low`, `close`, `volume`.
+5. **Timeframe file names**: `1m/5m/30m/1h/1d.parquet`.
+
+Safe to change freely: add/remove any **other** column (apex ignores extras), row counts, file
+internals/compression, partition values for non-equity classes.
+
+---
+
+## 7. Smoke test
+
+With a populated lake and `APEX_LIVEWIRE_ROOT` set, boot apex and pull bars:
+
+```bash
+export APEX_LIVEWIRE_ROOT=/Volumes/DATA_LAKE/livewire/data-lake/bronze
+uv run python -m src.api.server        # serves on :8322
+curl -s 'http://127.0.0.1:8322/bars/AAPL?timeframe=1d' | jq '.count, .bars[-1]'
+```
+
+Expect `200` with real OHLC and UTC `time` values. A `503` means `APEX_LIVEWIRE_ROOT` is unset;
+an empty `bars: []` means the file for that `(symbol, timeframe)` is missing or the range is
+empty. See [argon-apex-api.md](argon-apex-api.md) for the full read-surface reference.

--- a/docs/superpowers/specs/2026-06-14-chart-read-surface-design.md
+++ b/docs/superpowers/specs/2026-06-14-chart-read-surface-design.md
@@ -1,0 +1,118 @@
+# Apex Chart Read Surface — Design Spec
+
+**Date:** 2026-06-14
+**Branch:** `feat/apex-chart-read-surface`
+**Status:** approved (design decisions confirmed with user)
+
+## Problem
+
+The merged signal contract (`/ws/signals` + `/signals/{ticker}`) delivers only one
+layer of a trading chart: the discrete signal markers (the `ta_signals` rows —
+triangles, reversal/invalidation labels). To render a full chart — candles, the
+moving-average / SuperTrend / Bollinger overlays, the oscillator panes
+(RSI, MACD, OBV…), and the multi-timeframe confluence blocks — a consumer needs
+**continuous per-bar time series**, which apex computes but does not expose.
+
+**Hard constraint (user):** argon stores/saves nothing. It is a stateless renderer
+that fetches *everything* it needs from apex on load / reconnect / scroll-back /
+timeframe-switch. So apex must be the single read surface for the whole chart.
+
+## What already exists (verified in code)
+
+- **Bars:** `LivewireOhlcProvider.fetch_bars(symbol, timeframe, start, end)` reads
+  full-history OHLCV from livewire bronze parquet (`ohlc_provider.py:64`). Apex
+  consumes these internally; no route exposes them.
+- **Indicator computation:** every indicator implements a *pure-functional*
+  `calculate(df, params) -> DataFrame` over a bar DataFrame (`base.py:112`) plus
+  `get_state(current, previous, params) -> dict` (`base.py:132`). The live
+  `IndicatorEngine` calls `indicator.calculate(df, indicator.default_params)`
+  (`indicator_engine.py:601`) — **default params, no YAML override** — so a
+  compute-on-read path using `default_params` yields values *identical* to live.
+  Registry: `get_indicator_registry().get(name)` (`registry.py:224`), 51 indicators.
+- **Confluence:** persisted to `confluence_scores`; readable via
+  `TASignalRepository.get_confluence_history(symbol, timeframe, start, end, limit)`.
+- **Persistence is wired:** `TASignalService` writes `indicator_values`
+  (`_persist_indicator`, `ta_signal_service.py:374`) and `confluence_scores`
+  (`_persist_confluence`, `:299`) whenever a persistence repo is supplied — which
+  the lifespan now does.
+
+## Decisions
+
+1. **Bars** → serve from livewire (full history). New `GET /bars/{ticker}`.
+2. **Indicator series** → **compute-on-read (full depth)**. apex fetches the bar
+   window (plus a warmup lead) from livewire and recomputes the indicator over it,
+   returning a per-bar value series. Chosen over serve-from-DB because indicator
+   values only exist in PG from when apex started watching; compute-on-read gives
+   gap-free lines that always match the candles, and it's deterministic
+   (pure function of bars + `default_params`).
+3. **Confluence** → serve from `confluence_scores` (DB-backed). Confluence is a
+   cross-indicator aggregate with debounce/state, *not* a pure function of one bar
+   series, so historical depth = what's persisted. Documented as such.
+4. **Contract rigor** → each new payload gets a JSON schema under
+   `config/verification/schemas/` and is validated on egress, exactly like the
+   signal payload. argon gets the same contract guarantee.
+
+## Components
+
+### New: `src/application/chart/indicator_compute.py`
+`compute_indicator_series(provider, registry, symbol, timeframe, indicator, start, end, *, safety=3) -> list[dict]`
+- Look up the indicator; raise `UnknownIndicatorError` if absent.
+- Extend the fetch start back by `warmup_periods * timeframe_delta * safety` so the
+  visible window has valid (non-NaN) values.
+- `provider.fetch_bars(...)` → DataFrame (index = bar time, cols open/high/low/close/volume).
+- `indicator.calculate(df, indicator.default_params)`; walk rows building
+  `{time, state, bar_close}` via `get_state(current, previous)`.
+- Coerce numpy/NaN to JSON-native (NaN → None).
+- Trim to `time >= start` (drop the warmup lead). Empty bars → `[]`.
+
+### New: `src/api/payload/chart.py`
+`build_bars_payload`, `build_indicator_payload`, `build_confluence_payload` — pure
+dict builders mirroring `payload/builder.py` (ISO timestamps, `count`, `generated_at`).
+
+### New schemas (`config/verification/schemas/`)
+`bars_payload.schema.json`, `indicator_series_payload.schema.json`,
+`confluence_payload.schema.json`. Validated via the existing `validate.py` pattern
+(generalised to take a schema path).
+
+### New routes (`src/api/routes/chart.py`)
+- `GET /bars/{ticker}?timeframe=&start=&end=` → 503 if no `ohlc_provider`.
+- `GET /indicators/{ticker}?timeframe=&indicator=&start=&end=` → 503 if no provider;
+  404/422 on unknown indicator.
+- `GET /confluence/{ticker}?timeframe=&since=` → 503 if no `signal_repo`.
+
+### Lifespan wiring (`src/api/server.py`)
+Expose `app.state.ohlc_provider` (built from `APEX_LIVEWIRE_ROOT`) independent of the
+streaming block so the read routes work even without a live subscription; reuse it in
+the `SubscriptionManager`. Register the chart router in `create_app`.
+
+## Payload shapes
+
+```jsonc
+// GET /bars/AAPL?timeframe=1d
+{ "symbol":"AAPL","timeframe":"1d","count":1,"generated_at":"…",
+  "bars":[{"time":"…","open":1.0,"high":2.0,"low":0.5,"close":1.5,"volume":1000,"vwap":1.3}] }
+
+// GET /indicators/AAPL?timeframe=1d&indicator=rsi
+{ "symbol":"AAPL","timeframe":"1d","indicator":"rsi","count":1,"generated_at":"…",
+  "points":[{"time":"…","state":{"value":65.3,"zone":"neutral"},"bar_close":1.5}] }
+
+// GET /confluence/AAPL?timeframe=1d
+{ "symbol":"AAPL","timeframe":"1d","count":1,"generated_at":"…",
+  "points":[{"time":"…","alignment_score":0.4,"bullish_count":3,"bearish_count":1,
+             "neutral_count":2,"total_indicators":6,"dominant_direction":"bullish"}] }
+```
+
+## Out of scope (this PR)
+- Live WS push of bars/indicators/confluence (signals already stream; chart-data
+  WS deltas are a follow-up — REST backfill is enough for first render + polling).
+- Compute-on-read **confluence** (would need replaying the cross-indicator analyzer
+  per bar). DB-backed for now.
+- Re-serving live quotes (right-edge ladder); that's xenon's surface.
+
+## Testing
+- Unit: compute service (synthetic-bar fake provider — structural assertions: one
+  point per visible bar, warmup trimmed, bar_close aligned, unknown indicator
+  raises, empty bars → []); payload builders (shape + schema-valid).
+- Integration: each route 200 + schema-valid with fakes injected; 503 paths.
+- Live: boot against real xenon + Postgres, capture real frames, confirm
+  `indicator_values` / `confluence_scores` actually populate.

--- a/src/api/payload/chart.py
+++ b/src/api/payload/chart.py
@@ -85,8 +85,11 @@ _CONFLUENCE_FIELDS = (
 def build_confluence_payload(
     symbol: str, timeframe: str, rows: Iterable[Dict[str, Any]], *, generated_at: datetime
 ) -> Dict[str, Any]:
+    # get_confluence_history returns newest-first; emit oldest-first so the chart
+    # contract is a consistent ascending time series (like /bars and /indicators).
+    ordered = sorted(rows, key=lambda r: r["time"])
     out: List[Dict[str, Any]] = []
-    for r in rows:
+    for r in ordered:
         point: Dict[str, Any] = {"time": _iso(r["time"])}
         for field in _CONFLUENCE_FIELDS:
             if field in r:

--- a/src/api/payload/chart.py
+++ b/src/api/payload/chart.py
@@ -1,0 +1,94 @@
+"""Build chart read-surface payloads: bars, indicator series, confluence.
+
+These mirror ``payload/builder.py`` (ISO timestamps, ``count``, ``generated_at``) and
+are validated on egress against their schemas under config/verification/schemas/.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Iterable, List
+
+_TIMEFRAMES = ("1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w")
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if isinstance(value, datetime) else value
+
+
+def _bar_to_dict(bar: Any) -> Dict[str, Any]:
+    # livewire bars set timestamp == bar_start; prefer timestamp, fall back to bar_start.
+    when = bar.timestamp if getattr(bar, "timestamp", None) is not None else bar.bar_start
+    return {
+        "time": _iso(when),
+        "open": bar.open,
+        "high": bar.high,
+        "low": bar.low,
+        "close": bar.close,
+        "volume": bar.volume,
+        "vwap": bar.vwap,
+    }
+
+
+def build_bars_payload(
+    symbol: str, timeframe: str, bars: Iterable[Any], *, generated_at: datetime
+) -> Dict[str, Any]:
+    rows = [_bar_to_dict(b) for b in bars]
+    return {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "bars": rows,
+        "count": len(rows),
+        "generated_at": generated_at.isoformat(),
+    }
+
+
+def build_indicator_payload(
+    symbol: str,
+    timeframe: str,
+    indicator: str,
+    points: Iterable[Dict[str, Any]],
+    *,
+    generated_at: datetime,
+) -> Dict[str, Any]:
+    out: List[Dict[str, Any]] = [
+        {"time": _iso(p["time"]), "state": p["state"], "bar_close": p.get("bar_close")}
+        for p in points
+    ]
+    return {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "indicator": indicator,
+        "points": out,
+        "count": len(out),
+        "generated_at": generated_at.isoformat(),
+    }
+
+
+_CONFLUENCE_FIELDS = (
+    "alignment_score",
+    "bullish_count",
+    "bearish_count",
+    "neutral_count",
+    "total_indicators",
+    "dominant_direction",
+)
+
+
+def build_confluence_payload(
+    symbol: str, timeframe: str, rows: Iterable[Dict[str, Any]], *, generated_at: datetime
+) -> Dict[str, Any]:
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        point: Dict[str, Any] = {"time": _iso(r["time"])}
+        for field in _CONFLUENCE_FIELDS:
+            if field in r:
+                point[field] = r[field]
+        out.append(point)
+    return {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "points": out,
+        "count": len(out),
+        "generated_at": generated_at.isoformat(),
+    }

--- a/src/api/payload/chart.py
+++ b/src/api/payload/chart.py
@@ -6,14 +6,21 @@ are validated on egress against their schemas under config/verification/schemas/
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List
-
-_TIMEFRAMES = ("1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w")
 
 
 def _iso(value: Any) -> Any:
-    return value.isoformat() if isinstance(value, datetime) else value
+    """ISO-8601 string, normalised to UTC so the chart contract matches the signal one.
+
+    DuckDB returns bar timestamps in the session timezone; convert tz-aware values to
+    UTC (+00:00) for a consistent contract. Naive datetimes are emitted as-is.
+    """
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.astimezone(timezone.utc)
+        return value.isoformat()
+    return value
 
 
 def _bar_to_dict(bar: Any) -> Dict[str, Any]:

--- a/src/api/payload/validate.py
+++ b/src/api/payload/validate.py
@@ -13,26 +13,24 @@ from typing import Any
 
 import jsonschema
 
-_SCHEMA_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "config"
-    / "verification"
-    / "schemas"
-    / "signal_service_payload.schema.json"
+_SCHEMA_DIR = (
+    Path(__file__).resolve().parents[3] / "config" / "verification" / "schemas"
 )
+_DEFAULT_SCHEMA = "signal_service_payload"
 
 
 class ValidationFailure(ValueError):
     """Raised when a payload does not satisfy the contract schema."""
 
 
-@lru_cache(maxsize=1)
-def _schema() -> dict:
-    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+@lru_cache(maxsize=None)
+def _schema(name: str = _DEFAULT_SCHEMA) -> dict:
+    return json.loads((_SCHEMA_DIR / f"{name}.schema.json").read_text(encoding="utf-8"))
 
 
-def validate_payload(payload: dict[str, Any]) -> None:
+def validate_payload(payload: dict[str, Any], schema: str = _DEFAULT_SCHEMA) -> None:
+    """Validate ``payload`` against ``<schema>.schema.json`` (signal contract by default)."""
     try:
-        jsonschema.validate(instance=payload, schema=_schema())
+        jsonschema.validate(instance=payload, schema=_schema(schema))
     except jsonschema.ValidationError as exc:
         raise ValidationFailure(str(exc)) from exc

--- a/src/api/payload/validate.py
+++ b/src/api/payload/validate.py
@@ -13,9 +13,7 @@ from typing import Any
 
 import jsonschema
 
-_SCHEMA_DIR = (
-    Path(__file__).resolve().parents[3] / "config" / "verification" / "schemas"
-)
+_SCHEMA_DIR = Path(__file__).resolve().parents[3] / "config" / "verification" / "schemas"
 _DEFAULT_SCHEMA = "signal_service_payload"
 
 

--- a/src/api/routes/chart.py
+++ b/src/api/routes/chart.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from src.api.payload.chart import (
     build_bars_payload,
@@ -119,7 +119,7 @@ async def get_confluence(
     timeframe: str = "1d",
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
-    limit: int = 500,
+    limit: int = Query(default=500, ge=1, le=5000),
 ) -> dict:
     repo = getattr(request.app.state, "signal_repo", None)
     if repo is None:

--- a/src/api/routes/chart.py
+++ b/src/api/routes/chart.py
@@ -27,20 +27,38 @@ from src.application.chart.indicator_compute import (
     compute_indicator_series,
 )
 from src.domain.signals.indicators.registry import get_indicator_registry
+from src.infrastructure.adapters.livewire.paths import SUPPORTED_TIMEFRAMES
 
 router = APIRouter(tags=["chart"])
 
-# Default window when the caller omits start/end: the most recent ~500 bars.
+# Default no-arg window: the most recent N bars. We over-fetch in calendar time
+# (markets aren't 24/7, so N*delta would under-cover across closures) then tail-slice
+# to exactly N. Callers wanting an exact range pass start/end.
 _DEFAULT_BARS = 500
+_LOOKBACK_FUDGE = 10
+
+
+def _require_supported_timeframe(timeframe: str) -> None:
+    """Livewire warehouses a narrower set than the schema enum -- reject early (400)
+    instead of letting parquet_path raise ValueError -> 500."""
+    if timeframe not in SUPPORTED_TIMEFRAMES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported timeframe: {timeframe} (have {sorted(SUPPORTED_TIMEFRAMES)})",
+        )
 
 
 def _resolve_window(
     timeframe: str, start: Optional[datetime], end: Optional[datetime]
-) -> Tuple[datetime, datetime]:
+) -> Tuple[datetime, datetime, Optional[int]]:
+    """Return (start, end, tail_limit). When start is omitted, fetch a generous
+    lookback and tail-slice to _DEFAULT_BARS; an explicit start is honoured as-is."""
     end = end or datetime.now(timezone.utc)
     if start is None:
-        start = end - TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA) * _DEFAULT_BARS
-    return start, end
+        delta = TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA)
+        start = end - delta * _DEFAULT_BARS * _LOOKBACK_FUDGE
+        return start, end, _DEFAULT_BARS
+    return start, end, None
 
 
 @router.get("/bars/{ticker}")
@@ -54,8 +72,11 @@ async def get_bars(
     provider = getattr(request.app.state, "ohlc_provider", None)
     if provider is None:
         raise HTTPException(status_code=503, detail="bar provider not configured")
-    start, end = _resolve_window(timeframe, start, end)
+    _require_supported_timeframe(timeframe)
+    start, end, limit = _resolve_window(timeframe, start, end)
     bars = await provider.fetch_bars(ticker, timeframe, start, end)
+    if limit is not None:
+        bars = bars[-limit:]
     payload = build_bars_payload(ticker, timeframe, bars, generated_at=datetime.now(timezone.utc))
     validate_payload(payload, "bars_payload")
     return payload
@@ -73,14 +94,17 @@ async def get_indicators(
     provider = getattr(request.app.state, "ohlc_provider", None)
     if provider is None:
         raise HTTPException(status_code=503, detail="bar provider not configured")
+    _require_supported_timeframe(timeframe)
     registry = getattr(request.app.state, "indicator_registry", None) or get_indicator_registry()
-    start, end = _resolve_window(timeframe, start, end)
+    start, end, limit = _resolve_window(timeframe, start, end)
     try:
         points = await compute_indicator_series(
             provider, registry, ticker, timeframe, indicator, start, end
         )
     except UnknownIndicatorError:
         raise HTTPException(status_code=404, detail=f"unknown indicator: {indicator}")
+    if limit is not None:
+        points = points[-limit:]
     payload = build_indicator_payload(
         ticker, timeframe, indicator, points, generated_at=datetime.now(timezone.utc)
     )
@@ -95,11 +119,14 @@ async def get_confluence(
     timeframe: str = "1d",
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
+    limit: int = 500,
 ) -> dict:
     repo = getattr(request.app.state, "signal_repo", None)
     if repo is None:
         raise HTTPException(status_code=503, detail="signal persistence not configured")
-    rows = await repo.get_confluence_history(ticker, timeframe, start, end)
+    # Confluence is PG-backed (not livewire), so it accepts any timeframe the data has.
+    start, end, _ = _resolve_window(timeframe, start, end)
+    rows = await repo.get_confluence_history(ticker, timeframe, start, end, limit)
     payload = build_confluence_payload(
         ticker, timeframe, rows, generated_at=datetime.now(timezone.utc)
     )

--- a/src/api/routes/chart.py
+++ b/src/api/routes/chart.py
@@ -1,0 +1,107 @@
+"""Chart read surface for argon (stateless renderer pulls everything from apex).
+
+- GET /bars/{ticker}          -> OHLCV candles from livewire (full history)
+- GET /indicators/{ticker}    -> per-bar indicator series, compute-on-read (full depth)
+- GET /confluence/{ticker}    -> multi-timeframe confluence, DB-backed (persisted depth)
+
+Mirrors the signal contract: REST backfill + validate-on-egress on every response.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional, Tuple
+
+from fastapi import APIRouter, HTTPException, Request
+
+from src.api.payload.chart import (
+    build_bars_payload,
+    build_confluence_payload,
+    build_indicator_payload,
+)
+from src.api.payload.validate import validate_payload
+from src.application.chart.indicator_compute import (
+    DEFAULT_TF_DELTA,
+    TF_DELTAS,
+    UnknownIndicatorError,
+    compute_indicator_series,
+)
+from src.domain.signals.indicators.registry import get_indicator_registry
+
+router = APIRouter(tags=["chart"])
+
+# Default window when the caller omits start/end: the most recent ~500 bars.
+_DEFAULT_BARS = 500
+
+
+def _resolve_window(
+    timeframe: str, start: Optional[datetime], end: Optional[datetime]
+) -> Tuple[datetime, datetime]:
+    end = end or datetime.now(timezone.utc)
+    if start is None:
+        start = end - TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA) * _DEFAULT_BARS
+    return start, end
+
+
+@router.get("/bars/{ticker}")
+async def get_bars(
+    ticker: str,
+    request: Request,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> dict:
+    provider = getattr(request.app.state, "ohlc_provider", None)
+    if provider is None:
+        raise HTTPException(status_code=503, detail="bar provider not configured")
+    start, end = _resolve_window(timeframe, start, end)
+    bars = await provider.fetch_bars(ticker, timeframe, start, end)
+    payload = build_bars_payload(ticker, timeframe, bars, generated_at=datetime.now(timezone.utc))
+    validate_payload(payload, "bars_payload")
+    return payload
+
+
+@router.get("/indicators/{ticker}")
+async def get_indicators(
+    ticker: str,
+    request: Request,
+    indicator: str,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> dict:
+    provider = getattr(request.app.state, "ohlc_provider", None)
+    if provider is None:
+        raise HTTPException(status_code=503, detail="bar provider not configured")
+    registry = getattr(request.app.state, "indicator_registry", None) or get_indicator_registry()
+    start, end = _resolve_window(timeframe, start, end)
+    try:
+        points = await compute_indicator_series(
+            provider, registry, ticker, timeframe, indicator, start, end
+        )
+    except UnknownIndicatorError:
+        raise HTTPException(status_code=404, detail=f"unknown indicator: {indicator}")
+    payload = build_indicator_payload(
+        ticker, timeframe, indicator, points, generated_at=datetime.now(timezone.utc)
+    )
+    validate_payload(payload, "indicator_series_payload")
+    return payload
+
+
+@router.get("/confluence/{ticker}")
+async def get_confluence(
+    ticker: str,
+    request: Request,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> dict:
+    repo = getattr(request.app.state, "signal_repo", None)
+    if repo is None:
+        raise HTTPException(status_code=503, detail="signal persistence not configured")
+    rows = await repo.get_confluence_history(ticker, timeframe, start, end)
+    payload = build_confluence_payload(
+        ticker, timeframe, rows, generated_at=datetime.now(timezone.utc)
+    )
+    validate_payload(payload, "confluence_payload")
+    return payload

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -73,21 +73,36 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 app.state.signal_repo = TASignalRepository(cast("Database", pool))
                 logger.info("Signal repository ready (snapshot + REST backfill enabled)")
 
+        # Chart read surface (bars + compute-on-read indicators + confluence): expose
+        # the bar provider + indicator registry on app.state so /bars, /indicators and
+        # /confluence work even without a live subscription. Reused by the pipeline below.
+        if getattr(app.state, "ohlc_provider", None) is None:
+            app.state.ohlc_provider = None
+            livewire_root = os.environ.get("APEX_LIVEWIRE_ROOT")
+            if livewire_root:
+                from pathlib import Path
+
+                from src.infrastructure.adapters.livewire.ohlc_provider import (
+                    LivewireOhlcProvider,
+                )
+
+                app.state.ohlc_provider = LivewireOhlcProvider(bronze_root=Path(livewire_root))
+                logger.info("Bar provider ready (chart read surface enabled)")
+        if getattr(app.state, "indicator_registry", None) is None:
+            from src.domain.signals.indicators.registry import get_indicator_registry
+
+            app.state.indicator_registry = get_indicator_registry()
+
         # Full streaming pipeline (env-gated on APEX_LIVEWIRE_ROOT): construct the
         # event bus, TA compute service, signal emitter, and subscription manager so
         # the server itself streams signals. Guarded so tests can pre-inject fakes.
         if getattr(app.state, "subscription_manager", None) is None:
             livewire_root = os.environ.get("APEX_LIVEWIRE_ROOT")
             if livewire_root:
-                from pathlib import Path
-
                 from src.api.ws.emitter import SignalEmitter
                 from src.application.services.ta_signal_service import TASignalService
                 from src.application.subscriptions.manager import SubscriptionManager
                 from src.domain.events.priority_event_bus import PriorityEventBus
-                from src.infrastructure.adapters.livewire.ohlc_provider import (
-                    LivewireOhlcProvider,
-                )
 
                 timeframes = [
                     tf.strip()
@@ -112,9 +127,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 emitter.subscribe(bus)
                 app.state.signal_emitter = emitter
 
-                provider = LivewireOhlcProvider(bronze_root=Path(livewire_root))
                 app.state.subscription_manager = SubscriptionManager(
-                    provider=provider, compute=service, timeframes=timeframes
+                    provider=app.state.ohlc_provider, compute=service, timeframes=timeframes
                 )
                 logger.info("Streaming TA pipeline started (timeframes=%s)", timeframes)
 
@@ -198,6 +212,11 @@ def create_app() -> FastAPI:
 
     app.include_router(signals_router)
     app.include_router(signals_ws_router)
+
+    # Chart read surface: bars + compute-on-read indicators + confluence.
+    from src.api.routes.chart import router as chart_router
+
+    app.include_router(chart_router)
 
     return app
 

--- a/src/application/chart/__init__.py
+++ b/src/application/chart/__init__.py
@@ -1,0 +1,1 @@
+"""Chart read-surface application services (compute-on-read indicator series)."""

--- a/src/application/chart/indicator_compute.py
+++ b/src/application/chart/indicator_compute.py
@@ -1,0 +1,119 @@
+"""Compute-on-read indicator series for the chart read surface.
+
+Given a visible window, fetch livewire bars (extended back by a warmup lead so the
+window has valid, non-NaN values), run the SAME pure-functional
+``indicator.calculate(default_params)`` the live IndicatorEngine uses
+(``indicator_engine.py:601``), and return a per-bar ``[{time, state, bar_close}]``
+series trimmed to the window. Deterministic: a pure function of bars + default params,
+so the lines always match the live signals and the candles.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+# Bar duration per timeframe -- used to derive the warmup lead in calendar time.
+_TF_DELTAS: Dict[str, timedelta] = {
+    "1m": timedelta(minutes=1),
+    "5m": timedelta(minutes=5),
+    "15m": timedelta(minutes=15),
+    "30m": timedelta(minutes=30),
+    "1h": timedelta(hours=1),
+    "4h": timedelta(hours=4),
+    "1d": timedelta(days=1),
+    "1w": timedelta(weeks=1),
+}
+_DEFAULT_DELTA = timedelta(days=1)
+
+
+class UnknownIndicatorError(ValueError):
+    """Raised when the requested indicator is not registered."""
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce numpy scalars / NaN to JSON-native types (NaN -> None), recursively."""
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    item = value
+    if hasattr(value, "item") and not isinstance(value, (str, bytes)):
+        try:
+            item = value.item()  # numpy scalar -> python scalar
+        except (ValueError, AttributeError):
+            item = value
+    if isinstance(item, float) and math.isnan(item):
+        return None
+    return item
+
+
+def _bars_to_df(bars: List[Any]) -> pd.DataFrame:
+    """Build the OHLCV DataFrame exactly as the live IndicatorEngine does."""
+    rows = [
+        {
+            "timestamp": b.timestamp,
+            "open": b.open,
+            "high": b.high,
+            "low": b.low,
+            "close": b.close,
+            "volume": b.volume,
+        }
+        for b in bars
+    ]
+    df = pd.DataFrame(rows)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    return df.set_index("timestamp")
+
+
+async def compute_indicator_series(
+    provider: Any,
+    registry: Any,
+    symbol: str,
+    timeframe: str,
+    indicator: str,
+    start: datetime,
+    end: datetime,
+    *,
+    safety: int = 3,
+) -> List[Dict[str, Any]]:
+    """Return ``[{time, state, bar_close}]`` for ``indicator`` over ``[start, end]``.
+
+    ``provider`` must expose ``async fetch_bars(symbol, timeframe, start, end)``;
+    ``registry`` must expose ``get(name)``. ``safety`` multiplies the warmup lead to
+    cover non-trading gaps (weekends/holidays) when converting bar-count to time.
+    """
+    ind = registry.get(indicator)
+    if ind is None:
+        raise UnknownIndicatorError(indicator)
+
+    delta = _TF_DELTAS.get(timeframe, _DEFAULT_DELTA)
+    warmup = max(int(getattr(ind, "warmup_periods", 0)), 0)
+    fetch_start = start - delta * warmup * max(safety, 1)
+
+    bars = await provider.fetch_bars(symbol, timeframe, fetch_start, end)
+    if not bars:
+        return []
+
+    df = _bars_to_df(bars)
+    result = ind.calculate(df, ind.default_params)
+
+    points: List[Dict[str, Any]] = []
+    prev: Optional[pd.Series] = None
+    for ts, row in result.iterrows():
+        py_ts = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts
+        if start <= py_ts <= end:
+            state = ind.get_state(row, prev, ind.default_params)
+            close = df.at[ts, "close"] if ts in df.index else None
+            points.append(
+                {
+                    "time": py_ts,
+                    "state": _jsonable(state),
+                    "bar_close": _jsonable(close),
+                }
+            )
+        prev = row
+    return points

--- a/src/application/chart/indicator_compute.py
+++ b/src/application/chart/indicator_compute.py
@@ -10,6 +10,7 @@ so the lines always match the live signals and the candles.
 
 from __future__ import annotations
 
+import asyncio
 import math
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -99,6 +100,14 @@ async def compute_indicator_series(
     if not bars:
         return []
 
+    # calculate() + the per-row state loop are CPU-bound; run them off the event loop
+    # so a large window / expensive indicator can't stall the live signal WS stream.
+    return await asyncio.to_thread(_compute_points, ind, bars, start, end)
+
+
+def _compute_points(
+    ind: Any, bars: List[Any], start: datetime, end: datetime
+) -> List[Dict[str, Any]]:
     df = _bars_to_df(bars)
     result = ind.calculate(df, ind.default_params)
 

--- a/src/application/chart/indicator_compute.py
+++ b/src/application/chart/indicator_compute.py
@@ -17,7 +17,8 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 
 # Bar duration per timeframe -- used to derive the warmup lead in calendar time.
-_TF_DELTAS: Dict[str, timedelta] = {
+# Public so the chart routes can reuse it for default windows.
+TF_DELTAS: Dict[str, timedelta] = {
     "1m": timedelta(minutes=1),
     "5m": timedelta(minutes=5),
     "15m": timedelta(minutes=15),
@@ -27,7 +28,7 @@ _TF_DELTAS: Dict[str, timedelta] = {
     "1d": timedelta(days=1),
     "1w": timedelta(weeks=1),
 }
-_DEFAULT_DELTA = timedelta(days=1)
+DEFAULT_TF_DELTA = timedelta(days=1)
 
 
 class UnknownIndicatorError(ValueError):
@@ -90,7 +91,7 @@ async def compute_indicator_series(
     if ind is None:
         raise UnknownIndicatorError(indicator)
 
-    delta = _TF_DELTAS.get(timeframe, _DEFAULT_DELTA)
+    delta = TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA)
     warmup = max(int(getattr(ind, "warmup_periods", 0)), 0)
     fetch_start = start - delta * warmup * max(safety, 1)
 

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -4,32 +4,52 @@ Implements apex's HistoricalSourcePort (src/domain/interfaces/historical_source.
 Reads are on-demand, one (symbol, timeframe, date-range) at a time -- never the
 full universe.
 
-UNVERIFIED: COLUMN_MAP below uses the documented/fixture schema (`ts` + OHLCV).
-The REAL livewire bronze column names MUST be confirmed against a live parquet
-(see Phase 1 plan Task 1) before production wiring.
+Bronze schema matched to livewire's writers (``clients/bronze_client.py`` +
+``clients/intraday_bronze_client.py``, 2026-06-14): daily bars are keyed by
+``trade_date`` (date32) and carry ``adj_close``; intraday bars are keyed by
+``bar_timestamp`` (timestamp us, tz=UTC). Both also carry ``symbol_id`` (ignored
+here -- the symbol comes from the partition). OHLCV column names match 1:1.
+
+NOT yet smoke-tested against a live parquet (no bronze on disk in this env); the
+column/layout contract is verified against livewire's writer, not real bytes.
 """
 
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import List
+from typing import Any, List
 
 import duckdb
 
 from ....domain.events.domain_events import BarData
 from .paths import SUPPORTED_TIMEFRAMES, parquet_path
 
-# livewire column -> BarData field. CONFIRM the `ts`/OHLCV names against real data.
-COLUMN_MAP = {
-    "ts": "bar_start",
-    "open": "open",
-    "high": "high",
-    "low": "low",
-    "close": "close",
-    "volume": "volume",
-}
+# livewire keys daily bars by `trade_date` (a DATE) and intraday bars by
+# `bar_timestamp` (a tz-aware UTC TIMESTAMP). OHLCV columns are read by name; extra
+# columns (symbol_id, adj_close) are ignored.
+_DAILY_TS_COLUMN = "trade_date"
+_INTRADAY_TS_COLUMN = "bar_timestamp"
+
+
+def _timestamp_column(timeframe: str) -> str:
+    return _DAILY_TS_COLUMN if timeframe == "1d" else _INTRADAY_TS_COLUMN
+
+
+def _to_utc_datetime(value: Any) -> datetime:
+    """Coerce a livewire timestamp to a tz-aware UTC datetime.
+
+    DuckDB returns ``trade_date`` (date32) as ``datetime.date`` and ``bar_timestamp``
+    (timestamp tz=UTC) as a tz-aware ``datetime``. datetime is a subclass of date, so
+    check it first.
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    raise TypeError(f"unexpected livewire timestamp type: {type(value)!r}")
+
 
 # Bar duration per timeframe -- used to derive bar_end (not a zero-width bar).
 _TF_DELTAS = {
@@ -83,7 +103,7 @@ class LivewireOhlcProvider:
         start: datetime,
         end: datetime,
     ) -> List[BarData]:
-        ts_col = next(k for k, v in COLUMN_MAP.items() if v == "bar_start")
+        ts_col = _timestamp_column(timeframe)
         # NOTE: read_parquet path is inlined (NOT a bound parameter) -- DuckDB does
         # not accept a prepared-statement parameter for the parquet path. The path
         # is constructed by us from a validated symbol/timeframe, not user SQL.
@@ -91,16 +111,20 @@ class LivewireOhlcProvider:
             f"SELECT * FROM read_parquet('{path.as_posix()}') "
             f"WHERE {ts_col} >= ? AND {ts_col} <= ? ORDER BY {ts_col} ASC"
         )
+        # Daily `trade_date` is a DATE -- bind calendar-date params so the comparison
+        # is tz-agnostic (avoids DATE-vs-TIMESTAMPTZ session-tz surprises). Intraday
+        # `bar_timestamp` is TIMESTAMPTZ -- bind the tz-aware datetimes directly.
+        params = [start.date(), end.date()] if timeframe == "1d" else [start, end]
         con = duckdb.connect(database=":memory:")
         try:
-            rows = con.execute(sql, [start, end]).fetch_arrow_table().to_pylist()
+            rows = con.execute(sql, params).fetch_arrow_table().to_pylist()
         finally:
             con.close()
         return [self._row_to_bar(r, symbol, timeframe) for r in rows]
 
     @staticmethod
     def _row_to_bar(row: dict, symbol: str, timeframe: str) -> BarData:
-        ts = row[next(k for k, v in COLUMN_MAP.items() if v == "bar_start")]
+        ts = _to_utc_datetime(row[_timestamp_column(timeframe)])
         end = ts + _TF_DELTAS.get(timeframe, timedelta(0))
         vol = row.get("volume")
         return BarData(

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -39,14 +39,22 @@ def _timestamp_column(timeframe: str) -> str:
 
 
 def _to_utc_datetime(value: Any) -> datetime:
-    """Coerce a livewire timestamp to a tz-aware UTC datetime.
+    """Coerce a livewire timestamp to a UTC-*labelled* tz-aware datetime.
 
     DuckDB returns ``trade_date`` (date32) as ``datetime.date`` and ``bar_timestamp``
-    (timestamp tz=UTC) as a tz-aware ``datetime``. datetime is a subclass of date, so
-    check it first.
+    (TIMESTAMPTZ) as a tz-aware ``datetime`` -- but in the *session* timezone, NOT UTC
+    (e.g. ``Asia/Hong_Kong`` +08:00 on a HK-locale box). The instant is correct, the
+    label is not. We must ``astimezone(UTC)`` so seeded warmup bars (session tz) and
+    live tick bars (UTC) share one offset: a mixed-offset column crashes
+    ``pd.to_datetime(...)`` in the indicator engine and silently kills live compute.
+    datetime is a subclass of date, so check it first.
     """
     if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return (
+            value.astimezone(timezone.utc)
+            if value.tzinfo is not None
+            else value.replace(tzinfo=timezone.utc)
+        )
     if isinstance(value, date):
         return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
     raise TypeError(f"unexpected livewire timestamp type: {type(value)!r}")

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -10,8 +10,9 @@ Bronze schema matched to livewire's writers (``clients/bronze_client.py`` +
 ``bar_timestamp`` (timestamp us, tz=UTC). Both also carry ``symbol_id`` (ignored
 here -- the symbol comes from the partition). OHLCV column names match 1:1.
 
-NOT yet smoke-tested against a live parquet (no bronze on disk in this env); the
-column/layout contract is verified against livewire's writer, not real bytes.
+Smoke-tested 2026-06-14 against the real livewire bronze data lake: AAPL ``1d``
+(``trade_date``/DATE) and ``1m`` (``bar_timestamp``/TIMESTAMPTZ) read back correct
+OHLCV at the right instants.
 """
 
 from __future__ import annotations

--- a/src/infrastructure/adapters/livewire/paths.py
+++ b/src/infrastructure/adapters/livewire/paths.py
@@ -1,18 +1,44 @@
 """Resolve (symbol, timeframe) to a livewire bronze parquet path.
 
-The per-ticker Hive layout IS the read contract (livewire-adaptation.md 3, 5):
-  <root>/asset_class=equity/symbol=<SYM>/<tf>.parquet
+The per-ticker Hive layout IS the read contract, confirmed against livewire's
+``clients/bronze_client.py`` + ``clients/intraday_bronze_client.py`` (2026-06-14):
+
+  <root>/asset_class=equity/symbol=<encode_symbol(SYM)>/<tf>.parquet
+
+where ``<root>`` is livewire's ``data-lake/bronze`` directory (``APEX_LIVEWIRE_ROOT``).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# Timeframes livewire warehouses for equities (livewire-adaptation.md 2).
+# Timeframes livewire warehouses for equities: daily via BronzeClient (1d), intraday
+# via IntradayBronzeClient (1m/5m/30m/1h). Matches livewire's INTRADAY_TIMEFRAMES + 1d.
 SUPPORTED_TIMEFRAMES = ("1m", "5m", "30m", "1h", "1d")
+
+# Mirrors livewire's clients/symbol_paths.py exactly: keep these characters literal,
+# percent-encode everything else as UTF-8 bytes. Reversible + safe on case-insensitive
+# filesystems. Uppercase tickers with `.`/`-` (AAPL, BRK.B) are identity; `/` etc. encode.
+_CASE_SAFE = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+
+
+def encode_symbol(symbol: str) -> str:
+    """Encode a symbol to its livewire bronze partition name (matches livewire 1:1)."""
+    parts: list[str] = []
+    for character in symbol:
+        if character in _CASE_SAFE:
+            parts.append(character)
+        else:
+            parts.extend(f"%{byte:02X}" for byte in character.encode("utf-8"))
+    return "".join(parts)
 
 
 def parquet_path(bronze_root: Path, symbol: str, timeframe: str) -> Path:
     if timeframe not in SUPPORTED_TIMEFRAMES:
         raise ValueError(f"unsupported timeframe: {timeframe!r} (have {SUPPORTED_TIMEFRAMES})")
-    return bronze_root / "asset_class=equity" / f"symbol={symbol}" / f"{timeframe}.parquet"
+    return (
+        bronze_root
+        / "asset_class=equity"
+        / f"symbol={encode_symbol(symbol)}"
+        / f"{timeframe}.parquet"
+    )

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -234,3 +234,12 @@ async def test_get_confluence_passes_limit_to_repo() -> None:
         resp = await c.get("/confluence/AAPL", params={"timeframe": "1d", "limit": "3"})
     assert resp.status_code == 200
     assert repo.last_limit == 3
+
+
+async def test_get_confluence_rejects_out_of_range_limit() -> None:
+    """limit is bounded (ge=1, le=5000) so a negative LIMIT can't reach Postgres."""
+    app = create_app()
+    app.state.signal_repo = _FakeRepo()
+    async with _client(app) as c:
+        resp = await c.get("/confluence/AAPL", params={"timeframe": "1d", "limit": "0"})
+    assert resp.status_code == 422

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -1,0 +1,168 @@
+"""Chart read-surface routes return schema-valid payloads (the argon chart contract).
+
+ASGITransport does NOT run the lifespan, so each test pre-injects the fakes the
+route reads off app.state (ohlc_provider / signal_repo).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, List
+
+from httpx import ASGITransport, AsyncClient
+
+from src.api.payload.validate import validate_payload
+from src.api.server import create_app
+from src.domain.events.domain_events import BarData
+
+_DAY = timedelta(days=1)
+_T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _series(n: int) -> List[BarData]:
+    bars: List[BarData] = []
+    price = 100.0
+    for i in range(n):
+        price += 1.0 if i % 3 else -0.7
+        ts = _T0 + i * _DAY
+        bars.append(
+            BarData(
+                symbol="AAPL",
+                timeframe="1d",
+                open=price - 0.5,
+                high=price + 1.0,
+                low=price - 1.0,
+                close=price,
+                volume=1000 + i,
+                vwap=price + 0.1,
+                timestamp=ts,
+                bar_start=ts,
+            )
+        )
+    return bars
+
+
+class _FakeProvider:
+    def __init__(self, bars: List[BarData]) -> None:
+        self._bars = bars
+
+    async def fetch_bars(
+        self, symbol: str, timeframe: str, start: datetime, end: datetime
+    ) -> List[BarData]:
+        return [b for b in self._bars if start <= b.timestamp <= end]
+
+
+class _FakeRepo:
+    async def get_confluence_history(
+        self, symbol: str, timeframe: str, start: Any = None, end: Any = None, limit: int = 100
+    ) -> List[dict]:
+        return [
+            {
+                "time": _T0,
+                "alignment_score": 0.4,
+                "bullish_count": 3,
+                "bearish_count": 1,
+                "neutral_count": 2,
+                "total_indicators": 6,
+                "dominant_direction": "bullish",
+            }
+        ]
+
+
+def _client(app) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# --- /bars ---------------------------------------------------------------
+
+
+async def test_get_bars_returns_valid_payload() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(50))
+    async with _client(app) as c:
+        resp = await c.get(
+            "/bars/AAPL",
+            params={
+                "timeframe": "1d",
+                "start": _T0.isoformat(),
+                "end": (_T0 + 60 * _DAY).isoformat(),
+            },
+        )
+    assert resp.status_code == 200
+    payload = resp.json()
+    validate_payload(payload, "bars_payload")
+    assert payload["symbol"] == "AAPL"
+    assert payload["count"] == 50
+    assert payload["bars"][0]["close"] == 99.3  # i=0 -> i%3==0 -> price += -0.7
+
+
+async def test_get_bars_503_when_provider_unconfigured() -> None:
+    app = create_app()
+    app.state.ohlc_provider = None
+    async with _client(app) as c:
+        resp = await c.get("/bars/AAPL", params={"timeframe": "1d"})
+    assert resp.status_code == 503
+
+
+# --- /indicators ---------------------------------------------------------
+
+
+async def test_get_indicators_returns_valid_payload() -> None:
+    full = _series(200)
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(full)
+    start, end = full[100].timestamp, full[150].timestamp
+    async with _client(app) as c:
+        resp = await c.get(
+            "/indicators/AAPL",
+            params={
+                "timeframe": "1d",
+                "indicator": "rsi",
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+    assert resp.status_code == 200
+    payload = resp.json()
+    validate_payload(payload, "indicator_series_payload")
+    assert payload["indicator"] == "rsi"
+    assert payload["count"] == 51  # inclusive 100..150
+    assert "value" in payload["points"][0]["state"]
+
+
+async def test_get_indicators_404_on_unknown_indicator() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(50))
+    async with _client(app) as c:
+        resp = await c.get("/indicators/AAPL", params={"timeframe": "1d", "indicator": "not_real"})
+    assert resp.status_code == 404
+
+
+async def test_get_indicators_503_when_provider_unconfigured() -> None:
+    app = create_app()
+    app.state.ohlc_provider = None
+    async with _client(app) as c:
+        resp = await c.get("/indicators/AAPL", params={"timeframe": "1d", "indicator": "rsi"})
+    assert resp.status_code == 503
+
+
+# --- /confluence ---------------------------------------------------------
+
+
+async def test_get_confluence_returns_valid_payload() -> None:
+    app = create_app()
+    app.state.signal_repo = _FakeRepo()
+    async with _client(app) as c:
+        resp = await c.get("/confluence/AAPL", params={"timeframe": "1d"})
+    assert resp.status_code == 200
+    payload = resp.json()
+    validate_payload(payload, "confluence_payload")
+    assert payload["points"][0]["dominant_direction"] == "bullish"
+
+
+async def test_get_confluence_503_when_repo_unconfigured() -> None:
+    app = create_app()
+    app.state.signal_repo = None
+    async with _client(app) as c:
+        resp = await c.get("/confluence/AAPL", params={"timeframe": "1d"})
+    assert resp.status_code == 503

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -52,10 +52,38 @@ class _FakeProvider:
         return [b for b in self._bars if start <= b.timestamp <= end]
 
 
+def _series_ending(end_day: datetime, n: int) -> List[BarData]:
+    """n daily bars ending at end_day (used to test the no-arg default window)."""
+    bars: List[BarData] = []
+    price = 100.0
+    for i in range(n):
+        price += 1.0 if i % 3 else -0.7
+        ts = end_day - (n - 1 - i) * _DAY
+        bars.append(
+            BarData(
+                symbol="AAPL",
+                timeframe="1d",
+                open=price - 0.5,
+                high=price + 1.0,
+                low=price - 1.0,
+                close=price,
+                volume=1000 + i,
+                vwap=price,
+                timestamp=ts,
+                bar_start=ts,
+            )
+        )
+    return bars
+
+
 class _FakeRepo:
+    def __init__(self) -> None:
+        self.last_limit: Any = None
+
     async def get_confluence_history(
         self, symbol: str, timeframe: str, start: Any = None, end: Any = None, limit: int = 100
     ) -> List[dict]:
+        self.last_limit = limit
         return [
             {
                 "time": _T0,
@@ -104,6 +132,27 @@ async def test_get_bars_503_when_provider_unconfigured() -> None:
     assert resp.status_code == 503
 
 
+async def test_get_bars_rejects_unsupported_timeframe() -> None:
+    """Schema advertises 4h/15m/1w but livewire doesn't warehouse them -> 400, not 500."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(10))
+    async with _client(app) as c:
+        resp = await c.get("/bars/AAPL", params={"timeframe": "4h"})
+    assert resp.status_code == 400
+
+
+async def test_get_bars_default_window_tail_slices_to_500() -> None:
+    """No start/end -> most recent 500 bars even when more exist in the lookback."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(
+        _series_ending(datetime(2026, 6, 1, tzinfo=timezone.utc), 600)
+    )
+    async with _client(app) as c:
+        resp = await c.get("/bars/AAPL", params={"timeframe": "1d"})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 500
+
+
 # --- /indicators ---------------------------------------------------------
 
 
@@ -146,6 +195,14 @@ async def test_get_indicators_503_when_provider_unconfigured() -> None:
     assert resp.status_code == 503
 
 
+async def test_get_indicators_rejects_unsupported_timeframe() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(10))
+    async with _client(app) as c:
+        resp = await c.get("/indicators/AAPL", params={"timeframe": "1w", "indicator": "rsi"})
+    assert resp.status_code == 400
+
+
 # --- /confluence ---------------------------------------------------------
 
 
@@ -166,3 +223,14 @@ async def test_get_confluence_503_when_repo_unconfigured() -> None:
     async with _client(app) as c:
         resp = await c.get("/confluence/AAPL", params={"timeframe": "1d"})
     assert resp.status_code == 503
+
+
+async def test_get_confluence_passes_limit_to_repo() -> None:
+    """Confluence must not silently cap at the repo default -> expose `limit`."""
+    repo = _FakeRepo()
+    app = create_app()
+    app.state.signal_repo = repo
+    async with _client(app) as c:
+        resp = await c.get("/confluence/AAPL", params={"timeframe": "1d", "limit": "3"})
+    assert resp.status_code == 200
+    assert repo.last_limit == 3

--- a/tests/integration/test_xenon_to_ws_e2e.py
+++ b/tests/integration/test_xenon_to_ws_e2e.py
@@ -38,16 +38,17 @@ def _write_seed(root, symbol: str = "AAPL") -> None:
     sym_dir.mkdir(parents=True, exist_ok=True)
     base = datetime.now(timezone.utc) - timedelta(minutes=5)
     ts = [base + timedelta(minutes=i) for i in range(3)]
+    # Mirror livewire's REAL intraday bronze schema (clients/intraday_bronze_client.py):
+    # `bar_timestamp` (timestamp tz=UTC) + `symbol_id` + OHLCV. Symbol is the partition.
     pd.DataFrame(
         {
-            "ts": pd.to_datetime(ts, utc=True),
+            "bar_timestamp": pd.to_datetime(ts, utc=True),
+            "symbol_id": [1, 1, 1],
             "open": [10.0, 11.0, 12.0],
             "high": [10.5, 11.5, 12.5],
             "low": [9.5, 10.5, 11.5],
             "close": [11.0, 12.0, 13.0],
             "volume": [100, 200, 300],
-            "asset_class": ["equity"] * 3,
-            "symbol": [symbol] * 3,
         }
     ).to_parquet(sym_dir / "1m.parquet")
 

--- a/tests/unit/api/test_chart_payload.py
+++ b/tests/unit/api/test_chart_payload.py
@@ -1,0 +1,76 @@
+"""Chart payload builders produce schema-valid dicts (the argon chart contract)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.api.payload.chart import (
+    build_bars_payload,
+    build_confluence_payload,
+    build_indicator_payload,
+)
+from src.api.payload.validate import validate_payload
+from src.domain.events.domain_events import BarData
+
+_NOW = datetime(2026, 6, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def _bar(close: float) -> BarData:
+    return BarData(
+        symbol="AAPL",
+        timeframe="1d",
+        open=close - 1,
+        high=close + 2,
+        low=close - 2,
+        close=close,
+        volume=1_000_000,
+        vwap=close + 0.1,
+        timestamp=_NOW,
+        bar_start=_NOW,
+    )
+
+
+def test_build_bars_payload_is_schema_valid() -> None:
+    payload = build_bars_payload("AAPL", "1d", [_bar(150.0), _bar(151.0)], generated_at=_NOW)
+    validate_payload(payload, "bars_payload")
+    assert payload["symbol"] == "AAPL"
+    assert payload["timeframe"] == "1d"
+    assert payload["count"] == 2
+    assert payload["bars"][0]["close"] == 150.0
+    assert payload["bars"][0]["time"].endswith("+00:00")
+
+
+def test_build_indicator_payload_is_schema_valid() -> None:
+    points = [
+        {"time": _NOW, "state": {"value": 65.3, "zone": "neutral"}, "bar_close": 150.0},
+        {"time": _NOW, "state": {"value": 70.1, "zone": "overbought"}, "bar_close": 151.0},
+    ]
+    payload = build_indicator_payload("AAPL", "1d", "rsi", points, generated_at=_NOW)
+    validate_payload(payload, "indicator_series_payload")
+    assert payload["indicator"] == "rsi"
+    assert payload["count"] == 2
+    assert payload["points"][0]["state"]["value"] == 65.3
+
+
+def test_build_confluence_payload_is_schema_valid() -> None:
+    rows = [
+        {
+            "time": _NOW,
+            "alignment_score": 0.4,
+            "bullish_count": 3,
+            "bearish_count": 1,
+            "neutral_count": 2,
+            "total_indicators": 6,
+            "dominant_direction": "bullish",
+        }
+    ]
+    payload = build_confluence_payload("AAPL", "1d", rows, generated_at=_NOW)
+    validate_payload(payload, "confluence_payload")
+    assert payload["points"][0]["alignment_score"] == 0.4
+    assert payload["points"][0]["dominant_direction"] == "bullish"
+
+
+def test_signal_payload_validation_still_defaults_to_signal_schema() -> None:
+    """Backward-compat: validate_payload with no schema arg uses the signal contract."""
+    payload = {"signals": [], "timestamp": _NOW.isoformat(), "symbol_count": 0}
+    validate_payload(payload)

--- a/tests/unit/api/test_chart_payload.py
+++ b/tests/unit/api/test_chart_payload.py
@@ -70,6 +70,30 @@ def test_build_confluence_payload_is_schema_valid() -> None:
     assert payload["points"][0]["dominant_direction"] == "bullish"
 
 
+def test_build_confluence_payload_orders_points_ascending() -> None:
+    """get_confluence_history returns newest-first; the chart contract is a time series,
+    so points must come out oldest-first to match /bars and /indicators."""
+    older = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    newer = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+    def _row(ts: datetime, score: float) -> dict:
+        return {
+            "time": ts,
+            "alignment_score": score,
+            "bullish_count": 1,
+            "bearish_count": 0,
+            "neutral_count": 0,
+            "total_indicators": 1,
+            "dominant_direction": "bullish",
+        }
+
+    rows_desc = [_row(newer, 0.9), _row(older, 0.1)]  # as the repo returns them (DESC)
+    payload = build_confluence_payload("AAPL", "1d", rows_desc, generated_at=_NOW)
+    times = [p["time"] for p in payload["points"]]
+    assert times == sorted(times)  # ascending
+    assert payload["points"][0]["alignment_score"] == 0.1  # oldest first
+
+
 def test_signal_payload_validation_still_defaults_to_signal_schema() -> None:
     """Backward-compat: validate_payload with no schema arg uses the signal contract."""
     payload = {"signals": [], "timestamp": _NOW.isoformat(), "symbol_count": 0}

--- a/tests/unit/application/chart/test_indicator_compute.py
+++ b/tests/unit/application/chart/test_indicator_compute.py
@@ -1,0 +1,117 @@
+"""compute_indicator_series: compute-on-read indicator series for the chart surface.
+
+The /indicators route hands argon a per-bar value series so it can draw indicator
+lines/oscillators over the candles. The service fetches bars from livewire (with a
+warmup lead so the visible window has valid values), runs the SAME pure-functional
+``indicator.calculate(default_params)`` the live engine uses, and returns
+``[{time, state, bar_close}]`` trimmed to the requested window.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Tuple
+
+import pytest
+
+from src.application.chart.indicator_compute import (
+    UnknownIndicatorError,
+    compute_indicator_series,
+)
+from src.domain.events.domain_events import BarData
+from src.domain.signals.indicators.registry import get_indicator_registry
+
+_DAY = timedelta(days=1)
+_T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _series(n: int) -> List[BarData]:
+    """Deterministic non-constant closes so RSI is well-defined (not flat/NaN)."""
+    bars: List[BarData] = []
+    price = 100.0
+    for i in range(n):
+        price += 1.0 if i % 3 else -0.7  # zig-zag, net rising
+        ts = _T0 + i * _DAY
+        bars.append(
+            BarData(
+                symbol="AAPL",
+                timeframe="1d",
+                open=price - 0.5,
+                high=price + 1.0,
+                low=price - 1.0,
+                close=price,
+                volume=1000 + i,
+                timestamp=ts,
+                bar_start=ts,
+            )
+        )
+    return bars
+
+
+class _FakeProvider:
+    """Holds a full series; returns only the slice within [start, end] (like livewire)."""
+
+    def __init__(self, bars: List[BarData]) -> None:
+        self._bars = bars
+        self.calls: List[Tuple[datetime, datetime]] = []
+
+    async def fetch_bars(
+        self, symbol: str, timeframe: str, start: datetime, end: datetime
+    ) -> List[BarData]:
+        self.calls.append((start, end))
+        return [b for b in self._bars if start <= b.timestamp <= end]
+
+
+async def test_returns_one_point_per_visible_bar_with_state_and_close() -> None:
+    full = _series(200)
+    provider = _FakeProvider(full)
+    registry = get_indicator_registry()
+
+    start = full[120].timestamp
+    end = full[160].timestamp
+
+    points = await compute_indicator_series(
+        provider, registry, "AAPL", "1d", "rsi", start, end
+    )
+
+    visible = [b for b in full if start <= b.timestamp <= end]
+    assert len(points) == len(visible)
+    assert all(start <= p["time"] <= end for p in points)
+    assert [p["time"] for p in points] == sorted(p["time"] for p in points)
+
+    first = points[0]
+    assert "value" in first["state"]
+    assert isinstance(first["state"]["value"], float)  # JSON-native, not numpy/NaN
+    assert first["bar_close"] == visible[0].close
+
+
+async def test_fetches_warmup_lead_before_requested_start() -> None:
+    full = _series(200)
+    provider = _FakeProvider(full)
+    registry = get_indicator_registry()
+    start = full[120].timestamp
+    end = full[160].timestamp
+
+    await compute_indicator_series(provider, registry, "AAPL", "1d", "rsi", start, end)
+
+    called_start, called_end = provider.calls[0]
+    assert called_start < start  # extended back to cover warmup
+    assert called_end == end
+
+
+async def test_unknown_indicator_raises() -> None:
+    provider = _FakeProvider(_series(50))
+    registry = get_indicator_registry()
+    with pytest.raises(UnknownIndicatorError):
+        await compute_indicator_series(
+            provider, registry, "AAPL", "1d", "not_an_indicator", _T0, _T0 + 10 * _DAY
+        )
+
+
+async def test_empty_bars_returns_empty() -> None:
+    provider = _FakeProvider([])  # livewire has nothing for this symbol
+    registry = get_indicator_registry()
+    points = await compute_indicator_series(
+        provider, registry, "AAPL", "1d", "rsi", _T0, _T0 + 10 * _DAY
+    )
+    assert points == []

--- a/tests/unit/application/chart/test_indicator_compute.py
+++ b/tests/unit/application/chart/test_indicator_compute.py
@@ -70,9 +70,7 @@ async def test_returns_one_point_per_visible_bar_with_state_and_close() -> None:
     start = full[120].timestamp
     end = full[160].timestamp
 
-    points = await compute_indicator_series(
-        provider, registry, "AAPL", "1d", "rsi", start, end
-    )
+    points = await compute_indicator_series(provider, registry, "AAPL", "1d", "rsi", start, end)
 
     visible = [b for b in full if start <= b.timestamp <= end]
     assert len(points) == len(visible)

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,30 +15,49 @@ WIDE_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
 
 
 def _write_fixture(root: Path) -> None:
-    """Write a 3-bar livewire bronze parquet for symbol TEST, timeframe 1d.
+    """Write a 3-bar daily livewire bronze parquet for symbol TEST.
 
-    Generated at runtime (not committed) because *.parquet is gitignored -- a
-    static fixture would be absent in CI. Mirrors the real bronze schema: a
-    tz-aware `ts` column plus OHLCV and the Hive partition columns.
+    Generated at runtime (*.parquet is gitignored). Mirrors livewire's REAL daily
+    bronze schema (clients/bronze_client.py): `trade_date` (date32), `symbol_id`,
+    OHLC, `adj_close`, `volume` -- the symbol lives in the partition dir, not a column.
     """
     sym_dir = root / "asset_class=equity" / "symbol=TEST"
     sym_dir.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame(
         {
-            "ts": pd.to_datetime(
-                ["2026-01-02T00:00:00Z", "2026-01-03T00:00:00Z", "2026-01-06T00:00:00Z"],
+            "trade_date": [dt.date(2026, 1, 2), dt.date(2026, 1, 3), dt.date(2026, 1, 6)],
+            "symbol_id": [1, 1, 1],
+            "open": [10.0, 11.0, 12.0],
+            "high": [10.5, 11.5, 12.5],
+            "low": [9.5, 10.5, 11.5],
+            "close": [11.0, 12.0, 13.0],
+            "adj_close": [11.0, 12.0, 13.0],
+            "volume": [100, 200, 300],
+        }
+    )
+    df.to_parquet(sym_dir / "1d.parquet")
+
+
+def _write_intraday_fixture(root: Path) -> None:
+    """Write a 3-bar 1m parquet mirroring livewire's intraday schema:
+    `bar_timestamp` (tz-aware UTC) + `symbol_id` + OHLCV."""
+    sym_dir = root / "asset_class=equity" / "symbol=TEST"
+    sym_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "bar_timestamp": pd.to_datetime(
+                ["2026-01-02T14:30:00Z", "2026-01-02T14:31:00Z", "2026-01-02T14:32:00Z"],
                 utc=True,
             ),
+            "symbol_id": [1, 1, 1],
             "open": [10.0, 11.0, 12.0],
             "high": [10.5, 11.5, 12.5],
             "low": [9.5, 10.5, 11.5],
             "close": [11.0, 12.0, 13.0],
             "volume": [100, 200, 300],
-            "asset_class": ["equity", "equity", "equity"],
-            "symbol": ["TEST", "TEST", "TEST"],
         }
     )
-    df.to_parquet(sym_dir / "1d.parquet")
+    df.to_parquet(sym_dir / "1m.parquet")
 
 
 @pytest.fixture
@@ -82,6 +102,23 @@ async def test_fetch_bars_date_range_filter(provider: LivewireOhlcProvider) -> N
     )
     assert len(bars) == 1
     assert bars[0].close == 12.0
+
+
+@pytest.mark.asyncio
+async def test_fetch_bars_intraday_reads_bar_timestamp(tmp_path: Path) -> None:
+    """Intraday bars are keyed by `bar_timestamp` (tz-aware UTC), not `trade_date`."""
+    _write_intraday_fixture(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars(
+        "TEST",
+        "1m",
+        datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc),
+        datetime(2026, 1, 2, 14, 32, tzinfo=timezone.utc),
+    )
+    assert [b.close for b in bars] == [11.0, 12.0, 13.0]
+    assert bars[0].bar_start == datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc)
+    assert bars[0].bar_start.tzinfo is not None  # tz-aware UTC, not naive
+    assert bars[0].bar_end > bars[0].bar_start  # 1m duration
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import datetime as dt
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from src.domain.interfaces.historical_source import HistoricalSourcePort
-from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+from src.infrastructure.adapters.livewire.ohlc_provider import (
+    LivewireOhlcProvider,
+    _to_utc_datetime,
+)
 
 WIDE_START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 WIDE_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
@@ -131,6 +134,33 @@ async def test_fetch_bars_missing_symbol_returns_empty(provider: LivewireOhlcPro
 async def test_unsupported_timeframe_raises(provider: LivewireOhlcProvider) -> None:
     with pytest.raises(ValueError, match="unsupported timeframe"):
         await provider.fetch_bars("TEST", "3m", WIDE_START, WIDE_END)
+
+
+def test_to_utc_datetime_normalizes_session_tz_to_utc() -> None:
+    """DuckDB returns TIMESTAMPTZ in the session timezone (e.g. +08:00), not UTC.
+
+    The provider must convert those to UTC so warmup-seeded bars (session tz) and
+    live tick bars (UTC) share one offset. A mixed-offset column crashes
+    `pd.to_datetime(...)` in the indicator engine (`Tz-aware datetime cannot be
+    converted to datetime64 unless utc=True`), killing live indicator compute.
+    """
+    hk = timezone(timedelta(hours=8))
+    aware_hk = datetime(2026, 6, 12, 22, 30, tzinfo=hk)  # == 14:30 UTC, same instant
+
+    out = _to_utc_datetime(aware_hk)
+
+    assert out.utcoffset() == timedelta(0)  # normalized to UTC, not left at +08:00
+    assert out.tzinfo == timezone.utc
+    assert out == datetime(2026, 6, 12, 14, 30, tzinfo=timezone.utc)  # instant preserved
+
+
+def test_to_utc_datetime_keeps_naive_and_date_as_utc() -> None:
+    """Naive datetimes are tagged UTC; date32 (daily `trade_date`) becomes midnight UTC."""
+    naive = _to_utc_datetime(datetime(2026, 1, 2, 9, 30))
+    assert naive == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
+
+    daily = _to_utc_datetime(dt.date(2026, 1, 2))
+    assert daily == datetime(2026, 1, 2, tzinfo=timezone.utc)
 
 
 def test_provider_satisfies_historical_source_port(bronze_root: Path) -> None:

--- a/tests/unit/infrastructure/livewire/test_paths.py
+++ b/tests/unit/infrastructure/livewire/test_paths.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.infrastructure.adapters.livewire.paths import (
     SUPPORTED_TIMEFRAMES,
+    encode_symbol,
     parquet_path,
 )
 
@@ -14,6 +15,20 @@ def test_parquet_path_layout() -> None:
     root = Path("/data/bronze")
     p = parquet_path(root, "AAPL", "1d")
     assert p == root / "asset_class=equity" / "symbol=AAPL" / "1d.parquet"
+
+
+def test_encode_symbol_matches_livewire() -> None:
+    # case-safe chars pass through (uppercase tickers, dots, hyphens)
+    assert encode_symbol("AAPL") == "AAPL"
+    assert encode_symbol("BRK.B") == "BRK.B"
+    assert encode_symbol("BF-A") == "BF-A"
+    # everything else is percent-encoded as UTF-8 bytes (matches livewire 1:1)
+    assert encode_symbol("BF/B") == "BF%2FB"
+
+
+def test_parquet_path_encodes_special_symbol() -> None:
+    p = parquet_path(Path("/data/bronze"), "BF/B", "1d")
+    assert p == Path("/data/bronze") / "asset_class=equity" / "symbol=BF%2FB" / "1d.parquet"
 
 
 def test_unsupported_timeframe_raises() -> None:


### PR DESCRIPTION
## Update (2026-06-14) — caveats below resolved

- ✅ **§10 is now a REAL data-lake capture** (commit `be7e0fe`), replacing the synthetic fixture:
  real AAPL `1d` bars + compute-on-read `rsi`/`macd`/`bollinger` + a real Postgres confluence
  round-trip + the `404` path. The "synthetic fixture / `COLUMN_MAP` unverified" caveats below
  are **resolved** (the §12 caveat is narrowed to "sample numbers are point-in-time").
- ✅ **Merges #135** (commit `8bb581b`): the chart surface can only read the real lake with #135's
  bronze schema fix + UTC tz normalization, so this PR **stacks on #135**. Merge order: merge
  **#135 → master first, then this PR**.
- ✅ **Integration docs added** (commit `3d1cb12`): `docs/livewire-apex-integration.md` (the
  bronze read contract) and `docs/argon-apex-api.md` (the apex API reference for argon).
- CI green (12/12).

---

## Summary

Adds the **chart read surface** so a **stateless argon** can render a full chart — candles,
indicator overlays/oscillators, and multi-timeframe confluence — pulling everything from apex
(argon stores nothing). Builds on the merged signal contract (#133); same validate-on-egress
discipline.

Three REST endpoints:

| Endpoint | Backed by | Storage model |
|---|---|---|
| `GET /bars/{ticker}` | livewire bronze (DuckDB) | read on the fly — no apex storage |
| `GET /indicators/{ticker}?indicator=` | `indicator.calculate()` | **compute-on-read** (full depth, gap-free, matches candles) |
| `GET /confluence/{ticker}` | PG `confluence_scores` | served from storage (persisted depth) |

Compute-on-read uses the **same `default_params` as the live `IndicatorEngine`**
(`indicator_engine.py:601`), so chart lines line up with fired signals. Heavy compute runs in
a worker thread so it can't stall the live signal WS.

## Design decisions (confirmed with maintainer)
- **Indicators = compute-on-read (full depth)** over serve-from-DB: `indicator_values` only has
  data from when apex started watching → gappy; recomputing from livewire bars is gap-free.
- **Confluence = DB-backed**: it's a cross-indicator aggregate (not a pure function of one bar
  series), so historical depth = persisted history.
- **Bars are never stored by apex** — livewire is the warehouse; apex reads via an ephemeral
  in-memory DuckDB query per request.

## What's included
- `src/application/chart/indicator_compute.py` — compute-on-read service (warmup lead, UTC,
  NaN/numpy coercion, off-event-loop via `asyncio.to_thread`).
- `src/api/payload/chart.py` + 3 JSON schemas (`bars/indicator_series/confluence_payload`);
  `validate_payload(payload, schema=)` generalized (backward-compatible).
- `src/api/routes/chart.py` — 3 routes; `503` when provider/repo unconfigured, `404` unknown
  indicator, `400` unsupported timeframe, bounded `limit`.
- `src/api/server.py` — lifespan exposes `ohlc_provider` + `indicator_registry` on `app.state`
  (chart works without a live subscription); reuses the one provider in the pipeline.
- `docs/argon-signal-consumption.md` — new §10 with **real captured frames**.

## Verified end-to-end (real capture, 2026-06-14)
Booted the real FastAPI lifespan → `LivewireOhlcProvider` reads a bronze parquet via DuckDB →
compute-on-read → `validate_payload` → JSON; confluence is a real Postgres round-trip on
`apex_signals`. `/bars`, `/indicators` (rsi/macd/bollinger), `/confluence` all `200` and
schema-valid; unknown indicator `404`. Frames embedded in the doc.
**Caveat:** bar *data* is a synthetic bronze fixture (real livewire bronze not reachable in the
capture env) — code path/shapes/validation are real; `COLUMN_MAP` still unverified vs real data.

## Review-cycle
- **Pass 1 (self):** found + fixed confluence ordering (now ASC, consistent with bars/indicators)
  and chart-timestamp tz (now UTC).
- **Pass 2 (codex):** offload compute off the event loop; `400` (not `500`) on unsupported
  timeframes; correct no-arg default window (over-fetch + tail-slice to 500, robust across
  market closures); expose confluence `limit`.
- **Pass 3 (adversarial):** bounded `limit` (`ge=1, le=5000`) so a negative/huge `LIMIT` can't
  reach Postgres.

## Standing rules
- ✅ No Yahoo; ✅ backtest untouched; ✅ no secrets to codex (diff was src+tests only);
  ✅ no AI attribution trailers; ✅ PR before merge.

## Not verified / follow-ups
- Real livewire bronze `COLUMN_MAP` (synthetic fixture used).
- Live pipeline *populating* `confluence_scores` end-to-end (read path proven via a seeded row;
  write path is code-verified).
- Explicit (non-default) bars/indicator windows are uncapped (trusted-network service).
- Live WS push for chart data is out of scope (REST poll for now; signals still stream over WS).

## Test plan
- [ ] CI green (unit, integration, type, lint, security, complexity, dead-code)
- [x] `uv run pytest` chart unit + integration (59 chart tests; 102 in touched areas)
- [x] `mypy src/ --ignore-missing-imports --disable-error-code=no-any-return` clean
- [x] black/isort/flake8 clean
- [x] live end-to-end capture against local Postgres
