### PR TITLE
chore: break CLAUDE.md into per-subsystem files, align with xenon/argon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,15 +117,25 @@ coverage.xml
 *.ddb
 /data/MD（富途moomoo）副图版.txt
 /data/MD（富途moomoo） 主图版.txt
-/output/systematic-hedge-fund-quant-dev-interview-prep.html
-/output/systematic-hedge-fund-quant-dev-interview-prep.json
 /plan-reviewer/SKILL.md
 /plan-reviewer/scripts/example_script.cjs
 /plan-reviewer/references/example_reference.md
 /plan-reviewer/assets/example_asset.txt
 /.gemini/settings.json
-/design_mockups.html
-/landing_page.png
 /package-lock.json
 .worktrees/
 /docs/
+
+# =============================================================================
+# Browser automation / design scratch / screenshot artifacts
+# =============================================================================
+.playwright-mcp/
+.playwright-cli/
+.mcp.json
+output/
+*.png
+!docs/screenshots/*.png
+network-requests.txt
+*.base64.txt
+*-base64.txt
+/design_mockups.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Master policy file. Subsystem-specific rules live in subdirectory `CLAUDE.md` files:
+
+| Area | File |
+|------|------|
+| FastAPI server, routes, WS hub | `src/api/CLAUDE.md` |
+| Domain layer: signals, regime, screeners, strategy, events | `src/domain/CLAUDE.md` |
+| Adapters, persistence, stores | `src/infrastructure/CLAUDE.md` |
+| Backtest engine, optimization | `src/backtest/CLAUDE.md` |
+| Test suite layout and rules | `tests/CLAUDE.md` |
+| Config YAML management | `config/CLAUDE.md` |
+
+## Identity
+
+**Apex** — signal computation engine and chart data API. Reads OHLCV from the livewire Parquet lake, runs the full indicator + signal pipeline, and exposes results via REST + WebSocket consumed by argon (Options Analytics Cockpit).
+
+Not a broker terminal — no direct order placement. Live IB ticks arrive via xenon's WS feed (`XENON_WS_URL`). Historical bars from the livewire lake (Cloudflare R2 Parquet).
+
+## Commands
+
+```bash
+# Install
+uv pip install -e ".[dev,observability,server,cloudflare]"
+
+# Run
+make api-server        # REST + WS API (:8322) — primary service for argon
+make signal-service    # Signal daemon (ticks → signals → PG)
+make dev               # Both together
+
+# Test
+uv run pytest tests/unit/             # unit only
+uv run pytest                         # all tests
+uv run pytest -k "test_rule"          # pattern match
+
+# Code quality (run before every commit)
+make format            # black + isort
+make lint              # black + isort + flake8
+make type-check        # mypy src/ tests/
+make quality           # all: lint + type-check + dead-code + complexity
+
+# Screeners
+make momentum          # Momentum: universe + OHLCV + screen
+make pead              # PEAD: full pipeline
+
+# Strategy verification (after any strategy change)
+make strategy-verify   # unit tests → parity → mypy → format → compare
+
+# R2 Data Pipeline
+make r2-universe       # FMP screener → R2 meta/
+make r2-backfill       # Full backfill (all symbols, 2019-present)
+make r2-delta          # Incremental delta update
+make r2-validate       # Generate data_quality.json only
+
+# Database
+make db-init           # Create PG schema
+make db-reset          # Drop + recreate PG schema
+```
+
+## Architecture
+
+Hexagonal — five layers:
+
+```
+API             src/api/          FastAPI: /bars /indicators /confluence /ws/signals /regime /screener
+CLI             src/runners/      momentum, pead, strategy_compare, optimize, validation
+APPLICATION     src/application/  bootstrap, orchestrators, chart service, subscription manager
+DOMAIN          src/domain/       signals, strategy, screeners, events, interfaces (no infra imports)
+INFRASTRUCTURE  src/infrastructure/ adapters (livewire, xenon_ws, r2, fmp, ib), persistence, stores
+```
+
+Signal pipeline: tick (xenon WS) → `BarAggregator` → `IndicatorEngine` → `RuleEngine` → PostgreSQL → argon via REST + WS.
+
+## External Dependencies
+
+| Dependency | Default | Env var |
+|---|---|---|
+| xenon WS live ticks | `ws://127.0.0.1:8765` | `XENON_WS_URL` |
+| PostgreSQL | — | `APEX_PG_URL` |
+| R2 Parquet lake | — | `R2_*` in `config/secrets.yaml` |
+| FMP API (screeners) | — | `FMP_API_KEY` or `config/secrets.yaml` |
+
+## Data Source Priority
+
+livewire R2 Parquet → FMP (paid, daily deltas) → Yahoo (bulk backfill only, **never live**)
+
+IB ticks arrive via xenon WS — apex never connects to IB directly.
+
+## Mandatory Rules
+
+1. **uv only** — `uv run pytest`, never bare `python`, `pip`, or activated venvs
+2. **Never Yahoo Finance as a live source** — bulk backfill for R2 initial fill only
+3. **No naked shorts** — defined-risk only
+4. **Never commit without explicit user request** — draft first, wait
+5. **Always open a PR before merging to master** — never `git push origin master` directly
+6. **`/codex-review` before finalizing any substantial change**
+7. **Module size budget** — target <500 lines; 1000+ → stop and propose a domain-seam split
+8. **Fix every issue you spot** — no "pre-existing" dismissals
+9. **Wire all features** — never leave code dead/unconnected; no accumulating dead code behind flags
+
+## Python Standards
+
+- Python 3.13, 4-space indent, 100-char line length
+- Type hints required on all functions (mypy strict)
+- Use `ib_async` (not `ib_insync`), TA-Lib for indicators
+- `try/except` always logs the error
+- Typed dataclasses for return values (not `Dict[str, Any]`)
+- **Naming**: `get_*` (from cache), `fetch_*` (network/disk), `load_*` (deserialize from file/DB)
+
+## Strategy Development SOP
+
+Every strategy change must complete **all** steps:
+
+1. `config/strategy/{name}.yaml` — add/update `params:`, push old to `history:`
+2. `src/domain/strategy/signals/{name}.py` — signal generator; `warmup_bars` = longest lookback
+3. `src/domain/strategy/playbook/{name}.py` — `@register_strategy("name")`
+4. `src/backtest/optimization/strategy_objective.py` — add in `_suggest_params()`, ≤7 tunable
+5. `tests/integration/test_strategy_parity.py` — smoke, warmup, entry/exit no-overlap
+6. `make strategy-verify`

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,0 +1,33 @@
+# config/ — Configuration files
+
+Root `CLAUDE.md` is authoritative for policy.
+
+## Single source of truth rule
+
+**One YAML per strategy** — `config/strategy/{name}.yaml`. All code reads params via `get_strategy_params("name")` from `src/domain/strategy/param_loader.py`. Never hardcode param values in:
+- Runner dicts
+- `__init__` defaults
+- `.get()` fallbacks
+
+When changing params: update `params:` in YAML and push old values to `history:`. The loader serves both signal generators and the runner's strategy registry.
+
+## Key config files
+
+| File | Purpose |
+|------|---------|
+| `base.yaml` | Broker ports, risk limits, MDQC thresholds |
+| `universe.yaml` | All symbols, sectors, subsets — add subsets here, never create new files |
+| `risk_config.yaml` | Stop loss, earnings risk, correlations |
+| `signals/*.yaml` | Per-rule YAML definitions for the RuleEngine |
+| `strategy/{name}.yaml` | Canonical params + history for each strategy |
+| `strategy/regime_policy.yaml` | Per-strategy regime gating thresholds |
+| `secrets.yaml` | FMP API key, SMTP — **gitignored** |
+| `backtest/` | Optuna search spaces and spec YAMLs — NOT param defaults |
+
+## Adding a new config subset (universe)
+
+Add the subset directly to `config/universe.yaml` under the `subsets:` key. Do not create a new YAML file for a subset — that violates the single-source rule and breaks `config_manager.py`'s universe loading.
+
+## Config manager
+
+`src/config/config_manager.py` loads `base.yaml`, `universe.yaml`, and `risk_config.yaml` into a typed `Config` dataclass. Access via `get_config()` — never read YAML files directly in application code.

--- a/src/api/CLAUDE.md
+++ b/src/api/CLAUDE.md
@@ -1,0 +1,39 @@
+# src/api/ — FastAPI server + WS hub
+
+Root `CLAUDE.md` is authoritative for policy.
+
+## Entry point
+
+`src/api/server.py` — app factory with lifespan. Port **8322**. Consumed by argon.
+
+## Routes
+
+| Route | Purpose |
+|-------|---------|
+| `GET /bars` | OHLCV bars from livewire lake or PG |
+| `GET /indicators` | Compute-on-read indicator series |
+| `GET /confluence` | Confluence points (oldest-first ASC) |
+| `WS /ws/signals` | Streaming signal events via SignalHub |
+| `GET /regime` | Current regime classification (R0–R3) |
+| `GET /screener` | Screener results (momentum, PEAD) |
+| `POST /backtest` | Trigger strategy backtest |
+| `GET /health` | Liveness check |
+
+## Lifespan startup order
+
+1. PG pool (`APEX_PG_URL`) — optional; routes degrade gracefully when absent
+2. `SignalHub` (`src/api/ws/hub.py`) — WS broadcast hub for signal events
+3. xenon WS client (`XENON_WS_URL`, default `ws://127.0.0.1:8765`) — live tick feed; bootstraps livewire history on connect
+
+Everything is torn down in `finally` so a half-built pipeline never leaks the pool.
+
+## WS hub (`src/api/ws/`)
+
+`SignalHub` manages client connections and fans out `TRADING_SIGNAL` events from the domain bus to all subscribed argon clients. Route: `src/api/routes/signals.py`.
+
+## Rules
+
+- **Routers are thin.** No business logic — call into `src/application/` or `src/domain/`. A route resolves params → calls service → returns model.
+- **chart.py is compute-on-read.** `GET /bars` and `GET /indicators` recompute from the livewire lake per request; there is no pre-computed cache to invalidate.
+- **CORS** — loopback (`127.0.0.1` / `localhost`) on ports `3000–3003` for local argon dev. Do not widen without an architectural reason.
+- **JobManager** (`src/api/jobs/`) handles long-running compute (backtest, screener) as background tasks so routes stay non-blocking.

--- a/src/backtest/CLAUDE.md
+++ b/src/backtest/CLAUDE.md
@@ -1,0 +1,41 @@
+# src/backtest/ — Backtest engine and optimization
+
+Root `CLAUDE.md` is authoritative for policy.
+
+## Two execution paths
+
+| Path | Entry | When to use |
+|------|-------|-------------|
+| **ApexEngine** (`core/`) | `runner.py` + `--strategy` flag | Event-driven; same strategy code as live trading. Use for strategy verification and parity tests |
+| **BehavioralRunner** (`behavioral_runner.py`) | CLI args | Walk-forward analysis, ablation, behavioral experiments |
+
+The same `Clock` abstraction lets strategy code run identically in live and backtest — never branch on "am I in backtest?" in strategy code.
+
+## Optimization (`optimization/`)
+
+- `strategy_objective.py` — Optuna objective; add new strategies in `_suggest_params()`. Keep ≤ 7 optimizable params per strategy; freeze non-tunable ones.
+- `bayesian.py` — Optuna sampler wiring (TPE with warm-start)
+- `stress_validator.py` — `_calc_max_drawdown()` returns **negative** values (drawdown as loss)
+- `grid.py` — grid search for coarse sweeps before Optuna
+
+**Nested CV rule:** Optuna sees inner CV only. Outer test fold is held out for evaluation — never touch it during tuning.
+
+## Analysis (`analysis/`)
+
+Post-run analysis: attribution, trade-level stats, drawdown, Sharpe. These are pure functions over `RunResult` objects — no DB access.
+
+## Spec files (`config/`)
+
+`config/backtest/` holds Optuna search spaces and spec YAMLs. NOT strategy param defaults — those live in `config/strategy/{name}.yaml`.
+
+## Runner entry
+
+```bash
+uv run python -m src.backtest.runner --strategy trend_pulse --symbols AAPL --start 2024-01-01 --end 2024-06-30
+uv run python -m src.backtest.runner --list-strategies
+uv run python -m src.backtest.runner --spec config/backtest/playbook/trend_pulse_validate.yaml
+```
+
+## Constructor kwarg filtering
+
+`runner.py` uses `inspect.signature()` to filter YAML params before passing to `BacktestEngine` — never pass raw YAML dicts directly to constructors.

--- a/src/domain/CLAUDE.md
+++ b/src/domain/CLAUDE.md
@@ -1,0 +1,70 @@
+# src/domain/ — Domain layer
+
+Root `CLAUDE.md` is authoritative for policy.
+
+## Invariant
+
+Domain never imports infrastructure. All external dependencies flow in via interfaces (`src/domain/interfaces/`). Dependency injection is via constructor.
+
+## Signal Pipeline
+
+```
+Tick (xenon WS) → BarAggregator (per-timeframe, publishes BAR_CLOSE)
+  → IndicatorEngine (ThreadPool, per-symbol RLocks, publishes INDICATOR_UPDATE)
+  → RuleEngine (threshold_cross / state_change / range, cooldowns, publishes TRADING_SIGNAL)
+  → ConfluenceCalculator (optional cross-indicator / multi-timeframe)
+  → PostgreSQL (bars, signals, summary, score_history)
+  → argon via REST + WS
+```
+
+Key files: `signal_engine.py` (top-level wiring), `indicator_engine.py` (40+ indicators), `rule_engine.py` (threshold/state/range rules), `confluence_calculator.py`.
+
+Performance invariants:
+- DataFrame created once per bar, shared across threads (40× memory reduction)
+- Per-(symbol, timeframe) RLocks eliminate cross-symbol contention
+- `detect_initial` flag: threshold rules fire on first evaluation after restart
+
+## Regime Detector (`signals/indicators/regime/`)
+
+4-regime classification that gates position sizing:
+
+| Regime | Name | Trading implication |
+|--------|------|---------------------|
+| R0 | Healthy Uptrend | Full trading |
+| R1 | Choppy/Extended | Reduced frequency |
+| R2 | Risk-Off | No new positions |
+| R3 | Rebound Window | Small defined-risk only |
+
+Pipeline: Component states (Trend/Vol/Chop/Extension/IV) → Decision tree → Hysteresis → Composite score (0–100).
+
+`MarketRegime` enum — full member names: `R0_HEALTHY_UPTREND`, `R1_CHOPPY_EXTENDED`, `R2_RISK_OFF`, `R3_REBOUND_WINDOW`. `.value` returns short form ("R0", "R1", ...).
+
+## Screeners (`screeners/`)
+
+- **Momentum** (`screeners/momentum/`) — 12-1 momentum / FIP; universe + OHLCV + screen
+- **PEAD** (`screeners/pead/`) — earnings drift; earnings-driven entries
+
+Both use the waterfall: FMP (paid) → Yahoo (batch fallback) — never Yahoo as primary.
+
+## Strategy (`strategy/`)
+
+| File | Role |
+|------|------|
+| `playbook/{name}.py` | `@register_strategy("name")` classes, one per strategy |
+| `signals/{name}.py` | Event-driven signal generators |
+| `param_loader.py` | `get_strategy_params()` — only way to read strategy YAML |
+| `regime_gate.py` | Per-symbol regime state; `evaluate()` takes `bar_count` not `bar_idx` |
+| `exit_manager.py` | 5-level priority exit; skips ATR trail when `atr <= 0` |
+| `position_sizer.py` | `portfolio_value` in constructor; `max_position_pct` caps shares |
+| `risk_gate.py` | Runtime risk checks |
+
+Entry shift: signal generators always shift entry +1 bar. Same-bar conflict: exit wins.
+
+## Priority Event Bus (`events/priority_event_bus.py`)
+
+| Lane | Events | Behavior |
+|------|--------|----------|
+| **Fast** | Risk, Trading, Market Data | Priority queue, 500 events or 50ms yield |
+| **Slow** | Snapshot, UI, Diagnostics | Debounced 100ms, coalesced by (type, symbol) |
+
+`register_heavy_callback()` offloads to thread pool (max 4). Never register blocking callbacks on the fast lane.

--- a/src/infrastructure/CLAUDE.md
+++ b/src/infrastructure/CLAUDE.md
@@ -1,0 +1,57 @@
+# src/infrastructure/ — Adapters, persistence, stores
+
+Root `CLAUDE.md` is authoritative for policy.
+
+## Adapters (`adapters/`)
+
+| Adapter | Role |
+|---------|------|
+| `livewire/` | Reads OHLCV Parquet from Cloudflare R2 via DuckDB (in-memory, not a datastore) |
+| `xenon/` | WebSocket client for xenon's IB realtime feed — live tick source |
+| `r2/` | Cloudflare R2 S3-compatible store (boto3); Parquet lake read/write |
+| `fmp/` | Financial Modeling Prep API — daily OHLCV deltas, screener data |
+| `ib/` | IB Gateway adapter (secondary; live ticks come via xenon WS in normal operation) |
+| `futu/` | Futu OpenD read-only adapter |
+| `yahoo/` | Yahoo Finance — R2 bulk backfill **only**, never live or incremental |
+
+## DuckDB (livewire)
+
+`adapters/livewire/ohlc_provider.py` creates an **in-memory** DuckDB session per request to query Parquet files over R2. **Not a persistent database** — any `*.duckdb` file on disk is a stale artifact (gitignored). Never treat it as a source of truth.
+
+## FMP Intraday Limits
+
+FMP caps intraday at ~410 rows/request. Pagination required for full history:
+
+| Timeframe | Cap | Chunk size |
+|-----------|-----|------------|
+| 1h | ~410 bars (~3 months) | 90-day windows |
+| 4h | ~245 bars (~6 months) | 180-day windows |
+| 1d | 2,500+ bars | No pagination needed |
+
+Strategy: Yahoo for initial bulk 1h/4h R2 fill; FMP for daily deltas.
+
+## Persistence (`persistence/`)
+
+- `pg_schema.py` — DDL for 6 tables: bars, signals, summary, score_history, + 2 more. CLI for init/reset.
+- `pg_repositories.py` — asyncpg writes; thin repository over the pool.
+- `signal_listener.py` — PostgreSQL LISTEN/NOTIFY for real-time signal fan-out.
+
+Schema is managed via `make db-init` / `make db-reset` — no migration framework; schema is recreated from DDL.
+
+## Stores (`stores/`)
+
+RCU (Read-Copy-Update) pattern: readers get lock-free snapshots; writers swap in a new copy atomically. Used for market data and position state that's read frequently from the signal pipeline.
+
+- `rcu_store.py` — base RCU implementation
+- `market_data_store.py` — live quotes
+- `position_store.py` — live positions
+- `parquet_historical_store.py` — cached Parquet data
+- `duckdb_coverage_store.py` — data coverage metadata
+
+## Anti-patterns (DO NOT)
+
+- Do NOT call `prune_stale_subscriptions()` on fetch cycles — causes subscription churn
+- Do NOT filter positions before `fetch_market_data()` when pruning is involved
+- Do NOT forget `MarketDataFetcher.start_dispatch()` — processes IB callback thread
+- Do NOT merge tick data without updating `MarketData.timestamp`
+- Do NOT treat the livewire DuckDB as a persistent store — it is in-memory per request

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,36 @@
+# tests/ — pytest suite
+
+Root `CLAUDE.md` is authoritative for policy.
+
+## Layout
+
+```
+tests/
+├── unit/         # pure-function tests, no DB, no network (CI: hard gate)
+├── integration/  # real services (PG, R2, xenon WS)
+├── partial/      # excluded from CI (long-running, external deps)
+└── support/      # shared fixtures and helpers
+```
+
+Standalone test files at `tests/` root (`test_vix_alert.py`, etc.) are legacy — new tests go inside the tree.
+
+## Rules
+
+- **`uv run pytest`** — never bare `pytest`
+- **Coverage threshold: 40%** (`--cov-fail-under=40`); enforced in CI
+- **Read `tests/unit/signals/conftest.py`** before writing signal tests — existing fixtures must be reused
+- Run targeted tests during dev (`-k "pattern"`), full suite before commit
+- After generating >20 tests, run immediately — don't batch failures
+
+## CI exclusions
+
+CI (`pytest tests/unit/ tests/integration/`) excludes:
+- `tests/partial/`
+- `tests/integration/test_futu_adapter.py`
+- `tests/integration/test_multi_broker.py`
+
+## Integration test notes
+
+- Integration tests may require `APEX_PG_URL` (PG) and `R2_*` env vars (livewire lake)
+- Xenon WS e2e tests (`test_xenon_live_e2e.py`, `test_xenon_to_ws_e2e.py`) require a running xenon instance — excluded from default CI run
+- Strategy parity tests (`test_strategy_parity.py`) are the canonical regression gate for strategy changes


### PR DESCRIPTION
## Summary

- **Root `CLAUDE.md`** slimmed from 476 → 121 lines: compact master policy with a pointer table, matching xenon/argon convention
- **6 new subdirectory `CLAUDE.md` files** — Claude Code loads only the files relevant to the current working directory, so each subsystem gets focused guidance without competing with every other layer

| New file | Coverage |
|----------|---------|
| `src/api/CLAUDE.md` | Routes table, lifespan startup order, WS hub, thin-router rule, CORS policy |
| `src/domain/CLAUDE.md` | Signal pipeline invariants, regime R0–R3, screeners, strategy subsystem, event bus lanes |
| `src/infrastructure/CLAUDE.md` | Adapter roles, DuckDB in-memory note, FMP pagination limits, RCU stores, anti-patterns |
| `src/backtest/CLAUDE.md` | Two engines (ApexEngine vs BehavioralRunner), Optuna rules, nested CV, constructor kwarg filtering |
| `tests/CLAUDE.md` | Layout, uv-only rule, CI exclusions, integration test requirements |
| `config/CLAUDE.md` | Single source of truth rule, param_loader pattern, universe subset policy |

- **`.gitignore`** gains a "Browser automation / screenshot artifacts" section (`.playwright-mcp/`, `.mcp.json`, `output/`, `*.png`, `network-requests.txt`) replacing stale per-file entries

## Test plan

- [ ] Verify `CLAUDE.md` files load correctly in a new Claude Code session (pointer table is navigable)
- [ ] Confirm `.gitignore` patterns correctly ignore `output/`, `*.png`, `.mcp.json`