### PR TITLE
chore: remove DuckDB-as-a-database confusion (*.duckdb guard + doc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,9 +107,14 @@ coverage.xml
 /results/
 /.claude/
 /data/equity.csv
-/data/historical/_metadata.duckdb
 /data/coverage_report.html
 /data/historical/
+
+# apex holds NO DuckDB database — DuckDB is used in-memory per request over the
+# livewire Parquet lake (src/infrastructure/adapters/livewire/ohlc_provider.py).
+# Any *.duckdb file on disk is a stray legacy artifact, never a real datastore.
+*.duckdb
+*.ddb
 /data/MD（富途moomoo）副图版.txt
 /data/MD（富途moomoo） 主图版.txt
 /output/systematic-hedge-fund-quant-dev-interview-prep.html

--- a/docs/livewire-apex-integration.md
+++ b/docs/livewire-apex-integration.md
@@ -121,6 +121,12 @@ anything here — just keep writing UTC `TIMESTAMPTZ`.
 
 ## 4. How apex queries (for reference)
 
+> **There is NO DuckDB database.** apex opens a fresh **in-memory** (`:memory:`) DuckDB
+> connection per request, runs one `read_parquet()` over a single Parquet file, and closes
+> it immediately — no `.duckdb` file, no catalog, nothing persisted. **The Parquet files
+> *are* the store.** (A stray `*.duckdb` on disk is a legacy artifact, not used by this
+> service; `*.duckdb` is gitignored.)
+
 Per request, in a worker thread (off the event loop), against an in-memory DuckDB connection:
 
 ```sql


### PR DESCRIPTION
## Why
"Where is the DuckDB?" — a stray `data/historical/_metadata.duckdb` made it look like apex has a database. **It does not.** DuckDB is used purely **in-memory, per request**, over the livewire Parquet lake (`ohlc_provider.py:127` opens a fresh `:memory:` connection, runs one `read_parquet()`, closes it). The Parquet files are the store.

## What
- **Deleted** the stray `data/historical/_metadata.duckdb` (274 KB, gitignored, a leftover from the old historical-data loader / `DuckDBCoverageStore` — unused by the live service).
- **`.gitignore`**: replaced the one-off `/data/historical/_metadata.duckdb` line with a general **`*.duckdb` / `*.ddb`** guard (+ a comment explaining apex has no DB), so no DuckDB file can ever masquerade as — or be committed as — a datastore.
- **`docs/livewire-apex-integration.md` §4**: explicit "There is NO DuckDB database" callout.

## Verified
- Live API (`server.py` + its imports) references **no** persistent DuckDB / historical store; the only DuckDB in the API/application live path is the in-memory provider.
- `find . -name '*.duckdb'` → **0 files** after cleanup.

## Out of scope (tracked as Phase 6, task #14)
The dead code that *could* recreate such files — `DuckDBCoverageStore`, `ParquetHistoricalStore`, `historical_data_manager`, the `src/application/__init__.py → bootstrap` import coupling, the backtest DuckDB storage — is old-stack and isolated from the live API. Removing it is a real strip-down (blast radius on `from src.application import …`), so it's a dedicated CI-verified PR, not this one.