### PR TITLE
fix: coerce numpy scalars before persisting indicator state to JSONB

### DIFF
--- a/src/application/chart/indicator_compute.py
+++ b/src/application/chart/indicator_compute.py
@@ -11,11 +11,12 @@ so the lines always match the live signals and the candles.
 from __future__ import annotations
 
 import asyncio
-import math
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
+
+from src.utils.jsonable import to_jsonable
 
 # Bar duration per timeframe -- used to derive the warmup lead in calendar time.
 # Public so the chart routes can reuse it for default windows.
@@ -34,23 +35,6 @@ DEFAULT_TF_DELTA = timedelta(days=1)
 
 class UnknownIndicatorError(ValueError):
     """Raised when the requested indicator is not registered."""
-
-
-def _jsonable(value: Any) -> Any:
-    """Coerce numpy scalars / NaN to JSON-native types (NaN -> None), recursively."""
-    if isinstance(value, dict):
-        return {k: _jsonable(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_jsonable(v) for v in value]
-    item = value
-    if hasattr(value, "item") and not isinstance(value, (str, bytes)):
-        try:
-            item = value.item()  # numpy scalar -> python scalar
-        except (ValueError, AttributeError):
-            item = value
-    if isinstance(item, float) and math.isnan(item):
-        return None
-    return item
 
 
 def _bars_to_df(bars: List[Any]) -> pd.DataFrame:
@@ -121,8 +105,8 @@ def _compute_points(
             points.append(
                 {
                     "time": py_ts,
-                    "state": _jsonable(state),
-                    "bar_close": _jsonable(close),
+                    "state": to_jsonable(state),
+                    "bar_close": to_jsonable(close),
                 }
             )
         prev = row

--- a/src/infrastructure/persistence/repositories/ta_signal_repository.py
+++ b/src/infrastructure/persistence/repositories/ta_signal_repository.py
@@ -37,6 +37,7 @@ from tenacity import (
 
 from src.domain.interfaces.signal_persistence import SignalPersistencePort
 from src.infrastructure.persistence.database import Database
+from src.utils.jsonable import to_jsonable
 
 if TYPE_CHECKING:
     from src.domain.signals.models import TradingSignal
@@ -425,8 +426,8 @@ class TASignalRepository(SignalPersistencePort):
             symbol,
             timeframe,
             indicator,
-            json.dumps(state),
-            json.dumps(previous_state) if previous_state else None,
+            json.dumps(to_jsonable(state)),
+            json.dumps(to_jsonable(previous_state)) if previous_state else None,
             bar_close,
         )
 

--- a/src/utils/jsonable.py
+++ b/src/utils/jsonable.py
@@ -1,0 +1,37 @@
+"""Coerce numpy scalars / NaN into JSON-native types, recursively.
+
+Indicator ``state`` dicts come straight out of pandas/numpy compute, so they carry
+numpy scalars -- numpy bool (e.g. bollinger's ``squeeze``), numpy int/float -- which
+stdlib ``json`` cannot serialize (raises ``TypeError``), plus ``NaN`` (a bare ``NaN`` is
+invalid JSON and Postgres JSONB rejects it). Both egress paths that JSON-encode that
+state -- the chart compute-on-read service and the live-persist repository -- share this
+one coercer so they encode identically and can't drift.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def to_jsonable(value: Any) -> Any:
+    """Recursively convert numpy scalars to Python scalars and NaN to None.
+
+    Leaves JSON-native values untouched. ``dict``/``list``/``tuple`` are recursed
+    (tuples become lists). numpy scalars are unwrapped via ``.item()``; any float NaN
+    (numpy or Python) becomes ``None``.
+    """
+    if isinstance(value, dict):
+        return {k: to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(v) for v in value]
+
+    item = value
+    if hasattr(value, "item") and not isinstance(value, (str, bytes)):
+        try:
+            item = value.item()  # numpy scalar -> python scalar
+        except (ValueError, AttributeError):
+            item = value
+    if isinstance(item, float) and math.isnan(item):
+        return None
+    return item

--- a/tests/unit/persistence/test_ta_signal_repository_save.py
+++ b/tests/unit/persistence/test_ta_signal_repository_save.py
@@ -1,0 +1,79 @@
+"""save_indicator: persist indicator state as JSONB without choking on numpy scalars.
+
+Live indicators (e.g. bollinger's ``squeeze``) carry numpy bools in their ``state``.
+stdlib ``json.dumps`` raises ``TypeError: Object of type bool is not JSON serializable``
+on those, which previously killed the best-effort persist in a background task. The repo
+must coerce numpy scalars to JSON-native types (and the persisted JSON must contain a real
+boolean, not the string ``"True"``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+
+from src.infrastructure.persistence.repositories.ta_signal_repository import (
+    TASignalRepository,
+)
+
+
+class _FakeDB:
+    """Records execute() params, like asyncpg would receive them."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def execute(self, query: str, *args):
+        self.calls.append((query, args))
+        return "INSERT 0 1"
+
+
+@pytest.mark.asyncio
+async def test_save_indicator_coerces_numpy_bool_in_state() -> None:
+    db = _FakeDB()
+    repo = TASignalRepository(db)
+
+    state = {
+        "value": np.float64(208.7),
+        "squeeze": np.bool_(True),  # numpy bool -> would raise TypeError on json.dumps
+        "upper": np.float64("nan"),  # NaN -> must become null (invalid JSON otherwise)
+    }
+
+    # Previously raised: "Object of type bool is not JSON serializable".
+    await repo.save_indicator(
+        symbol="AAPL",
+        timeframe="1d",
+        indicator="bollinger",
+        timestamp=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        state=state,
+    )
+
+    assert len(db.calls) == 1
+    _query, args = db.calls[0]
+    state_json = args[4]  # 5th INSERT param is state (json string)
+    decoded = json.loads(state_json)
+    assert decoded["squeeze"] is True  # real JSON boolean, not "True"
+    assert decoded["value"] == 208.7
+    assert decoded["upper"] is None  # NaN -> null
+
+
+@pytest.mark.asyncio
+async def test_save_indicator_coerces_numpy_in_previous_state() -> None:
+    db = _FakeDB()
+    repo = TASignalRepository(db)
+
+    await repo.save_indicator(
+        symbol="AAPL",
+        timeframe="1d",
+        indicator="bollinger",
+        timestamp=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        state={"squeeze": np.bool_(False)},
+        previous_state={"squeeze": np.bool_(True)},
+    )
+
+    _query, args = db.calls[0]
+    assert json.loads(args[4])["squeeze"] is False  # state
+    assert json.loads(args[5])["squeeze"] is True  # previous_state

--- a/tests/unit/utils/test_jsonable.py
+++ b/tests/unit/utils/test_jsonable.py
@@ -1,0 +1,63 @@
+"""to_jsonable: coerce numpy scalars / NaN to JSON-native types, recursively.
+
+Both egress paths that serialize indicator state to JSON -- the chart compute-on-read
+service (``src/application/chart/indicator_compute.py``) and the live-persist repository
+(``ta_signal_repository.save_indicator``) -- must encode identically, so they share this
+one coercer. The key cases: numpy bool/int/float scalars are NOT JSON-serializable by
+stdlib ``json`` (raises ``TypeError``), and numpy/float ``NaN`` must become ``null`` (a
+bare ``NaN`` is invalid JSON and Postgres JSONB rejects it).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+
+from src.utils.jsonable import to_jsonable
+
+
+def test_numpy_bool_becomes_python_bool() -> None:
+    out = to_jsonable(np.bool_(True))
+    assert out is True
+    assert isinstance(out, bool)
+    assert json.dumps(out) == "true"
+
+
+def test_numpy_int_and_float_become_python_scalars() -> None:
+    assert to_jsonable(np.int64(7)) == 7
+    assert isinstance(to_jsonable(np.int64(7)), int)
+    assert to_jsonable(np.float64(1.5)) == 1.5
+    assert isinstance(to_jsonable(np.float64(1.5)), float)
+
+
+def test_nan_becomes_none() -> None:
+    assert to_jsonable(np.float64("nan")) is None
+    assert to_jsonable(float("nan")) is None
+
+
+def test_recurses_into_dicts_and_lists() -> None:
+    state = {
+        "squeeze": np.bool_(True),  # the bollinger field that crashed persist
+        "value": np.float64(42.5),
+        "history": [np.int64(1), np.float64("nan"), np.bool_(False)],
+        "nested": {"flag": np.bool_(False)},
+    }
+    out = to_jsonable(state)
+
+    # Whole structure is now stdlib-json serializable (the original raised TypeError).
+    encoded = json.dumps(out)
+    assert json.loads(encoded) == {
+        "squeeze": True,
+        "value": 42.5,
+        "history": [1, None, False],
+        "nested": {"flag": False},
+    }
+
+
+def test_plain_python_values_pass_through() -> None:
+    state = {"a": 1, "b": "x", "c": 2.0, "d": True, "e": None}
+    assert to_jsonable(state) == state
+    # math.nan still maps to None even when nested in a plain dict
+    assert to_jsonable({"k": math.nan}) == {"k": None}


### PR DESCRIPTION
## Problem

Once live indicators actually compute against real data, the **indicator-value persistence** path logs:

```
Failed to persist indicator bollinger/volume for AAPL: Object of type bool is not JSON serializable
```

Indicator `state` carries **numpy scalars** straight out of pandas/numpy compute — e.g. bollinger's `squeeze` is a numpy bool. stdlib `json.dumps` can't serialize those (raises `TypeError`), so the **best-effort** persist in a background task silently died. Non-fatal (logged, pipeline continues, signals still flow + validate), but indicator history wasn't being written.

This was surfaced during the true `/ws/signals` subscription run against the real lake (see PR #135). It was deliberately left out of #134/#135 as an out-of-scope follow-up; this is that follow-up.

## Fix

The chart compute-on-read path already coerced numpy/NaN via a private `_jsonable` helper. Infrastructure can't import that (application/chart → would invert layering), so lift it into a shared low-layer util `src/utils/jsonable.py` (`to_jsonable`) and use it in **both** egress paths:

- **`TASignalRepository.save_indicator`** — the chokepoint that *both* live persist callers (`TASignalService` and `SignalCoordinator`) route through. Coerces `state` + `previous_state` before `json.dumps`.
- **`chart/indicator_compute`** — now imports the shared coercer instead of its own copy, so the **read** and **persist** paths encode identically and can't drift (same "share the normalizer" principle as `direction` in `contract.py`).

Semantics: numpy bool → real JSON `true` (**not** the string `"True"`, which `json.dumps(..., default=str)` would have produced); NaN → `null` (a bare `NaN` is invalid JSON and Postgres JSONB rejects it).

## Tests (TDD)

- `tests/unit/utils/test_jsonable.py` — numpy bool/int/float → python scalars, NaN → None, recursion into dicts/lists, plain values pass through.
- `tests/unit/persistence/test_ta_signal_repository_save.py` — `save_indicator` with a numpy-bool-bearing `state` now persists without raising; the JSON param carries a real boolean and `null` for NaN. (Reproduced the exact `TypeError` before the fix.)

## Verification

- New + adjacent suites green: **450 passed, 31 skipped** (`tests/unit/{utils,persistence,application,signals}`).
- `mypy` (cache-free) on the 3 touched source files: clean.
- black / isort / flake8: clean.

## Out of scope

`services/signal_service.py` regime-summary upsert uses a separate `json.dumps` on `component_states` (different service, different table, swallowed at `debug`). No evidence it carries numpy scalars — left untouched rather than speculatively widening the change.