### PR TITLE
fix(api): /health reports the real running version

### DIFF
--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -16,6 +16,7 @@ async def health(request: Request) -> dict:
     """Return service health + PG connection status."""
     return {
         "status": "ok",
+        "version": request.app.version,
         "uptime": round(time.time() - _start_time, 1),
         "service": "apex-signal-server",
         "pg_connected": getattr(request.app.state, "pg_connected", False),

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -24,6 +24,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _apex_version() -> str:
+    """Real running version, from the installed dist metadata (set from pyproject at
+    build). Falls back to the VERSION file for an editable checkout that isn't installed."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("apex-risk")
+    except PackageNotFoundError:  # pragma: no cover - only hit in a bare checkout
+        from pathlib import Path
+
+        try:
+            return Path(__file__).resolve().parents[2].joinpath("VERSION").read_text().strip()
+        except OSError:
+            return "unknown"
+
+
+APEX_VERSION = _apex_version()
+
 # xenon's ib_realtime WS server defaults to port 8765 (DEFAULT_IB_REALTIME_PORT on
 # the xenon side). Bake the same default in so apex connects to a local xenon out
 # of the box; override with APEX_XENON_WS_URL.
@@ -128,7 +147,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 app.state.signal_emitter = emitter
 
                 app.state.subscription_manager = SubscriptionManager(
-                    provider=app.state.ohlc_provider, compute=service, timeframes=timeframes
+                    provider=app.state.ohlc_provider,
+                    compute=service,
+                    timeframes=timeframes,
                 )
                 logger.info("Streaming TA pipeline started (timeframes=%s)", timeframes)
 
@@ -187,7 +208,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="APEX Signal Server",
         description="Signal generation, backtesting, and strategy management API",
-        version="0.1.0",
+        version=APEX_VERSION,
         lifespan=lifespan,
     )
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.api.server import create_app
+from src.api.server import APEX_VERSION, create_app
 
 
 @pytest.mark.asyncio
 async def test_health_returns_ok():
-    """GET /health returns status ok with uptime and service name."""
+    """GET /health returns status ok with uptime, service name, and running version."""
     app = create_app()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -21,3 +21,6 @@ async def test_health_returns_ok():
     assert data["status"] == "ok"
     assert "uptime" in data
     assert data["service"] == "apex-signal-server"
+    # version must reflect the real running build, not a hardcoded literal
+    assert data["version"] == APEX_VERSION
+    assert data["version"] not in ("", "unknown")


### PR DESCRIPTION
## Problem
`server.py` hardcoded `version="0.1.0"` on the FastAPI app — stale, and `/health` didn't expose it at all. So after a release there was no way to confirm which build was actually running on the macmini ("is it live?" was unanswerable without shelling into the box).

## Fix
- Resolve the real version from `importlib.metadata.version("apex-risk")` (set from `pyproject` at build time; correct inside the GHCR image), with a `VERSION`-file fallback for a bare editable checkout.
- Wire it into the FastAPI `version=` and add `"version"` to the `/health` payload.

## Result
```
curl -s localhost:8322/health | jq .version   # -> "0.1.2"
```

## Verification
- `test_health` asserts `/health.version == APEX_VERSION` and is non-empty. Passes.
- lint + mypy clean on changed files.