### PR TITLE
feat: add adjusted Livewire bar reads and shadow canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ makes its endpoints return `503` (degrades, never crashes).
 | Variable | Default | Enables |
 |---|---|---|
 | `APEX_LIVEWIRE_ROOT` | unset | `/bars`, `/indicators`, and the streaming warmup seed |
-| `APEX_LIVEWIRE_SILVER_ROOT` | unset | Silver revision watcher (pre-cutover; adjusted reads land separately) |
+| `APEX_LIVEWIRE_SILVER_ROOT` | unset | Silver revision watcher and adjusted daily/factor artifacts |
+| `APEX_LIVEWIRE_PRICE_MODE` | `raw` | Bar reads: `raw` Bronze or `adjusted` Silver/factor-joined Bronze |
 | `APEX_LIVEWIRE_REVISION_POLL_SECONDS` | `30` | Poll interval for atomically published Silver revisions |
 | `APEX_PG_URL` | unset | `/signals` snapshot/backfill, `/confluence`, and signal persistence |
 | `APEX_XENON_WS_URL` | `ws://127.0.0.1:8765` | live ticks → live WS signal frames |
@@ -85,8 +86,10 @@ When `APEX_LIVEWIRE_SILVER_ROOT` is configured, the long-running service polls
 `revisions/current.json`. A newer valid revision reseeds only affected active
 subscriptions, buffers that symbol's Xenon ticks during replacement, atomically
 swaps all configured timeframe histories, and replays buffered ticks. Leave the
-variable unset until Livewire's Silver publisher and Apex's adjusted provider
-complete canary validation; the watcher does not itself adjust prices.
+price mode at its default `raw` during shadow validation. Setting
+`APEX_LIVEWIRE_PRICE_MODE=adjusted` makes daily reads use materialized Silver and
+intraday reads apply Silver factor intervals to Bronze. Missing or incomplete
+Silver data fails explicitly; Apex never silently falls back to raw bars.
 
 ---
 

--- a/docs/livewire-apex-integration.md
+++ b/docs/livewire-apex-integration.md
@@ -23,9 +23,9 @@ the lake). This is the *read* side; livewire owns *writing* the bronze tree.
   preloads history before live ticks) and the **chart read surface** (`GET /bars`,
   `GET /indicators` — see [argon-apex-api.md](argon-apex-api.md)).
 
-### Silver revision contract (pre-cutover)
+### Silver revision and adjusted-read contract
 
-Apex can additionally mount Livewire's future `data-lake/silver` root read-only
+Apex can additionally mount Livewire's `data-lake/silver` root read-only
 through `APEX_LIVEWIRE_SILVER_ROOT`. When configured, Apex polls
 `revisions/current.json` every `APEX_LIVEWIRE_REVISION_POLL_SECONDS` (default
 `30`). A manifest is accepted only after schema, path-containment, and SHA-256
@@ -38,13 +38,25 @@ recomputes, and replays ticks in event-time order. Unrelated symbols continue
 normally. `/health` exposes observed, fully applied, and per-symbol revision
 state plus failures.
 
-The watcher does not itself make bars adjusted. Keep the Silver root unset in
-production until Livewire's adjustment publisher and Apex's adjusted read path
-complete their separate canary and cutover plans.
+The watcher does not itself make bars adjusted. `APEX_LIVEWIRE_PRICE_MODE` selects
+the provider behavior and defaults to `raw` for shadow validation. In `adjusted`
+mode, daily bars come directly from Silver while intraday bars are adjusted in one
+DuckDB range join against compact Silver factor intervals. A missing artifact,
+factor gap, or overlapping factor interval raises an explicit unavailable error;
+there is no silent raw fallback.
 
 ```
 livewire writers ──▶  data-lake/bronze/ (Parquet)  ◀── apex (DuckDB read_parquet, on demand)
                                                           └─▶ argon (/bars, /indicators)
+```
+
+Adjusted mode additionally reads:
+
+```
+<APEX_LIVEWIRE_SILVER_ROOT>/
+  asset_class=equity/symbol=<encoded>/1d.parquet
+  adjustments/asset_class=equity/symbol=<encoded>/factors.parquet
+  revisions/current.json
 ```
 
 ---
@@ -107,7 +119,7 @@ columns freely. The names and types apex requires:
 | Column | Type | apex uses it? | Notes |
 |---|---|---|---|
 | `trade_date` | `DATE` (date32) | ✅ **timestamp key** | The bar's calendar date. apex maps it to a UTC midnight instant. |
-| `open` `high` `low` `close` | `DOUBLE` | ✅ | OHLC. apex uses **raw `close`**, not `adj_close`. |
+| `open` `high` `low` `close` | `DOUBLE` | ✅ | Raw mode reads Bronze OHLC; adjusted mode reads materialized Silver OHLC. |
 | `volume` | `BIGINT` | ✅ | Cast to int; null tolerated. |
 | `vwap` | `DOUBLE` | ⚪ optional | Read if present, else `null` in the payload. |
 | `adj_close` | `DOUBLE` | ❌ ignored | apex charts use raw OHLC, not split/dividend-adjusted. |
@@ -125,7 +137,10 @@ columns freely. The names and types apex requires:
 | `symbol_id` | `BIGINT` | ❌ ignored | |
 | `asset_class`, `symbol` | `VARCHAR` | ❌ ignored | |
 
-> Intraday has **no `adj_close`** (and apex wouldn't use it anyway).
+> Intraday has no materialized adjusted file. In adjusted mode Apex multiplies
+> OHLC by `price_adjustment_factor` and volume by `split_volume_factor`; dividends
+> never alter volume. The bar timestamp is converted to an `America/New_York`
+> trading date for the factor join.
 
 ### Timezone (important)
 
@@ -170,11 +185,15 @@ Each returned row becomes a `BarData` with `bar_start = bar_end - <timeframe dur
 | Env var | Meaning |
 |---|---|
 | `APEX_LIVEWIRE_ROOT` | Absolute path to livewire's `data-lake/bronze`. **Required** for `/bars`, `/indicators`, and the streaming warmup seed — without it those return `503` / stay silent. |
+| `APEX_LIVEWIRE_SILVER_ROOT` | Absolute path to livewire's `data-lake/silver`. Required for the revision watcher and adjusted mode. |
+| `APEX_LIVEWIRE_PRICE_MODE` | `raw` (default) or `adjusted`. Invalid values fail startup. |
 
 Example (local external volume, 20,389 symbols):
 
 ```bash
 export APEX_LIVEWIRE_ROOT=/Volumes/DATA_LAKE/livewire/data-lake/bronze
+export APEX_LIVEWIRE_SILVER_ROOT=/Volumes/DATA_LAKE/livewire/data-lake/silver
+export APEX_LIVEWIRE_PRICE_MODE=raw
 ```
 
 R2 backup: livewire also mirrors bronze to R2 (`R2_*` creds + `sync_to_r2.py --download` pulls

--- a/scripts/check_silver_canary.py
+++ b/scripts/check_silver_canary.py
@@ -89,6 +89,7 @@ async def check_silver_canary(
     silver_root: Path,
     symbols: tuple[str, ...] = ("NVDA", "AAPL", "SPY"),
     control: str = "PLTR",
+    intraday_timeframes: tuple[str, ...] = ("1m", "5m", "30m", "1h"),
     start: datetime = datetime(2020, 1, 1, tzinfo=timezone.utc),
     end: datetime | None = None,
 ) -> dict[str, Any]:
@@ -100,30 +101,38 @@ async def check_silver_canary(
     results: dict[str, dict[str, Any]] = {}
 
     for symbol in (*symbols, control):
-        raw_daily, adjusted_daily, raw_intraday, adjusted_intraday = await asyncio.gather(
+        raw_daily, adjusted_daily = await asyncio.gather(
             raw_provider.fetch_bars(symbol, "1d", start, end),
             adjusted_provider.fetch_bars(symbol, "1d", start, end),
-            raw_provider.fetch_bars(symbol, "1m", start, end),
-            adjusted_provider.fetch_bars(symbol, "1m", start, end),
         )
-        counts_match = (
-            len(raw_daily) == len(adjusted_daily) > 0
-            and len(raw_intraday) == len(adjusted_intraday) > 0
-        )
-        timestamps_match = _same_timestamps(raw_daily, adjusted_daily) and _same_timestamps(
-            raw_intraday, adjusted_intraday
-        )
-        identity = _same_values(raw_daily, adjusted_daily) and _same_values(
-            raw_intraday, adjusted_intraday
-        )
+        counts_match = len(raw_daily) == len(adjusted_daily) > 0
+        timestamps_match = _same_timestamps(raw_daily, adjusted_daily)
+        identity = _same_values(raw_daily, adjusted_daily)
         volume_unchanged = counts_match and all(
             left.volume == right.volume
-            for raw_rows, adjusted_rows in (
-                (raw_daily, adjusted_daily),
-                (raw_intraday, adjusted_intraday),
-            )
-            for left, right in zip(raw_rows, adjusted_rows, strict=True)
+            for left, right in zip(raw_daily, adjusted_daily, strict=True)
         )
+        intraday_counts: dict[str, int] = {}
+        for timeframe in intraday_timeframes:
+            raw_intraday, adjusted_intraday = await asyncio.gather(
+                raw_provider.fetch_bars(symbol, timeframe, start, end),
+                adjusted_provider.fetch_bars(symbol, timeframe, start, end),
+            )
+            intraday_counts[timeframe] = len(raw_intraday)
+            timeframe_counts_match = len(raw_intraday) == len(adjusted_intraday) > 0
+            counts_match = counts_match and timeframe_counts_match
+            timestamps_match = timestamps_match and _same_timestamps(
+                raw_intraday, adjusted_intraday
+            )
+            identity = identity and _same_values(raw_intraday, adjusted_intraday)
+            volume_unchanged = (
+                volume_unchanged
+                and timeframe_counts_match
+                and all(
+                    left.volume == right.volume
+                    for left, right in zip(raw_intraday, adjusted_intraday, strict=True)
+                )
+            )
         raw_return = _return(raw_daily)
         adjusted_return = _return(adjusted_daily)
         continuity = _continuity_metrics(raw_daily, adjusted_daily)
@@ -145,7 +154,7 @@ async def check_silver_canary(
         results[symbol] = {
             "passed": symbol_passed,
             "daily_count": len(raw_daily),
-            "intraday_count": len(raw_intraday),
+            "intraday_counts": intraday_counts,
             "timestamps_match": timestamps_match,
             "raw_return": raw_return,
             "adjusted_return": adjusted_return,

--- a/scripts/check_silver_canary.py
+++ b/scripts/check_silver_canary.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Read-only raw-versus-adjusted Livewire canary for Apex."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.domain.events.domain_events import BarData
+from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+from src.infrastructure.adapters.livewire.revisions import RevisionManifestReader
+
+
+def _same_timestamps(raw: list[BarData], adjusted: list[BarData]) -> bool:
+    return [bar.bar_start for bar in raw] == [bar.bar_start for bar in adjusted]
+
+
+def _same_values(raw: list[BarData], adjusted: list[BarData]) -> bool:
+    return len(raw) == len(adjusted) and all(
+        (left.open, left.high, left.low, left.close, left.volume)
+        == (right.open, right.high, right.low, right.close, right.volume)
+        for left, right in zip(raw, adjusted, strict=True)
+    )
+
+
+def _return(bars: list[BarData]) -> float | None:
+    if len(bars) < 2 or not bars[0].close:
+        return None
+    last = bars[-1].close
+    if last is None:
+        return None
+    return float(last / bars[0].close - 1)
+
+
+async def check_silver_canary(
+    *,
+    bronze_root: Path,
+    silver_root: Path,
+    symbols: tuple[str, ...] = ("NVDA", "AAPL", "SPY"),
+    control: str = "PLTR",
+    start: datetime = datetime(2020, 1, 1, tzinfo=timezone.utc),
+    end: datetime | None = None,
+) -> dict[str, Any]:
+    """Compare raw and adjusted daily/intraday reads without changing artifacts."""
+    end = end or datetime.now(timezone.utc)
+    revision = await asyncio.to_thread(RevisionManifestReader(silver_root).read_current)
+    raw_provider = LivewireOhlcProvider(bronze_root, price_mode="raw")
+    adjusted_provider = LivewireOhlcProvider(bronze_root, silver_root, "adjusted")
+    results: dict[str, dict[str, Any]] = {}
+
+    for symbol in (*symbols, control):
+        raw_daily, adjusted_daily, raw_intraday, adjusted_intraday = await asyncio.gather(
+            raw_provider.fetch_bars(symbol, "1d", start, end),
+            adjusted_provider.fetch_bars(symbol, "1d", start, end),
+            raw_provider.fetch_bars(symbol, "1m", start, end),
+            adjusted_provider.fetch_bars(symbol, "1m", start, end),
+        )
+        counts_match = (
+            len(raw_daily) == len(adjusted_daily) > 0
+            and len(raw_intraday) == len(adjusted_intraday) > 0
+        )
+        timestamps_match = _same_timestamps(raw_daily, adjusted_daily) and _same_timestamps(
+            raw_intraday, adjusted_intraday
+        )
+        identity = _same_values(raw_daily, adjusted_daily) and _same_values(
+            raw_intraday, adjusted_intraday
+        )
+        volume_unchanged = counts_match and all(
+            left.volume == right.volume
+            for raw_rows, adjusted_rows in (
+                (raw_daily, adjusted_daily),
+                (raw_intraday, adjusted_intraday),
+            )
+            for left, right in zip(raw_rows, adjusted_rows, strict=True)
+        )
+        raw_return = _return(raw_daily)
+        adjusted_return = _return(adjusted_daily)
+        continuity_improved = (
+            raw_return is not None
+            and adjusted_return is not None
+            and abs(adjusted_return) <= abs(raw_return)
+        )
+        is_control = symbol == control
+        symbol_passed = (
+            counts_match
+            and timestamps_match
+            and (identity if is_control else (not identity and continuity_improved))
+        )
+        results[symbol] = {
+            "passed": symbol_passed,
+            "daily_count": len(raw_daily),
+            "intraday_count": len(raw_intraday),
+            "timestamps_match": timestamps_match,
+            "raw_return": raw_return,
+            "adjusted_return": adjusted_return,
+            "continuity_improved": continuity_improved,
+            "volume_unchanged": volume_unchanged,
+            "split_volume_adjusted": not volume_unchanged,
+            "identity_control": identity if is_control else False,
+        }
+
+    return {
+        "passed": all(item["passed"] for item in results.values()),
+        "revision": revision.revision,
+        "generation_id": revision.generation_id,
+        "symbols": results,
+    }
+
+
+def _parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bronze-root", required=True, type=Path)
+    parser.add_argument("--silver-root", required=True, type=Path)
+    parser.add_argument("--tickers", nargs="+", default=["NVDA", "AAPL", "SPY"])
+    parser.add_argument("--control", default="PLTR")
+    parser.add_argument("--start", type=_parse_timestamp, default="2020-01-01T00:00:00Z")
+    parser.add_argument("--end", type=_parse_timestamp)
+    args = parser.parse_args()
+    result = asyncio.run(
+        check_silver_canary(
+            bronze_root=args.bronze_root,
+            silver_root=args.silver_root,
+            symbols=tuple(args.tickers),
+            control=args.control,
+            start=args.start,
+            end=args.end,
+        )
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_silver_canary.py
+++ b/scripts/check_silver_canary.py
@@ -41,6 +41,48 @@ def _return(bars: list[BarData]) -> float | None:
     return float(last / bars[0].close - 1)
 
 
+def _continuity_metrics(raw: list[BarData], adjusted: list[BarData]) -> dict[str, int]:
+    """Count factor-change boundaries and those with a smaller local discontinuity."""
+    if len(raw) != len(adjusted):
+        return {"action_boundaries": 0, "improved_boundaries": 0}
+    ratios: list[float | None] = []
+    for raw_bar, adjusted_bar in zip(raw, adjusted, strict=True):
+        if not raw_bar.close or adjusted_bar.close is None:
+            ratios.append(None)
+        else:
+            ratios.append(float(adjusted_bar.close / raw_bar.close))
+
+    action_boundaries = improved_boundaries = 0
+    for index in range(1, len(raw)):
+        previous_ratio, current_ratio = ratios[index - 1], ratios[index]
+        if (
+            previous_ratio is None
+            or current_ratio is None
+            or abs(previous_ratio - current_ratio) <= 1e-12
+        ):
+            continue
+        previous_raw = raw[index - 1].close
+        current_raw = raw[index].close
+        previous_adjusted = adjusted[index - 1].close
+        current_adjusted = adjusted[index].close
+        if (
+            not previous_raw
+            or current_raw is None
+            or not previous_adjusted
+            or current_adjusted is None
+        ):
+            continue
+        action_boundaries += 1
+        raw_return = float(current_raw / previous_raw - 1)
+        adjusted_return = float(current_adjusted / previous_adjusted - 1)
+        if abs(adjusted_return) <= abs(raw_return) + 1e-12:
+            improved_boundaries += 1
+    return {
+        "action_boundaries": action_boundaries,
+        "improved_boundaries": improved_boundaries,
+    }
+
+
 async def check_silver_canary(
     *,
     bronze_root: Path,
@@ -84,16 +126,21 @@ async def check_silver_canary(
         )
         raw_return = _return(raw_daily)
         adjusted_return = _return(adjusted_daily)
-        continuity_improved = (
-            raw_return is not None
-            and adjusted_return is not None
-            and abs(adjusted_return) <= abs(raw_return)
-        )
+        continuity = _continuity_metrics(raw_daily, adjusted_daily)
+        continuity_improved = continuity["improved_boundaries"] > 0
         is_control = symbol == control
         symbol_passed = (
             counts_match
             and timestamps_match
-            and (identity if is_control else (not identity and continuity_improved))
+            and (
+                identity
+                if is_control
+                else (
+                    not identity
+                    and continuity["action_boundaries"] > 0
+                    and (volume_unchanged or continuity_improved)
+                )
+            )
         )
         results[symbol] = {
             "passed": symbol_passed,
@@ -103,6 +150,7 @@ async def check_silver_canary(
             "raw_return": raw_return,
             "adjusted_return": adjusted_return,
             "continuity_improved": continuity_improved,
+            **continuity,
             "volume_unchanged": volume_unchanged,
             "split_volume_adjusted": not volume_unchanged,
             "identity_control": identity if is_control else False,

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -15,11 +15,17 @@ _start_time = time.time()
 async def health(request: Request) -> dict:
     """Return service health + PG connection status."""
     watcher = getattr(request.app.state, "revision_watcher", None)
+    provider = getattr(request.app.state, "ohlc_provider", None)
     return {
         "status": "ok",
         "version": request.app.version,
         "uptime": round(time.time() - _start_time, 1),
         "service": "apex-signal-server",
         "pg_connected": getattr(request.app.state, "pg_connected", False),
+        "livewire": {
+            "configured": provider is not None,
+            "configured_price_mode": getattr(request.app.state, "livewire_price_mode", "raw"),
+            "effective_price_mode": provider.price_mode if provider is not None else None,
+        },
         "silver_revision": watcher.health() if watcher is not None else {"enabled": False},
     }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -20,6 +20,7 @@ from src.api.routes.strategy import router as strategy_router
 
 if TYPE_CHECKING:
     from src.domain.interfaces.event_bus import EventBus
+    from src.infrastructure.adapters.livewire.ohlc_provider import PriceMode
     from src.infrastructure.persistence.database import Database
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,13 @@ DEFAULT_XENON_WS_URL = "ws://127.0.0.1:8765"
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Connect PG + build the streaming pipeline on startup; tear it down on shutdown."""
+    livewire_root = os.environ.get("APEX_LIVEWIRE_ROOT")
+    silver_root = os.environ.get("APEX_LIVEWIRE_SILVER_ROOT")
+    livewire_price_mode = os.environ.get("APEX_LIVEWIRE_PRICE_MODE", "raw")
+    if livewire_price_mode not in ("raw", "adjusted"):
+        raise ValueError(f"unsupported Livewire price mode: {livewire_price_mode!r}")
+    app.state.livewire_price_mode = livewire_price_mode
+
     pg_url = os.environ.get("APEX_PG_URL")
     if pg_url:
         try:
@@ -97,7 +105,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # /confluence work even without a live subscription. Reused by the pipeline below.
         if getattr(app.state, "ohlc_provider", None) is None:
             app.state.ohlc_provider = None
-            livewire_root = os.environ.get("APEX_LIVEWIRE_ROOT")
             if livewire_root:
                 from pathlib import Path
 
@@ -105,7 +112,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     LivewireOhlcProvider,
                 )
 
-                app.state.ohlc_provider = LivewireOhlcProvider(bronze_root=Path(livewire_root))
+                app.state.ohlc_provider = LivewireOhlcProvider(
+                    bronze_root=Path(livewire_root),
+                    silver_root=Path(silver_root) if silver_root else None,
+                    price_mode=cast("PriceMode", livewire_price_mode),
+                )
                 logger.info("Bar provider ready (chart read surface enabled)")
         if getattr(app.state, "indicator_registry", None) is None:
             from src.domain.signals.indicators.registry import get_indicator_registry
@@ -116,7 +127,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # event bus, TA compute service, signal emitter, and subscription manager so
         # the server itself streams signals. Guarded so tests can pre-inject fakes.
         if getattr(app.state, "subscription_manager", None) is None:
-            livewire_root = os.environ.get("APEX_LIVEWIRE_ROOT")
             if livewire_root:
                 from src.api.ws.emitter import SignalEmitter
                 from src.application.services.ta_signal_service import TASignalService
@@ -173,7 +183,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
         if getattr(app.state, "revision_watcher", None) is None:
             app.state.revision_watcher = None
-            silver_root = os.environ.get("APEX_LIVEWIRE_SILVER_ROOT")
             subscription_manager = getattr(app.state, "subscription_manager", None)
             if silver_root and subscription_manager is not None:
                 from pathlib import Path

--- a/src/infrastructure/adapters/livewire/factory.py
+++ b/src/infrastructure/adapters/livewire/factory.py
@@ -12,4 +12,9 @@ def build_livewire_provider(config: Any) -> LivewireOhlcProvider:
     root = getattr(config, "livewire_bronze_root", None)
     if not root:
         raise ValueError("livewire_bronze_root is not configured")
-    return LivewireOhlcProvider(bronze_root=Path(root))
+    silver_root = getattr(config, "livewire_silver_root", None)
+    return LivewireOhlcProvider(
+        bronze_root=Path(root),
+        silver_root=Path(silver_root) if silver_root else None,
+        price_mode=getattr(config, "livewire_price_mode", "raw"),
+    )

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -20,18 +20,24 @@ from __future__ import annotations
 import asyncio
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Literal
 
 import duckdb
 
 from ....domain.events.domain_events import BarData
-from .paths import SUPPORTED_TIMEFRAMES, parquet_path
+from .paths import SUPPORTED_TIMEFRAMES, daily_silver_path, factor_path, parquet_path
 
 # livewire keys daily bars by `trade_date` (a DATE) and intraday bars by
 # `bar_timestamp` (a tz-aware UTC TIMESTAMP). OHLCV columns are read by name; extra
 # columns (symbol_id, adj_close) are ignored.
 _DAILY_TS_COLUMN = "trade_date"
 _INTRADAY_TS_COLUMN = "bar_timestamp"
+
+PriceMode = Literal["raw", "adjusted"]
+
+
+class AdjustedDataUnavailable(RuntimeError):
+    """Raised when adjusted mode cannot prove complete Silver coverage."""
 
 
 def _timestamp_column(timeframe: str) -> str:
@@ -76,8 +82,17 @@ class LivewireOhlcProvider:
     Satisfies HistoricalSourcePort (runtime_checkable Protocol).
     """
 
-    def __init__(self, bronze_root: Path) -> None:
-        self._root = Path(bronze_root)
+    def __init__(
+        self,
+        bronze_root: Path,
+        silver_root: Path | None = None,
+        price_mode: PriceMode = "raw",
+    ) -> None:
+        if price_mode not in ("raw", "adjusted"):
+            raise ValueError(f"unsupported Livewire price mode: {price_mode!r}")
+        self._bronze_root = Path(bronze_root)
+        self._silver_root = Path(silver_root) if silver_root is not None else None
+        self._price_mode = price_mode
 
     # --- HistoricalSourcePort ---
     @property
@@ -97,11 +112,40 @@ class LivewireOhlcProvider:
         start: datetime,
         end: datetime,
     ) -> List[BarData]:
-        # parquet_path raises ValueError on an unsupported timeframe.
-        path = parquet_path(self._root, symbol, timeframe)
-        if not path.exists():
+        bronze_path = parquet_path(self._bronze_root, symbol, timeframe)
+        if self._price_mode == "raw":
+            if not bronze_path.exists():
+                return []
+            return await asyncio.to_thread(
+                self._query,
+                bronze_path,
+                symbol,
+                timeframe,
+                start,
+                end,
+            )
+        if self._silver_root is None:
+            raise AdjustedDataUnavailable("Silver root is not configured")
+        if timeframe == "1d":
+            path = daily_silver_path(self._silver_root, symbol)
+            if not path.exists():
+                raise AdjustedDataUnavailable(f"Silver daily artifact is missing for {symbol}")
+            return await asyncio.to_thread(self._query, path, symbol, timeframe, start, end)
+
+        if not bronze_path.exists():
             return []
-        return await asyncio.to_thread(self._query, path, symbol, timeframe, start, end)
+        factors = factor_path(self._silver_root, symbol)
+        if not factors.exists():
+            raise AdjustedDataUnavailable(f"Silver factor artifact is missing for {symbol}")
+        return await asyncio.to_thread(
+            self._query_adjusted_intraday,
+            bronze_path,
+            factors,
+            symbol,
+            timeframe,
+            start,
+            end,
+        )
 
     # --- internals ---
     def _query(
@@ -130,6 +174,59 @@ class LivewireOhlcProvider:
         finally:
             con.close()
         return [self._row_to_bar(r, symbol, timeframe) for r in rows]
+
+    def _query_adjusted_intraday(
+        self,
+        bronze_path: Path,
+        factors_path: Path,
+        symbol: str,
+        timeframe: str,
+        start: datetime,
+        end: datetime,
+    ) -> List[BarData]:
+        sql = """
+            WITH raw AS (
+                SELECT *, count(*) OVER () AS raw_count
+                FROM read_parquet(?)
+                WHERE bar_timestamp >= ? AND bar_timestamp <= ?
+            )
+            SELECT
+                b.bar_timestamp,
+                b.open * f.price_adjustment_factor AS open,
+                b.high * f.price_adjustment_factor AS high,
+                b.low * f.price_adjustment_factor AS low,
+                b.close * f.price_adjustment_factor AS close,
+                CAST(ROUND(b.volume * f.split_volume_factor) AS BIGINT) AS volume,
+                b.raw_count,
+                f.adjustment_revision
+            FROM raw b
+            LEFT JOIN read_parquet(?) f
+              ON CAST(timezone('America/New_York', b.bar_timestamp) AS DATE)
+                 >= COALESCE(f.effective_start, DATE '0001-01-01')
+             AND CAST(timezone('America/New_York', b.bar_timestamp) AS DATE)
+                 <= COALESCE(f.effective_end, DATE '9999-12-31')
+            ORDER BY b.bar_timestamp
+        """
+        con = duckdb.connect(database=":memory:")
+        try:
+            rows = (
+                con.execute(
+                    sql,
+                    [bronze_path.as_posix(), start, end, factors_path.as_posix()],
+                )
+                .fetch_arrow_table()
+                .to_pylist()
+            )
+        finally:
+            con.close()
+        if not rows:
+            return []
+        raw_count = int(rows[0]["raw_count"])
+        if len(rows) != raw_count or any(row["adjustment_revision"] is None for row in rows):
+            raise AdjustedDataUnavailable(
+                f"incomplete or overlapping factor coverage for {symbol} {timeframe}"
+            )
+        return [self._row_to_bar(row, symbol, timeframe) for row in rows]
 
     @staticmethod
     def _row_to_bar(row: dict, symbol: str, timeframe: str) -> BarData:

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -99,6 +99,18 @@ class LivewireOhlcProvider:
     def source_name(self) -> str:
         return "livewire"
 
+    @property
+    def bronze_root(self) -> Path:
+        return self._bronze_root
+
+    @property
+    def silver_root(self) -> Path | None:
+        return self._silver_root
+
+    @property
+    def price_mode(self) -> PriceMode:
+        return self._price_mode
+
     def supports_timeframe(self, timeframe: str) -> bool:
         return timeframe in SUPPORTED_TIMEFRAMES
 

--- a/src/infrastructure/adapters/livewire/paths.py
+++ b/src/infrastructure/adapters/livewire/paths.py
@@ -42,3 +42,19 @@ def parquet_path(bronze_root: Path, symbol: str, timeframe: str) -> Path:
         / f"symbol={encode_symbol(symbol)}"
         / f"{timeframe}.parquet"
     )
+
+
+def daily_silver_path(silver_root: Path, symbol: str) -> Path:
+    """Return the materialized adjusted-daily artifact for ``symbol``."""
+    return silver_root / "asset_class=equity" / f"symbol={encode_symbol(symbol)}" / "1d.parquet"
+
+
+def factor_path(silver_root: Path, symbol: str) -> Path:
+    """Return the compact adjustment-factor artifact for ``symbol``."""
+    return (
+        silver_root
+        / "adjustments"
+        / "asset_class=equity"
+        / f"symbol={encode_symbol(symbol)}"
+        / "factors.parquet"
+    )

--- a/tests/integration/test_silver_revision_e2e.py
+++ b/tests/integration/test_silver_revision_e2e.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from scripts.check_silver_canary import _same_values, check_silver_canary
+from scripts.check_silver_canary import _continuity_metrics, _same_values, check_silver_canary
 from src.api.server import create_app, lifespan
 from src.application.subscriptions.manager import SubscriptionManager
 from src.domain.events.domain_events import BarData
@@ -191,6 +191,15 @@ async def _wait_for_revision(app: Any, revision: int) -> None:
 
 def test_canary_value_comparison_rejects_row_count_mismatch() -> None:
     assert _same_values([BarData(close=1.0)], []) is False
+
+
+def test_canary_measures_action_boundary_not_whole_window_return() -> None:
+    raw = [BarData(close=value) for value in (100.0, 90.0, 200.0)]
+    adjusted = [BarData(close=value) for value in (90.0, 90.0, 200.0)]
+
+    metrics = _continuity_metrics(raw, adjusted)
+
+    assert metrics == {"action_boundaries": 1, "improved_boundaries": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_silver_revision_e2e.py
+++ b/tests/integration/test_silver_revision_e2e.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from scripts.check_silver_canary import _same_values, check_silver_canary
+from src.api.server import create_app, lifespan
+from src.application.subscriptions.manager import SubscriptionManager
+from src.domain.events.domain_events import BarData
+from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+
+class _RecordingCompute:
+    def __init__(self) -> None:
+        self.started = False
+        self.injected: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        self.replaced: dict[str, dict[str, list[dict[str, Any]]]] = {}
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.started = False
+
+    async def inject_historical_bars(
+        self, symbol: str, timeframe: str, bars: list[dict[str, Any]]
+    ) -> int:
+        self.injected[(symbol, timeframe)] = bars
+        return len(bars)
+
+    def begin_symbol_refresh(self, symbol: str) -> None:
+        pass
+
+    async def replace_symbol_histories(
+        self, symbol: str, histories: dict[str, list[dict[str, Any]]]
+    ) -> dict[str, int]:
+        self.replaced[symbol] = histories
+        return {timeframe: len(rows) for timeframe, rows in histories.items()}
+
+    def commit_symbol_refresh(self, symbol: str) -> None:
+        pass
+
+    def abort_symbol_refresh(self, symbol: str) -> None:
+        pass
+
+
+def _atomic_parquet(path: Path, frame: pd.DataFrame) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".parquet.tmp")
+    frame.to_parquet(temporary)
+    os.replace(temporary, path)
+
+
+def _publish_symbol(
+    bronze_root: Path,
+    silver_root: Path,
+    symbol: str,
+    first_factor: float,
+    split_volume_factor: float,
+    first_raw_close: float,
+    second_raw_close: float,
+    first_date: date,
+    second_date: date,
+    revision: int,
+) -> tuple[Path, Path]:
+    bronze_dir = bronze_root / "asset_class=equity" / f"symbol={symbol}"
+    silver_dir = silver_root / "asset_class=equity" / f"symbol={symbol}"
+    factor_dir = silver_root / "adjustments" / "asset_class=equity" / f"symbol={symbol}"
+    timestamps = [
+        datetime.combine(first_date, time(14, 30), tzinfo=timezone.utc),
+        datetime.combine(second_date, time(14, 30), tzinfo=timezone.utc),
+    ]
+    raw_volume = [100, int(100 * split_volume_factor)]
+    raw_daily = pd.DataFrame(
+        {
+            "trade_date": [first_date, second_date],
+            "symbol_id": [1, 1],
+            "open": [first_raw_close, second_raw_close],
+            "high": [first_raw_close, second_raw_close],
+            "low": [first_raw_close, second_raw_close],
+            "close": [first_raw_close, second_raw_close],
+            "adj_close": [first_raw_close, second_raw_close],
+            "volume": raw_volume,
+        }
+    )
+    _atomic_parquet(bronze_dir / "1d.parquet", raw_daily)
+    _atomic_parquet(
+        bronze_dir / "1m.parquet",
+        pd.DataFrame(
+            {
+                "bar_timestamp": pd.to_datetime(timestamps, utc=True),
+                "symbol_id": [1, 1],
+                "open": [first_raw_close, second_raw_close],
+                "high": [first_raw_close, second_raw_close],
+                "low": [first_raw_close, second_raw_close],
+                "close": [first_raw_close, second_raw_close],
+                "volume": raw_volume,
+            }
+        ),
+    )
+    adjusted_first = first_raw_close * first_factor
+    daily_path = silver_dir / "1d.parquet"
+    _atomic_parquet(
+        daily_path,
+        pd.DataFrame(
+            {
+                "trade_date": [first_date, second_date],
+                "symbol_id": [1, 1],
+                "open": [adjusted_first, second_raw_close],
+                "high": [adjusted_first, second_raw_close],
+                "low": [adjusted_first, second_raw_close],
+                "close": [adjusted_first, second_raw_close],
+                "adj_close": [adjusted_first, second_raw_close],
+                "volume": [int(100 * split_volume_factor), raw_volume[1]],
+                "price_adjustment_factor": [first_factor, 1.0],
+                "split_volume_factor": [split_volume_factor, 1.0],
+                "adjustment_revision": [revision, revision],
+            }
+        ),
+    )
+    factor_path = factor_dir / "factors.parquet"
+    _atomic_parquet(
+        factor_path,
+        pd.DataFrame(
+            {
+                "effective_start": [None, second_date],
+                "effective_end": [first_date, None],
+                "price_adjustment_factor": [first_factor, 1.0],
+                "split_volume_factor": [split_volume_factor, 1.0],
+                "adjustment_revision": [revision, revision],
+            }
+        ),
+    )
+    return daily_path, factor_path
+
+
+def _publish_manifest(
+    silver_root: Path,
+    revision: int,
+    artifacts: list[Path],
+    affected: list[str],
+    earliest_date: date,
+) -> None:
+    payload = {
+        "schema_version": 1,
+        "revision": revision,
+        "generation_id": f"integration-{revision}",
+        "published_at": datetime.now(timezone.utc).isoformat(),
+        "corporate_actions_as_of": datetime.now(timezone.utc).isoformat(),
+        "affected": [
+            {
+                "symbol": symbol,
+                "earliest_date": earliest_date.isoformat(),
+                "timeframes": ["1d", "1m"],
+            }
+            for symbol in affected
+        ],
+        "artifacts": [
+            {
+                "path": path.relative_to(silver_root).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for path in artifacts
+        ],
+    }
+    revisions = silver_root / "revisions"
+    revisions.mkdir(parents=True, exist_ok=True)
+    immutable = revisions / f"revision={revision}.json"
+    immutable.write_text(json.dumps(payload), encoding="utf-8")
+    temporary = revisions / "current.json.tmp"
+    temporary.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(temporary, revisions / "current.json")
+
+
+async def _wait_for_revision(app: Any, revision: int) -> None:
+    for _ in range(100):
+        if app.state.revision_watcher.last_fully_applied_revision == revision:
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"revision {revision} was not applied")
+
+
+def test_canary_value_comparison_rejects_row_count_mismatch() -> None:
+    assert _same_values([BarData(close=1.0)], []) is False
+
+
+@pytest.mark.asyncio
+async def test_adjusted_canary_and_revision_reseed_without_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bronze_root = tmp_path / "bronze"
+    silver_root = tmp_path / "silver"
+    first_date = date.today() - timedelta(days=2)
+    second_date = date.today() - timedelta(days=1)
+    artifacts: list[Path] = []
+    fixtures = {
+        "NVDA": (0.5, 2.0, 100.0, 50.0),
+        "AAPL": (0.9, 1.0, 100.0, 90.0),
+        "SPY": (0.9, 1.0, 100.0, 90.0),
+        "PLTR": (1.0, 1.0, 100.0, 101.0),
+    }
+    for symbol, values in fixtures.items():
+        artifacts.extend(
+            _publish_symbol(
+                bronze_root,
+                silver_root,
+                symbol,
+                *values,
+                first_date,
+                second_date,
+                1,
+            )
+        )
+    _publish_manifest(silver_root, 1, artifacts, list(fixtures), first_date)
+
+    before = {path: hashlib.sha256(path.read_bytes()).hexdigest() for path in artifacts}
+    canary = await check_silver_canary(
+        bronze_root=bronze_root,
+        silver_root=silver_root,
+        symbols=("NVDA", "AAPL", "SPY"),
+        control="PLTR",
+        start=datetime.combine(first_date, time.min, tzinfo=timezone.utc),
+        end=datetime.combine(second_date, time.max, tzinfo=timezone.utc),
+    )
+    assert canary["passed"] is True
+    assert canary["revision"] == 1
+    assert canary["symbols"]["NVDA"]["split_volume_adjusted"] is True
+    assert canary["symbols"]["AAPL"]["volume_unchanged"] is True
+    assert canary["symbols"]["SPY"]["volume_unchanged"] is True
+    assert canary["symbols"]["PLTR"]["identity_control"] is True
+    assert before == {path: hashlib.sha256(path.read_bytes()).hexdigest() for path in artifacts}
+
+    provider = LivewireOhlcProvider(bronze_root, silver_root, "adjusted")
+    compute = _RecordingCompute()
+    manager = SubscriptionManager(provider, compute, ["1d", "1m"], seed_lookback_days=10)
+    await manager.subscribe("NVDA")
+    app = create_app()
+    app.state.ohlc_provider = provider
+    app.state.subscription_manager = manager
+    monkeypatch.setenv("APEX_LIVEWIRE_SILVER_ROOT", str(silver_root))
+    monkeypatch.setenv("APEX_LIVEWIRE_PRICE_MODE", "adjusted")
+    monkeypatch.setenv("APEX_LIVEWIRE_REVISION_POLL_SECONDS", "0.01")
+    monkeypatch.delenv("APEX_LIVEWIRE_ROOT", raising=False)
+    monkeypatch.delenv("APEX_PG_URL", raising=False)
+
+    async with lifespan(app):
+        await _wait_for_revision(app, 1)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/bars/NVDA",
+                params={
+                    "timeframe": "1d",
+                    "start": first_date.isoformat(),
+                    "end": second_date.isoformat(),
+                    "limit": 0,
+                },
+            )
+        assert response.status_code == 200
+        assert [bar["close"] for bar in response.json()["bars"]] == [50.0, 50.0]
+
+        revised_artifacts = list(
+            _publish_symbol(
+                bronze_root,
+                silver_root,
+                "NVDA",
+                0.4,
+                2.0,
+                100.0,
+                50.0,
+                first_date,
+                second_date,
+                2,
+            )
+        )
+        _publish_manifest(silver_root, 2, revised_artifacts, ["NVDA"], first_date)
+        await _wait_for_revision(app, 2)
+
+        assert compute.replaced["NVDA"]["1d"][0]["close"] == 40.0
+        assert compute.replaced["NVDA"]["1m"][0]["close"] == 40.0
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            health = (await client.get("/health")).json()["silver_revision"]
+        assert health["observed_revision"] == 2
+        assert health["last_fully_applied_revision"] == 2
+        assert health["per_symbol_revision"] == {"NVDA": 2}

--- a/tests/integration/test_silver_revision_e2e.py
+++ b/tests/integration/test_silver_revision_e2e.py
@@ -93,20 +93,19 @@ def _publish_symbol(
         }
     )
     _atomic_parquet(bronze_dir / "1d.parquet", raw_daily)
-    _atomic_parquet(
-        bronze_dir / "1m.parquet",
-        pd.DataFrame(
-            {
-                "bar_timestamp": pd.to_datetime(timestamps, utc=True),
-                "symbol_id": [1, 1],
-                "open": [first_raw_close, second_raw_close],
-                "high": [first_raw_close, second_raw_close],
-                "low": [first_raw_close, second_raw_close],
-                "close": [first_raw_close, second_raw_close],
-                "volume": raw_volume,
-            }
-        ),
+    intraday = pd.DataFrame(
+        {
+            "bar_timestamp": pd.to_datetime(timestamps, utc=True),
+            "symbol_id": [1, 1],
+            "open": [first_raw_close, second_raw_close],
+            "high": [first_raw_close, second_raw_close],
+            "low": [first_raw_close, second_raw_close],
+            "close": [first_raw_close, second_raw_close],
+            "volume": raw_volume,
+        }
     )
+    for timeframe in ("1m", "5m", "30m", "1h"):
+        _atomic_parquet(bronze_dir / f"{timeframe}.parquet", intraday)
     adjusted_first = first_raw_close * first_factor
     daily_path = silver_dir / "1d.parquet"
     _atomic_parquet(
@@ -243,6 +242,12 @@ async def test_adjusted_canary_and_revision_reseed_without_restart(
     assert canary["passed"] is True
     assert canary["revision"] == 1
     assert canary["symbols"]["NVDA"]["split_volume_adjusted"] is True
+    assert set(canary["symbols"]["NVDA"]["intraday_counts"]) == {
+        "1m",
+        "5m",
+        "30m",
+        "1h",
+    }
     assert canary["symbols"]["AAPL"]["volume_unchanged"] is True
     assert canary["symbols"]["SPY"]["volume_unchanged"] is True
     assert canary["symbols"]["PLTR"]["identity_control"] is True

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -22,6 +22,11 @@ async def test_health_returns_ok():
     assert "uptime" in data
     assert data["service"] == "apex-signal-server"
     assert data["silver_revision"] == {"enabled": False}
+    assert data["livewire"] == {
+        "configured": False,
+        "configured_price_mode": "raw",
+        "effective_price_mode": None,
+    }
     # version must reflect the real running build, not a hardcoded literal
     assert data["version"] == APEX_VERSION
     assert data["version"] not in ("", "unknown")
@@ -45,3 +50,25 @@ async def test_health_includes_revision_watcher_state():
 
     assert resp.json()["silver_revision"]["observed_revision"] == 42
     assert resp.json()["silver_revision"]["last_fully_applied_revision"] == 41
+
+
+@pytest.mark.asyncio
+async def test_health_reports_configured_and_effective_price_mode(tmp_path):
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+    app = create_app()
+    app.state.livewire_price_mode = "adjusted"
+    app.state.ohlc_provider = LivewireOhlcProvider(
+        bronze_root=tmp_path / "bronze",
+        silver_root=tmp_path / "silver",
+        price_mode="adjusted",
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    assert resp.json()["livewire"] == {
+        "configured": True,
+        "configured_price_mode": "adjusted",
+        "effective_price_mode": "adjusted",
+    }

--- a/tests/unit/api/test_server_lifespan.py
+++ b/tests/unit/api/test_server_lifespan.py
@@ -186,6 +186,40 @@ async def test_lifespan_builds_full_pipeline_when_livewire_root_set(monkeypatch,
 
 
 @pytest.mark.asyncio
+async def test_lifespan_wires_one_adjusted_provider_for_charts_and_subscriptions(
+    monkeypatch, tmp_path
+) -> None:
+    bronze_root = tmp_path / "bronze"
+    silver_root = tmp_path / "silver"
+    monkeypatch.setenv("APEX_LIVEWIRE_ROOT", str(bronze_root))
+    monkeypatch.setenv("APEX_LIVEWIRE_SILVER_ROOT", str(silver_root))
+    monkeypatch.setenv("APEX_LIVEWIRE_PRICE_MODE", "adjusted")
+    monkeypatch.setenv("APEX_XENON_WS_URL", "ws://127.0.0.1:1")
+    monkeypatch.delenv("APEX_PG_URL", raising=False)
+    monkeypatch.setattr(xenon_client_mod, "XenonTickClient", _SpyClient)
+
+    app = create_app()
+    async with lifespan(app):
+        provider = app.state.ohlc_provider
+        assert provider.bronze_root == bronze_root
+        assert provider.silver_root == silver_root
+        assert provider.price_mode == "adjusted"
+        assert app.state.subscription_manager._provider is provider
+
+
+@pytest.mark.asyncio
+async def test_lifespan_rejects_invalid_livewire_price_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("APEX_LIVEWIRE_ROOT", str(tmp_path))
+    monkeypatch.setenv("APEX_LIVEWIRE_PRICE_MODE", "sometimes-adjusted")
+    monkeypatch.delenv("APEX_PG_URL", raising=False)
+
+    app = create_app()
+    with pytest.raises(ValueError, match="price mode"):
+        async with lifespan(app):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_lifespan_passes_signal_repo_as_persistence(monkeypatch, tmp_path) -> None:
     """A configured signal_repo is handed to TASignalService as its persistence
     sink (so fired signals are written to PG), and the pre-injected repo is not

--- a/tests/unit/infrastructure/livewire/test_factory.py
+++ b/tests/unit/infrastructure/livewire/test_factory.py
@@ -10,6 +10,20 @@ def test_factory_builds_provider(tmp_path) -> None:
     assert p.source_name == "livewire"
 
 
+def test_factory_propagates_silver_root_and_price_mode(tmp_path) -> None:
+    silver_root = tmp_path / "silver"
+    p = build_livewire_provider(
+        SimpleNamespace(
+            livewire_bronze_root=str(tmp_path / "bronze"),
+            livewire_silver_root=str(silver_root),
+            livewire_price_mode="adjusted",
+        )
+    )
+
+    assert p.silver_root == silver_root
+    assert p.price_mode == "adjusted"
+
+
 def test_factory_requires_root() -> None:
     with pytest.raises(ValueError, match="livewire_bronze_root"):
         build_livewire_provider(SimpleNamespace(livewire_bronze_root=None))

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -9,6 +9,7 @@ import pytest
 
 from src.domain.interfaces.historical_source import HistoricalSourcePort
 from src.infrastructure.adapters.livewire.ohlc_provider import (
+    AdjustedDataUnavailable,
     LivewireOhlcProvider,
     _to_utc_datetime,
 )
@@ -61,6 +62,72 @@ def _write_intraday_fixture(root: Path) -> None:
         }
     )
     df.to_parquet(sym_dir / "1m.parquet")
+
+
+def _write_silver_daily_fixture(root: Path) -> None:
+    sym_dir = root / "asset_class=equity" / "symbol=TEST"
+    sym_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "trade_date": [dt.date(2026, 1, 2), dt.date(2026, 1, 3), dt.date(2026, 1, 6)],
+            "symbol_id": [1, 1, 1],
+            "open": [5.0, 5.5, 12.0],
+            "high": [5.25, 5.75, 12.5],
+            "low": [4.75, 5.25, 11.5],
+            "close": [5.5, 6.0, 13.0],
+            "adj_close": [5.5, 6.0, 13.0],
+            "volume": [200, 400, 300],
+            "price_adjustment_factor": [0.5, 0.5, 1.0],
+            "split_volume_factor": [2.0, 2.0, 1.0],
+            "adjustment_revision": [1, 1, 1],
+        }
+    ).to_parquet(sym_dir / "1d.parquet")
+
+
+def _write_factor_fixture(root: Path, *, cover_bar_date: bool = True) -> None:
+    sym_dir = root / "adjustments" / "asset_class=equity" / "symbol=TEST"
+    sym_dir.mkdir(parents=True, exist_ok=True)
+    effective_start = dt.date(2026, 1, 2) if cover_bar_date else dt.date(2026, 1, 3)
+    pd.DataFrame(
+        {
+            "effective_start": [effective_start],
+            "effective_end": [dt.date(2026, 1, 2) if cover_bar_date else None],
+            "price_adjustment_factor": [0.5],
+            "split_volume_factor": [2.0],
+            "adjustment_revision": [1],
+        }
+    ).to_parquet(sym_dir / "factors.parquet")
+
+
+def _write_action_span_fixtures(bronze_root: Path, silver_root: Path) -> None:
+    bronze_dir = bronze_root / "asset_class=equity" / "symbol=TEST"
+    bronze_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "bar_timestamp": pd.to_datetime(
+                ["2026-01-02T14:30:00Z", "2026-01-05T14:30:00Z", "2026-01-06T14:30:00Z"],
+                utc=True,
+            ),
+            "symbol_id": [1, 1, 1],
+            "open": [10.0, 10.0, 10.0],
+            "high": [11.0, 11.0, 11.0],
+            "low": [9.0, 9.0, 9.0],
+            "close": [10.0, 10.0, 10.0],
+            "volume": [100, 100, 100],
+        }
+    ).to_parquet(bronze_dir / "1m.parquet")
+
+    factor_dir = silver_root / "adjustments" / "asset_class=equity" / "symbol=TEST"
+    factor_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "effective_start": [None, dt.date(2026, 1, 3), dt.date(2026, 1, 6)],
+            "effective_end": [dt.date(2026, 1, 2), dt.date(2026, 1, 5), None],
+            "price_adjustment_factor": [0.45, 0.9, 1.0],
+            "split_volume_factor": [2.0, 1.0, 1.0],
+            "adjustment_revision": [1, 1, 1],
+        }
+    ).to_parquet(factor_dir / "factors.parquet")
 
 
 @pytest.fixture
@@ -122,6 +189,117 @@ async def test_fetch_bars_intraday_reads_bar_timestamp(tmp_path: Path) -> None:
     assert bars[0].bar_start == datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc)
     assert bars[0].bar_start.tzinfo is not None  # tz-aware UTC, not naive
     assert bars[0].bar_end > bars[0].bar_start  # 1m duration
+
+
+@pytest.mark.asyncio
+async def test_adjusted_daily_reads_materialized_silver(tmp_path: Path) -> None:
+    bronze_root = tmp_path / "bronze"
+    silver_root = tmp_path / "silver"
+    _write_fixture(bronze_root)
+    _write_silver_daily_fixture(silver_root)
+    provider = LivewireOhlcProvider(
+        bronze_root=bronze_root,
+        silver_root=silver_root,
+        price_mode="adjusted",
+    )
+
+    bars = await provider.fetch_bars("TEST", "1d", WIDE_START, WIDE_END)
+
+    assert [bar.close for bar in bars] == [5.5, 6.0, 13.0]
+    assert [bar.volume for bar in bars] == [200, 400, 300]
+
+
+@pytest.mark.asyncio
+async def test_adjusted_daily_does_not_require_bronze_artifact(tmp_path: Path) -> None:
+    silver_root = tmp_path / "silver"
+    _write_silver_daily_fixture(silver_root)
+    provider = LivewireOhlcProvider(
+        bronze_root=tmp_path / "bronze",
+        silver_root=silver_root,
+        price_mode="adjusted",
+    )
+
+    bars = await provider.fetch_bars("TEST", "1d", WIDE_START, WIDE_END)
+
+    assert [bar.close for bar in bars] == [5.5, 6.0, 13.0]
+
+
+@pytest.mark.asyncio
+async def test_adjusted_intraday_applies_price_and_split_volume_factors(tmp_path: Path) -> None:
+    bronze_root = tmp_path / "bronze"
+    silver_root = tmp_path / "silver"
+    _write_intraday_fixture(bronze_root)
+    _write_factor_fixture(silver_root)
+    provider = LivewireOhlcProvider(
+        bronze_root=bronze_root,
+        silver_root=silver_root,
+        price_mode="adjusted",
+    )
+
+    bars = await provider.fetch_bars(
+        "TEST",
+        "1m",
+        datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc),
+        datetime(2026, 1, 2, 14, 32, tzinfo=timezone.utc),
+    )
+
+    assert [bar.open for bar in bars] == [5.0, 5.5, 6.0]
+    assert [bar.close for bar in bars] == [5.5, 6.0, 6.5]
+    assert [bar.volume for bar in bars] == [200, 400, 600]
+
+
+@pytest.mark.asyncio
+async def test_adjusted_intraday_spans_split_dividend_and_identity_intervals(
+    tmp_path: Path,
+) -> None:
+    bronze_root = tmp_path / "bronze"
+    silver_root = tmp_path / "silver"
+    _write_action_span_fixtures(bronze_root, silver_root)
+    provider = LivewireOhlcProvider(
+        bronze_root=bronze_root,
+        silver_root=silver_root,
+        price_mode="adjusted",
+    )
+
+    bars = await provider.fetch_bars("TEST", "1m", WIDE_START, WIDE_END)
+
+    assert [bar.open for bar in bars] == [4.5, 9.0, 10.0]
+    assert [bar.volume for bar in bars] == [200, 100, 100]
+
+
+@pytest.mark.asyncio
+async def test_adjusted_intraday_rejects_missing_factor_artifact(tmp_path: Path) -> None:
+    bronze_root = tmp_path / "bronze"
+    _write_intraday_fixture(bronze_root)
+    provider = LivewireOhlcProvider(
+        bronze_root=bronze_root,
+        silver_root=tmp_path / "silver",
+        price_mode="adjusted",
+    )
+
+    with pytest.raises(AdjustedDataUnavailable, match="factor artifact"):
+        await provider.fetch_bars("TEST", "1m", WIDE_START, WIDE_END)
+
+
+@pytest.mark.asyncio
+async def test_adjusted_intraday_rejects_incomplete_factor_coverage(tmp_path: Path) -> None:
+    bronze_root = tmp_path / "bronze"
+    silver_root = tmp_path / "silver"
+    _write_intraday_fixture(bronze_root)
+    _write_factor_fixture(silver_root, cover_bar_date=False)
+    provider = LivewireOhlcProvider(
+        bronze_root=bronze_root,
+        silver_root=silver_root,
+        price_mode="adjusted",
+    )
+
+    with pytest.raises(AdjustedDataUnavailable, match="factor coverage"):
+        await provider.fetch_bars(
+            "TEST",
+            "1m",
+            datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc),
+            datetime(2026, 1, 2, 14, 32, tzinfo=timezone.utc),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infrastructure/livewire/test_paths.py
+++ b/tests/unit/infrastructure/livewire/test_paths.py
@@ -6,7 +6,9 @@ import pytest
 
 from src.infrastructure.adapters.livewire.paths import (
     SUPPORTED_TIMEFRAMES,
+    daily_silver_path,
     encode_symbol,
+    factor_path,
     parquet_path,
 )
 
@@ -29,6 +31,20 @@ def test_encode_symbol_matches_livewire() -> None:
 def test_parquet_path_encodes_special_symbol() -> None:
     p = parquet_path(Path("/data/bronze"), "BF/B", "1d")
     assert p == Path("/data/bronze") / "asset_class=equity" / "symbol=BF%2FB" / "1d.parquet"
+
+
+def test_daily_silver_path_layout() -> None:
+    root = Path("/data/silver")
+    assert daily_silver_path(root, "AAPL") == (
+        root / "asset_class=equity" / "symbol=AAPL" / "1d.parquet"
+    )
+
+
+def test_factor_path_layout_and_symbol_encoding() -> None:
+    root = Path("/data/silver")
+    assert factor_path(root, "BF/B") == (
+        root / "adjustments" / "asset_class=equity" / "symbol=BF%2FB" / "factors.parquet"
+    )
 
 
 def test_unsupported_timeframe_raises() -> None:


### PR DESCRIPTION
## What changed

- add explicit raw and adjusted Livewire price modes while keeping raw as the default
- read adjusted daily bars directly from materialized Silver Parquet
- adjust intraday Bronze bars with a New York trading-date range join against Silver factor intervals
- reject missing, incomplete, or overlapping factor coverage instead of silently falling back to raw
- share one configured provider across chart and subscription paths
- expose configured/effective price mode through health
- add a read-only NVDA/AAPL/SPY/PLTR shadow canary and an end-to-end revision reseed test

## Why

Apex already watches Livewire Silver revisions, but the provider still returned raw Bronze bars. This PR completes the shadow-mode read path so charts, warmups, and revision reseeds can consume split- and dividend-adjusted data without changing the production default.

## Impact

- `APEX_LIVEWIRE_PRICE_MODE=raw` remains the default
- `adjusted` mode requires both Bronze and Silver roots
- daily bars come from Silver
- intraday OHLC uses `price_adjustment_factor`
- intraday volume uses `split_volume_factor` only
- missing or invalid adjusted data fails closed
- Docker Compose and production deployment are unchanged

## Validation

- focused Silver/watcher/API regression: 85 passed
- CI integration-equivalent: 78 passed, 1 skipped
- CI unit-equivalent: 2010 passed, 79 skipped; 2 unchanged Yahoo-network baseline failures reproduce on master
- coverage: 50.95% (40% required)
- Black, isort, flake8, mypy, Bandit, version sync, signal verification, and regime verification passed on Python 3.13
- local FastAPI server retrieved real adjusted bars and applied Silver revision 1
- disposable real-data Silver build: 198 corporate actions, 4 symbols, revision 1, zero failures
- real canary passed NVDA, AAPL, SPY, and PLTR across `1d`, `1m`, `5m`, `30m`, and `1h`
- 2,017,115 real intraday bars per raw/adjusted side had matching counts and timestamps
- NVDA split-volume adjustment, AAPL/SPY dividend-only volume invariance, and PLTR identity control passed

## Known upstream data issue

Massive reports NVDA 2024-06-10 daily high as 195.95 in both adjusted and unadjusted responses. Bronze preserves that value and Silver correctly applies its dividend factor. This is a source-data quality follow-up, not an Apex adjustment discrepancy.