### PR TITLE
Match livewire bronze read contract to the real schema (trade_date / bar_timestamp / encode_symbol)

### DIFF
--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -4,32 +4,52 @@ Implements apex's HistoricalSourcePort (src/domain/interfaces/historical_source.
 Reads are on-demand, one (symbol, timeframe, date-range) at a time -- never the
 full universe.
 
-UNVERIFIED: COLUMN_MAP below uses the documented/fixture schema (`ts` + OHLCV).
-The REAL livewire bronze column names MUST be confirmed against a live parquet
-(see Phase 1 plan Task 1) before production wiring.
+Bronze schema matched to livewire's writers (``clients/bronze_client.py`` +
+``clients/intraday_bronze_client.py``, 2026-06-14): daily bars are keyed by
+``trade_date`` (date32) and carry ``adj_close``; intraday bars are keyed by
+``bar_timestamp`` (timestamp us, tz=UTC). Both also carry ``symbol_id`` (ignored
+here -- the symbol comes from the partition). OHLCV column names match 1:1.
+
+NOT yet smoke-tested against a live parquet (no bronze on disk in this env); the
+column/layout contract is verified against livewire's writer, not real bytes.
 """
 
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import List
+from typing import Any, List
 
 import duckdb
 
 from ....domain.events.domain_events import BarData
 from .paths import SUPPORTED_TIMEFRAMES, parquet_path
 
-# livewire column -> BarData field. CONFIRM the `ts`/OHLCV names against real data.
-COLUMN_MAP = {
-    "ts": "bar_start",
-    "open": "open",
-    "high": "high",
-    "low": "low",
-    "close": "close",
-    "volume": "volume",
-}
+# livewire keys daily bars by `trade_date` (a DATE) and intraday bars by
+# `bar_timestamp` (a tz-aware UTC TIMESTAMP). OHLCV columns are read by name; extra
+# columns (symbol_id, adj_close) are ignored.
+_DAILY_TS_COLUMN = "trade_date"
+_INTRADAY_TS_COLUMN = "bar_timestamp"
+
+
+def _timestamp_column(timeframe: str) -> str:
+    return _DAILY_TS_COLUMN if timeframe == "1d" else _INTRADAY_TS_COLUMN
+
+
+def _to_utc_datetime(value: Any) -> datetime:
+    """Coerce a livewire timestamp to a tz-aware UTC datetime.
+
+    DuckDB returns ``trade_date`` (date32) as ``datetime.date`` and ``bar_timestamp``
+    (timestamp tz=UTC) as a tz-aware ``datetime``. datetime is a subclass of date, so
+    check it first.
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    raise TypeError(f"unexpected livewire timestamp type: {type(value)!r}")
+
 
 # Bar duration per timeframe -- used to derive bar_end (not a zero-width bar).
 _TF_DELTAS = {
@@ -83,7 +103,7 @@ class LivewireOhlcProvider:
         start: datetime,
         end: datetime,
     ) -> List[BarData]:
-        ts_col = next(k for k, v in COLUMN_MAP.items() if v == "bar_start")
+        ts_col = _timestamp_column(timeframe)
         # NOTE: read_parquet path is inlined (NOT a bound parameter) -- DuckDB does
         # not accept a prepared-statement parameter for the parquet path. The path
         # is constructed by us from a validated symbol/timeframe, not user SQL.
@@ -91,16 +111,20 @@ class LivewireOhlcProvider:
             f"SELECT * FROM read_parquet('{path.as_posix()}') "
             f"WHERE {ts_col} >= ? AND {ts_col} <= ? ORDER BY {ts_col} ASC"
         )
+        # Daily `trade_date` is a DATE -- bind calendar-date params so the comparison
+        # is tz-agnostic (avoids DATE-vs-TIMESTAMPTZ session-tz surprises). Intraday
+        # `bar_timestamp` is TIMESTAMPTZ -- bind the tz-aware datetimes directly.
+        params = [start.date(), end.date()] if timeframe == "1d" else [start, end]
         con = duckdb.connect(database=":memory:")
         try:
-            rows = con.execute(sql, [start, end]).fetch_arrow_table().to_pylist()
+            rows = con.execute(sql, params).fetch_arrow_table().to_pylist()
         finally:
             con.close()
         return [self._row_to_bar(r, symbol, timeframe) for r in rows]
 
     @staticmethod
     def _row_to_bar(row: dict, symbol: str, timeframe: str) -> BarData:
-        ts = row[next(k for k, v in COLUMN_MAP.items() if v == "bar_start")]
+        ts = _to_utc_datetime(row[_timestamp_column(timeframe)])
         end = ts + _TF_DELTAS.get(timeframe, timedelta(0))
         vol = row.get("volume")
         return BarData(

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -39,14 +39,22 @@ def _timestamp_column(timeframe: str) -> str:
 
 
 def _to_utc_datetime(value: Any) -> datetime:
-    """Coerce a livewire timestamp to a tz-aware UTC datetime.
+    """Coerce a livewire timestamp to a UTC-*labelled* tz-aware datetime.
 
     DuckDB returns ``trade_date`` (date32) as ``datetime.date`` and ``bar_timestamp``
-    (timestamp tz=UTC) as a tz-aware ``datetime``. datetime is a subclass of date, so
-    check it first.
+    (TIMESTAMPTZ) as a tz-aware ``datetime`` -- but in the *session* timezone, NOT UTC
+    (e.g. ``Asia/Hong_Kong`` +08:00 on a HK-locale box). The instant is correct, the
+    label is not. We must ``astimezone(UTC)`` so seeded warmup bars (session tz) and
+    live tick bars (UTC) share one offset: a mixed-offset column crashes
+    ``pd.to_datetime(...)`` in the indicator engine and silently kills live compute.
+    datetime is a subclass of date, so check it first.
     """
     if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return (
+            value.astimezone(timezone.utc)
+            if value.tzinfo is not None
+            else value.replace(tzinfo=timezone.utc)
+        )
     if isinstance(value, date):
         return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
     raise TypeError(f"unexpected livewire timestamp type: {type(value)!r}")

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -10,8 +10,9 @@ Bronze schema matched to livewire's writers (``clients/bronze_client.py`` +
 ``bar_timestamp`` (timestamp us, tz=UTC). Both also carry ``symbol_id`` (ignored
 here -- the symbol comes from the partition). OHLCV column names match 1:1.
 
-NOT yet smoke-tested against a live parquet (no bronze on disk in this env); the
-column/layout contract is verified against livewire's writer, not real bytes.
+Smoke-tested 2026-06-14 against the real livewire bronze data lake: AAPL ``1d``
+(``trade_date``/DATE) and ``1m`` (``bar_timestamp``/TIMESTAMPTZ) read back correct
+OHLCV at the right instants.
 """
 
 from __future__ import annotations

--- a/src/infrastructure/adapters/livewire/paths.py
+++ b/src/infrastructure/adapters/livewire/paths.py
@@ -1,18 +1,44 @@
 """Resolve (symbol, timeframe) to a livewire bronze parquet path.
 
-The per-ticker Hive layout IS the read contract (livewire-adaptation.md 3, 5):
-  <root>/asset_class=equity/symbol=<SYM>/<tf>.parquet
+The per-ticker Hive layout IS the read contract, confirmed against livewire's
+``clients/bronze_client.py`` + ``clients/intraday_bronze_client.py`` (2026-06-14):
+
+  <root>/asset_class=equity/symbol=<encode_symbol(SYM)>/<tf>.parquet
+
+where ``<root>`` is livewire's ``data-lake/bronze`` directory (``APEX_LIVEWIRE_ROOT``).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# Timeframes livewire warehouses for equities (livewire-adaptation.md 2).
+# Timeframes livewire warehouses for equities: daily via BronzeClient (1d), intraday
+# via IntradayBronzeClient (1m/5m/30m/1h). Matches livewire's INTRADAY_TIMEFRAMES + 1d.
 SUPPORTED_TIMEFRAMES = ("1m", "5m", "30m", "1h", "1d")
+
+# Mirrors livewire's clients/symbol_paths.py exactly: keep these characters literal,
+# percent-encode everything else as UTF-8 bytes. Reversible + safe on case-insensitive
+# filesystems. Uppercase tickers with `.`/`-` (AAPL, BRK.B) are identity; `/` etc. encode.
+_CASE_SAFE = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+
+
+def encode_symbol(symbol: str) -> str:
+    """Encode a symbol to its livewire bronze partition name (matches livewire 1:1)."""
+    parts: list[str] = []
+    for character in symbol:
+        if character in _CASE_SAFE:
+            parts.append(character)
+        else:
+            parts.extend(f"%{byte:02X}" for byte in character.encode("utf-8"))
+    return "".join(parts)
 
 
 def parquet_path(bronze_root: Path, symbol: str, timeframe: str) -> Path:
     if timeframe not in SUPPORTED_TIMEFRAMES:
         raise ValueError(f"unsupported timeframe: {timeframe!r} (have {SUPPORTED_TIMEFRAMES})")
-    return bronze_root / "asset_class=equity" / f"symbol={symbol}" / f"{timeframe}.parquet"
+    return (
+        bronze_root
+        / "asset_class=equity"
+        / f"symbol={encode_symbol(symbol)}"
+        / f"{timeframe}.parquet"
+    )

--- a/tests/integration/test_xenon_to_ws_e2e.py
+++ b/tests/integration/test_xenon_to_ws_e2e.py
@@ -38,16 +38,17 @@ def _write_seed(root, symbol: str = "AAPL") -> None:
     sym_dir.mkdir(parents=True, exist_ok=True)
     base = datetime.now(timezone.utc) - timedelta(minutes=5)
     ts = [base + timedelta(minutes=i) for i in range(3)]
+    # Mirror livewire's REAL intraday bronze schema (clients/intraday_bronze_client.py):
+    # `bar_timestamp` (timestamp tz=UTC) + `symbol_id` + OHLCV. Symbol is the partition.
     pd.DataFrame(
         {
-            "ts": pd.to_datetime(ts, utc=True),
+            "bar_timestamp": pd.to_datetime(ts, utc=True),
+            "symbol_id": [1, 1, 1],
             "open": [10.0, 11.0, 12.0],
             "high": [10.5, 11.5, 12.5],
             "low": [9.5, 10.5, 11.5],
             "close": [11.0, 12.0, 13.0],
             "volume": [100, 200, 300],
-            "asset_class": ["equity"] * 3,
-            "symbol": [symbol] * 3,
         }
     ).to_parquet(sym_dir / "1m.parquet")
 

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,30 +15,49 @@ WIDE_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
 
 
 def _write_fixture(root: Path) -> None:
-    """Write a 3-bar livewire bronze parquet for symbol TEST, timeframe 1d.
+    """Write a 3-bar daily livewire bronze parquet for symbol TEST.
 
-    Generated at runtime (not committed) because *.parquet is gitignored -- a
-    static fixture would be absent in CI. Mirrors the real bronze schema: a
-    tz-aware `ts` column plus OHLCV and the Hive partition columns.
+    Generated at runtime (*.parquet is gitignored). Mirrors livewire's REAL daily
+    bronze schema (clients/bronze_client.py): `trade_date` (date32), `symbol_id`,
+    OHLC, `adj_close`, `volume` -- the symbol lives in the partition dir, not a column.
     """
     sym_dir = root / "asset_class=equity" / "symbol=TEST"
     sym_dir.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame(
         {
-            "ts": pd.to_datetime(
-                ["2026-01-02T00:00:00Z", "2026-01-03T00:00:00Z", "2026-01-06T00:00:00Z"],
+            "trade_date": [dt.date(2026, 1, 2), dt.date(2026, 1, 3), dt.date(2026, 1, 6)],
+            "symbol_id": [1, 1, 1],
+            "open": [10.0, 11.0, 12.0],
+            "high": [10.5, 11.5, 12.5],
+            "low": [9.5, 10.5, 11.5],
+            "close": [11.0, 12.0, 13.0],
+            "adj_close": [11.0, 12.0, 13.0],
+            "volume": [100, 200, 300],
+        }
+    )
+    df.to_parquet(sym_dir / "1d.parquet")
+
+
+def _write_intraday_fixture(root: Path) -> None:
+    """Write a 3-bar 1m parquet mirroring livewire's intraday schema:
+    `bar_timestamp` (tz-aware UTC) + `symbol_id` + OHLCV."""
+    sym_dir = root / "asset_class=equity" / "symbol=TEST"
+    sym_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "bar_timestamp": pd.to_datetime(
+                ["2026-01-02T14:30:00Z", "2026-01-02T14:31:00Z", "2026-01-02T14:32:00Z"],
                 utc=True,
             ),
+            "symbol_id": [1, 1, 1],
             "open": [10.0, 11.0, 12.0],
             "high": [10.5, 11.5, 12.5],
             "low": [9.5, 10.5, 11.5],
             "close": [11.0, 12.0, 13.0],
             "volume": [100, 200, 300],
-            "asset_class": ["equity", "equity", "equity"],
-            "symbol": ["TEST", "TEST", "TEST"],
         }
     )
-    df.to_parquet(sym_dir / "1d.parquet")
+    df.to_parquet(sym_dir / "1m.parquet")
 
 
 @pytest.fixture
@@ -82,6 +102,23 @@ async def test_fetch_bars_date_range_filter(provider: LivewireOhlcProvider) -> N
     )
     assert len(bars) == 1
     assert bars[0].close == 12.0
+
+
+@pytest.mark.asyncio
+async def test_fetch_bars_intraday_reads_bar_timestamp(tmp_path: Path) -> None:
+    """Intraday bars are keyed by `bar_timestamp` (tz-aware UTC), not `trade_date`."""
+    _write_intraday_fixture(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars(
+        "TEST",
+        "1m",
+        datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc),
+        datetime(2026, 1, 2, 14, 32, tzinfo=timezone.utc),
+    )
+    assert [b.close for b in bars] == [11.0, 12.0, 13.0]
+    assert bars[0].bar_start == datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc)
+    assert bars[0].bar_start.tzinfo is not None  # tz-aware UTC, not naive
+    assert bars[0].bar_end > bars[0].bar_start  # 1m duration
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import datetime as dt
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from src.domain.interfaces.historical_source import HistoricalSourcePort
-from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+from src.infrastructure.adapters.livewire.ohlc_provider import (
+    LivewireOhlcProvider,
+    _to_utc_datetime,
+)
 
 WIDE_START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 WIDE_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
@@ -131,6 +134,33 @@ async def test_fetch_bars_missing_symbol_returns_empty(provider: LivewireOhlcPro
 async def test_unsupported_timeframe_raises(provider: LivewireOhlcProvider) -> None:
     with pytest.raises(ValueError, match="unsupported timeframe"):
         await provider.fetch_bars("TEST", "3m", WIDE_START, WIDE_END)
+
+
+def test_to_utc_datetime_normalizes_session_tz_to_utc() -> None:
+    """DuckDB returns TIMESTAMPTZ in the session timezone (e.g. +08:00), not UTC.
+
+    The provider must convert those to UTC so warmup-seeded bars (session tz) and
+    live tick bars (UTC) share one offset. A mixed-offset column crashes
+    `pd.to_datetime(...)` in the indicator engine (`Tz-aware datetime cannot be
+    converted to datetime64 unless utc=True`), killing live indicator compute.
+    """
+    hk = timezone(timedelta(hours=8))
+    aware_hk = datetime(2026, 6, 12, 22, 30, tzinfo=hk)  # == 14:30 UTC, same instant
+
+    out = _to_utc_datetime(aware_hk)
+
+    assert out.utcoffset() == timedelta(0)  # normalized to UTC, not left at +08:00
+    assert out.tzinfo == timezone.utc
+    assert out == datetime(2026, 6, 12, 14, 30, tzinfo=timezone.utc)  # instant preserved
+
+
+def test_to_utc_datetime_keeps_naive_and_date_as_utc() -> None:
+    """Naive datetimes are tagged UTC; date32 (daily `trade_date`) becomes midnight UTC."""
+    naive = _to_utc_datetime(datetime(2026, 1, 2, 9, 30))
+    assert naive == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
+
+    daily = _to_utc_datetime(dt.date(2026, 1, 2))
+    assert daily == datetime(2026, 1, 2, tzinfo=timezone.utc)
 
 
 def test_provider_satisfies_historical_source_port(bronze_root: Path) -> None:

--- a/tests/unit/infrastructure/livewire/test_paths.py
+++ b/tests/unit/infrastructure/livewire/test_paths.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.infrastructure.adapters.livewire.paths import (
     SUPPORTED_TIMEFRAMES,
+    encode_symbol,
     parquet_path,
 )
 
@@ -14,6 +15,20 @@ def test_parquet_path_layout() -> None:
     root = Path("/data/bronze")
     p = parquet_path(root, "AAPL", "1d")
     assert p == root / "asset_class=equity" / "symbol=AAPL" / "1d.parquet"
+
+
+def test_encode_symbol_matches_livewire() -> None:
+    # case-safe chars pass through (uppercase tickers, dots, hyphens)
+    assert encode_symbol("AAPL") == "AAPL"
+    assert encode_symbol("BRK.B") == "BRK.B"
+    assert encode_symbol("BF-A") == "BF-A"
+    # everything else is percent-encoded as UTF-8 bytes (matches livewire 1:1)
+    assert encode_symbol("BF/B") == "BF%2FB"
+
+
+def test_parquet_path_encodes_special_symbol() -> None:
+    p = parquet_path(Path("/data/bronze"), "BF/B", "1d")
+    assert p == Path("/data/bronze") / "asset_class=equity" / "symbol=BF%2FB" / "1d.parquet"
 
 
 def test_unsupported_timeframe_raises() -> None:


### PR DESCRIPTION
## Update (2026-06-14) — items below partially superseded

- ✅ **Live-bytes smoke test DONE** (the "Not verified" note below is resolved). Verified against
  the real lake at `/Volumes/DATA_LAKE/livewire/data-lake/bronze` (real AAPL `1d`/`1m`): correct
  OHLCV at correct UTC instants.
- ✅ **+ TZ normalization fix** (commit `8b06fdc`). DuckDB returns `bar_timestamp` (TIMESTAMPTZ)
  in the **session** tz (e.g. `Asia/Hong_Kong` +08:00), not UTC. `_to_utc_datetime` now
  `astimezone(UTC)`. Without it, warmup-seeded intraday bars (+08:00) mixed with live UTC tick
  bars crash `pd.to_datetime(df["timestamp"])` in `indicator_engine.py:490` and **silently kill
  live indicator compute**. Found by a true `/ws/signals` subscription against the real lake;
  added unit tests asserting the +08:00 → UTC normalization.
- CI green (12/12); mypy/black/isort/flake8 clean.

---

## Summary

apex's `LivewireOhlcProvider` read contract was built against a **documented/fixture** schema
(`ts` column, raw `symbol=` partition) that **does not match what livewire actually writes**.
Verified against livewire's own writers (`clients/bronze_client.py`,
`clients/intraday_bronze_client.py`, `clients/symbol_paths.py`, 2026-06-14) and corrected so
`/bars` + `/indicators` (PR #134) and the streaming warmup read real bronze correctly.

## The mismatch (was → now)

| | was (assumed) | now (livewire's real schema) |
|---|---|---|
| daily timestamp | `ts` | **`trade_date`** (date32) |
| intraday timestamp | `ts` | **`bar_timestamp`** (timestamp µs, tz=UTC) |
| symbol partition | `symbol=<TICKER>` (raw) | `symbol=<**encode_symbol**(TICKER)>` |
| daily extras | — | `adj_close`, `symbol_id` present (ignored) |

## Changes
- `paths.py`: add `encode_symbol()` (byte-for-byte match to livewire's `symbol_paths.py`),
  use it in `parquet_path`. `SUPPORTED_TIMEFRAMES` already matched livewire (1m/5m/30m/1h/1d).
- `ohlc_provider.py`: per-timeframe timestamp column (`trade_date` for 1d, `bar_timestamp`
  otherwise); `date32 → tz-aware UTC datetime` coercion; daily filter binds **calendar-date**
  params (tz-safe — no DATE-vs-TIMESTAMPTZ session-tz surprises); reads OHLCV by name and
  ignores extra columns.
- Test fixtures (`test_ohlc_provider.py`, `test_xenon_to_ws_e2e.py`) rewritten to the **real**
  schema; new `encode_symbol` + intraday `bar_timestamp` tests.

## Verified
- `uv run pytest tests/unit/infrastructure/livewire tests/integration` — **132 passed, 1 skipped**
  (real DuckDB reads of real-schema parquet, both daily date32 and intraday tz-aware paths).
- `mypy ... ` clean (518 files); black/isort/flake8 clean.

## Not verified (still)
- **No real bronze bytes on disk in this env** — livewire's warehouse exists
  (`~/market-warehouse`) but `data-lake/bronze/` isn't populated locally. The contract is now
  matched to livewire's writer; a live smoke test (point `APEX_LIVEWIRE_ROOT` at a real
  `…/data-lake/bronze` and `GET /bars/AAPL`) is the remaining step once data is present.

## Related
- Builds the correct foundation for **PR #134** (chart read surface). Independent files; no
  conflict. The §10 doc caveat in #134 ("COLUMN_MAP unverified") will be softened to
  "matched to livewire's writer; live-bytes smoke pending" once both land.

## Test plan
- [ ] CI green
- [x] livewire provider/paths unit tests (real-schema fixtures, both timeframes)
- [x] xenon→ws e2e (intraday bar_timestamp) green
- [x] mypy + lint clean
