### PR TITLE
fix(api): honor limit on /bars and /indicators, default 2000, uncapped

### DIFF
--- a/src/api/routes/chart.py
+++ b/src/api/routes/chart.py
@@ -34,7 +34,7 @@ router = APIRouter(tags=["chart"])
 # Default no-arg window: the most recent N bars. We over-fetch in calendar time
 # (markets aren't 24/7, so N*delta would under-cover across closures) then tail-slice
 # to exactly N. Callers wanting an exact range pass start/end.
-_DEFAULT_BARS = 500
+_DEFAULT_BARS = 2000
 _LOOKBACK_FUDGE = 10
 
 
@@ -49,15 +49,20 @@ def _require_supported_timeframe(timeframe: str) -> None:
 
 
 def _resolve_window(
-    timeframe: str, start: Optional[datetime], end: Optional[datetime]
+    timeframe: str,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    bars: int = _DEFAULT_BARS,
 ) -> Tuple[datetime, datetime, Optional[int]]:
     """Return (start, end, tail_limit). When start is omitted, fetch a generous
-    lookback and tail-slice to _DEFAULT_BARS; an explicit start is honoured as-is."""
+    lookback and tail-slice to `bars`; an explicit start is honoured as-is."""
     end = end or datetime.now(timezone.utc)
     if start is None:
+        if bars <= 0:  # full history: no tail-slice, fetch from the epoch
+            return datetime(1970, 1, 1, tzinfo=timezone.utc), end, None
         delta = TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA)
-        start = end - delta * _DEFAULT_BARS * _LOOKBACK_FUDGE
-        return start, end, _DEFAULT_BARS
+        start = end - delta * bars * _LOOKBACK_FUDGE
+        return start, end, bars
     return start, end, None
 
 
@@ -68,15 +73,19 @@ async def get_bars(
     timeframe: str = "1d",
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
+    limit: int = Query(
+        default=_DEFAULT_BARS,
+        description="tail-slice to N most recent bars; <=0 for full history",
+    ),
 ) -> dict:
     provider = getattr(request.app.state, "ohlc_provider", None)
     if provider is None:
         raise HTTPException(status_code=503, detail="bar provider not configured")
     _require_supported_timeframe(timeframe)
-    start, end, limit = _resolve_window(timeframe, start, end)
+    start, end, tail = _resolve_window(timeframe, start, end, limit)
     bars = await provider.fetch_bars(ticker, timeframe, start, end)
-    if limit is not None:
-        bars = bars[-limit:]
+    if tail is not None:
+        bars = bars[-tail:]
     payload = build_bars_payload(ticker, timeframe, bars, generated_at=datetime.now(timezone.utc))
     validate_payload(payload, "bars_payload")
     return payload
@@ -90,21 +99,25 @@ async def get_indicators(
     timeframe: str = "1d",
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
+    limit: int = Query(
+        default=_DEFAULT_BARS,
+        description="tail-slice to N most recent bars; <=0 for full history",
+    ),
 ) -> dict:
     provider = getattr(request.app.state, "ohlc_provider", None)
     if provider is None:
         raise HTTPException(status_code=503, detail="bar provider not configured")
     _require_supported_timeframe(timeframe)
     registry = getattr(request.app.state, "indicator_registry", None) or get_indicator_registry()
-    start, end, limit = _resolve_window(timeframe, start, end)
+    start, end, tail = _resolve_window(timeframe, start, end, limit)
     try:
         points = await compute_indicator_series(
             provider, registry, ticker, timeframe, indicator, start, end
         )
     except UnknownIndicatorError:
         raise HTTPException(status_code=404, detail=f"unknown indicator: {indicator}")
-    if limit is not None:
-        points = points[-limit:]
+    if tail is not None:
+        points = points[-tail:]
     payload = build_indicator_payload(
         ticker, timeframe, indicator, points, generated_at=datetime.now(timezone.utc)
     )

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -81,7 +81,12 @@ class _FakeRepo:
         self.last_limit: Any = None
 
     async def get_confluence_history(
-        self, symbol: str, timeframe: str, start: Any = None, end: Any = None, limit: int = 100
+        self,
+        symbol: str,
+        timeframe: str,
+        start: Any = None,
+        end: Any = None,
+        limit: int = 100,
     ) -> List[dict]:
         self.last_limit = limit
         return [
@@ -141,16 +146,23 @@ async def test_get_bars_rejects_unsupported_timeframe() -> None:
     assert resp.status_code == 400
 
 
-async def test_get_bars_default_window_tail_slices_to_500() -> None:
-    """No start/end -> most recent 500 bars even when more exist in the lookback."""
+async def test_get_bars_limit_tail_slices() -> None:
+    """No start/end -> tail-slice to `limit` most recent bars; the param is honored
+    (the bug this fixes: /bars silently dropped limit and hard-capped at 500)."""
     app = create_app()
     app.state.ohlc_provider = _FakeProvider(
         _series_ending(datetime(2026, 6, 1, tzinfo=timezone.utc), 600)
     )
     async with _client(app) as c:
-        resp = await c.get("/bars/AAPL", params={"timeframe": "1d"})
-    assert resp.status_code == 200
-    assert resp.json()["count"] == 500
+        # default window keeps all 600 (default is 2000, above the series length)
+        default_resp = await c.get("/bars/AAPL", params={"timeframe": "1d"})
+        # explicit limit tail-slices
+        limited_resp = await c.get("/bars/AAPL", params={"timeframe": "1d", "limit": "100"})
+        # limit<=0 -> full history, no tail-slice
+        full_resp = await c.get("/bars/AAPL", params={"timeframe": "1d", "limit": "0"})
+    assert default_resp.json()["count"] == 600
+    assert limited_resp.json()["count"] == 100
+    assert full_resp.json()["count"] == 600
 
 
 # --- /indicators ---------------------------------------------------------


### PR DESCRIPTION
## Problem

`GET /bars` and `GET /indicators` never declared a `limit` query param, so FastAPI silently dropped `?limit=N`. Every no-`start` request was capped at the hardcoded `_DEFAULT_BARS=500` — surfaced when a macmini caller passed `limit=2000` and still got ~500 bars. `/confluence` had the param; these two didn't.

## Fix

- Add `limit` query param to `/bars` and `/indicators`, threaded through `_resolve_window`.
- Default raised to **2000** (~8yr daily).
- **No upper cap** — removed `le=5000`. Ceiling is now livewire's on-disk depth.
- `limit<=0` = **full history**: fetch from epoch, no tail-slice.
- Explicit `start` still returns the exact range (tail-slice off).
- `/confluence` unchanged (PG-backed, separate).

## Verification

- `_resolve_window` unit-exercised: default→2000, limit=9000→9000, limit=0/-1→full history from 1970 with no tail.
- `make lint` clean, `mypy src/api/routes/chart.py` clean.