### PR TITLE
feat(api): /v1 surface covering every livewire asset class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ All notable changes to apex are recorded here. Format follows
 ### Changed
 
 - Flat routes (`/bars/{ticker}` etc.) are deprecated aliases; they emit `Deprecation` and `Sunset`.
+- **Breaking for `/indicators` callers:** an unknown `indicator` now returns `400 invalid_parameter`
+  instead of `404`. The symbol was never the problem; the old code sent callers to check their
+  ticker.
+- FastAPI's own request-validation failures (bad `limit`, unparseable date) keep their 422 status
+  but now use the error envelope instead of `{"detail": [...]}`, so the surface has one error shape.
 - `bars_payload` no longer emits `vwap` (always null -- no lake parquet carries the column).
 - `bars_payload` timeframe enum narrowed to `1m/5m/30m/1h/1d`.
 
@@ -34,6 +39,20 @@ All notable changes to apex are recorded here. Format follows
 - Non-equity symbols no longer resolve into `asset_class=equity` and read an absent file.
 - fx and volatility intraday are reachable: both publish an intraday ladder that a
   daily-only assumption would have hidden (126 parquet files).
+- Unknown symbols on `/indicators` and `/rates/.../series` return `404` instead of an empty
+  `200`, which read as "no signal fired" / "this yield had no observations".
+- `listing=any` probes the requested asset class, not always equity (`bronze-delisted` holds
+  `asset_class=fx` too), so fx ticker reuse is no longer reported as unambiguous.
+- A `start` after `end` is a `400`, not a `200` with zero rows.
+- Indicators reject `rates`: computing over a yield's null OHLC returned a number-shaped
+  answer to a question that has none.
+- Adjusted daily reads probe Silver as well as Bronze, so a Silver-only symbol with an empty
+  window is no longer a false `404`.
+- Coverage-catalog reads run off the event loop; a synchronous DuckDB read was stalling every
+  other request on the worker.
+- Unanticipated failures (the lake volume going away, a truncated parquet) return a typed
+  `500 internal_error` in the envelope rather than an unparseable bare 500, and no longer echo
+  absolute lake paths to the client.
 
 ## [0.1.4] — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ All notable changes to apex are recorded here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- `/v1/{asset_class}/{symbol}/bars` covering equity, volatility, fx, cmdty and futures.
+- `/v1/rates/{symbol}/series` for FRED Treasury yields (a yield has no OHLC, so it gets its
+  own payload shape).
+- `/v1/instruments` and `/v1/{asset_class}/{symbol}` discovery.
+- `/v1/equity/{symbol}/actions` and `/delisting` specified, returning a typed 501 pending livewire.
+- Typed error envelope with machine-readable codes on every failure.
+- `price_mode`, `listing_status`, `asset_class` and `adjustment_revision` on every bars payload.
+- Futures bars carry `settlement`, `open_interest` and contract identity.
+- `/health` now reports real bronze/silver recency read from the artifacts.
+
+### Changed
+
+- Flat routes (`/bars/{ticker}` etc.) are deprecated aliases; they emit `Deprecation` and `Sunset`.
+- `bars_payload` no longer emits `vwap` (always null -- no lake parquet carries the column).
+- `bars_payload` timeframe enum narrowed to `1m/5m/30m/1h/1d`.
+
+### Fixed
+
+- Missing Silver artifacts return `503 adjusted_unavailable` instead of a bare 500 (243 symbols
+  including HON, MMM, CMCSA).
+- Non-equity symbols no longer resolve into `asset_class=equity` and read an absent file.
+- fx and volatility intraday are reachable: both publish an intraday ladder that a
+  daily-only assumption would have hidden (126 parquet files).
+
 ## [0.1.4] — 2026-08-22
 
 ### Fixed

--- a/config/verification/schemas/bars_payload.schema.json
+++ b/config/verification/schemas/bars_payload.schema.json
@@ -4,12 +4,36 @@
   "title": "BarsPayload",
   "description": "OHLCV bar series for chart rendering (sourced from livewire)",
   "type": "object",
-  "required": ["symbol", "timeframe", "bars", "generated_at"],
+  "required": [
+    "symbol",
+    "asset_class",
+    "timeframe",
+    "price_mode",
+    "listing_status",
+    "bars",
+    "generated_at"
+  ],
   "properties": {
     "symbol": { "type": "string", "minLength": 1 },
+    "asset_class": {
+      "type": "string",
+      "enum": ["equity", "volatility", "fx", "cmdty", "futures"]
+    },
     "timeframe": {
       "type": "string",
-      "enum": ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w"]
+      "enum": ["1m", "5m", "30m", "1h", "1d"]
+    },
+    "price_mode": { "type": "string", "enum": ["raw", "adjusted"] },
+    "listing_status": { "type": "string", "enum": ["listed", "delisted"] },
+    "adjustment_revision": { "type": ["integer", "null"] },
+    "contract": {
+      "type": ["object", "null"],
+      "required": ["contract_id", "root_symbol", "expiry_date"],
+      "properties": {
+        "contract_id": { "type": ["integer", "string"] },
+        "root_symbol": { "type": "string" },
+        "expiry_date": { "type": "string" }
+      }
     },
     "count": { "type": "integer", "minimum": 0 },
     "generated_at": { "type": "string", "format": "date-time" },
@@ -26,7 +50,8 @@
         "low": { "type": "number" },
         "close": { "type": "number" },
         "volume": { "type": ["integer", "number", "null"] },
-        "vwap": { "type": ["number", "null"] }
+        "settlement": { "type": ["number", "null"] },
+        "open_interest": { "type": ["integer", "null"] }
       }
     }
   }

--- a/config/verification/schemas/instruments_payload.schema.json
+++ b/config/verification/schemas/instruments_payload.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apex.trading/schemas/instruments_payload.schema.json",
+  "title": "InstrumentsPayload",
+  "description": "Instrument coverage discovery, sourced from livewire's coverage snapshot",
+  "type": "object",
+  "required": ["instruments", "count", "source", "generated_at"],
+  "properties": {
+    "count": { "type": "integer", "minimum": 0 },
+    "source": { "type": "string", "const": "livewire_coverage_snapshot" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "instruments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "symbol",
+          "asset_class",
+          "listing_status",
+          "silver_available",
+          "price_mode"
+        ],
+        "properties": {
+          "symbol": { "type": "string", "minLength": 1 },
+          "asset_class": {
+            "type": "string",
+            "enum": ["equity", "volatility", "fx", "cmdty", "futures", "rates"]
+          },
+          "listing_status": {
+            "type": "string",
+            "enum": ["listed", "delisted"]
+          },
+          "first_date": { "type": ["string", "null"] },
+          "last_date": { "type": ["string", "null"] },
+          "silver_available": { "type": "boolean" },
+          "price_mode": { "type": "string", "enum": ["raw", "adjusted"] }
+        }
+      }
+    }
+  }
+}

--- a/config/verification/schemas/rates_series_payload.schema.json
+++ b/config/verification/schemas/rates_series_payload.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apex.trading/schemas/rates_series_payload.schema.json",
+  "title": "RatesSeriesPayload",
+  "description": "Yield series from livewire asset_class=rates (FRED Treasury constant maturity)",
+  "type": "object",
+  "required": ["symbol", "asset_class", "points", "generated_at"],
+  "properties": {
+    "symbol": { "type": "string", "minLength": 1 },
+    "asset_class": { "type": "string", "const": "rates" },
+    "tenor_years": { "type": ["number", "null"] },
+    "count": { "type": "integer", "minimum": 0 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "points": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["time", "yield_pct"],
+        "properties": {
+          "time": { "type": "string", "format": "date-time" },
+          "yield_pct": { "type": "number" }
+        }
+      }
+    }
+  }
+}

--- a/docs/argon-apex-api.md
+++ b/docs/argon-apex-api.md
@@ -18,7 +18,38 @@ state from apex on demand.
 |---|---|
 | Base URL | `http://<host>:8322` (HTTP) / `ws://<host>:8322` (WS). Port = `APEX_API_PORT`, default `8322`. |
 | Run apex | `uv run python -m src.api.server` |
-| Health | `GET /health` → `{ "status": "ok", "uptime": <s>, "service": "apex-signal-server", "pg_connected": <bool> }` |
+| Health | `GET /health` — see the real shape below |
+
+```json
+{
+  "status": "ok",
+  "version": "0.1.4",
+  "uptime": 102407.2,
+  "service": "apex-signal-server",
+  "pg_connected": true,
+  "livewire": {
+    "configured": true,
+    "configured_price_mode": "adjusted",
+    "effective_price_mode": "adjusted",
+    "recency": {
+      "bronze_last_trade_date": "2026-08-21",
+      "silver_last_trade_date": "2026-08-21",
+      "lag_days": 0
+    }
+  },
+  "silver_revision": {
+    "enabled": true, "running": true,
+    "observed_revision": 33, "last_fully_applied_revision": 33,
+    "per_symbol_revision": {}, "failed": {}, "pending": [],
+    "consecutive_failures": 0, "last_error": null,
+    "last_success_age_seconds": 53594.0
+  }
+}
+```
+
+`recency` is read from the parquet artifacts, **not** from livewire's 11:00 UTC coverage
+snapshot — that snapshot under-reports and would show a lag that does not exist.
+`lag_days` is **calendar** days, not trading sessions.
 
 apex's data sources are env-gated, which determines what's available:
 
@@ -122,6 +153,92 @@ Query: `timeframe` (default `1d`), `start`, `end`, `limit` (default `500`, `1..5
 GET /confluence/AAPL?timeframe=1d
 GET /confluence/AAPL?timeframe=1d&limit=2000
 ```
+
+---
+
+## 3a. The `/v1` surface (asset-class aware)
+
+Every route is `/v1/{asset_class}/{symbol}/...`. The flat routes in §3 still work and are
+**deprecated aliases** — see the migration table below.
+
+### Asset classes
+
+| Class | Timeframes | Payload | Adjustment | Notes |
+|---|---|---|---|---|
+| `equity` | `1m 5m 30m 1h 1d` | `bars_payload` | raw **or adjusted** | The only class with a Silver tree |
+| `fx` | `1m 5m 30m 1h 1d` | `bars_payload` | raw only | All 21 pairs carry the full ladder |
+| `volatility` | `5m 30m 1h 1d` | `bars_payload` | raw only | **No `1m`** anywhere; 30 of 44 symbols are `1d`-only |
+| `cmdty` | `1d` | `bars_payload` | raw only | |
+| `futures` | `1d` | `bars_payload` | raw only | Adds `settlement`, `open_interest`, `contract` |
+| `rates` | `1d` | `rates_series_payload` | n/a | A **yield**, not a price — no OHLC |
+
+`timeframes` is a per-**class** ceiling, not a per-symbol guarantee. A symbol that lacks a
+given timeframe returns `404 unknown_symbol`.
+
+### Routes
+
+| Method · Path | Purpose | Key errors |
+|---|---|---|
+| `GET /v1/{asset_class}/{symbol}/bars` | OHLCV candles | `400` class/tf/mode · `404` no artifact · `409` ambiguous · `501` delisted · `503` no Silver |
+| `GET /v1/rates/{symbol}/series` | Treasury yield series | `503` no provider |
+| `GET /v1/{asset_class}/{symbol}/indicators` | Per-bar indicator series | `400` · `404` unknown indicator · `503` |
+| `GET /v1/equity/{symbol}/confluence` | Multi-timeframe confluence (PG) | `503` no PG |
+| `GET /v1/equity/{symbol}/signals` | Signal backfill (PG) | `503` no PG |
+| `GET /v1/instruments` | Discovery across all classes | `400` bad class · `501` delisted · `503` no catalog |
+| `GET /v1/{asset_class}/{symbol}` | One instrument's metadata | `400` bad class · `404` no artifact · `503` |
+| `GET /v1/equity/{symbol}/actions` | Corporate actions | **`501` always** — blocked on livewire |
+| `GET /v1/equity/{symbol}/delisting` | Delisting terminal state | **`501` always** — blocked on livewire |
+
+### Query parameters
+
+| Param | Routes | Default | Meaning |
+|---|---|---|---|
+| `timeframe` | bars, indicators | `1d` | Must be in the class's ladder |
+| `start` / `end` | all series | none | ISO-8601. Omit both → most recent `limit` bars |
+| `limit` | bars, indicators, confluence, instruments | `2000` (bars) | Tail-slice; `<=0` → full history |
+| `price_mode` | bars | provider default | `raw` \| `adjusted`. A **request**, not a hint |
+| `listing` | bars | `listed` | `listed` \| `delisted` \| `any` |
+| `indicator` | indicators | **required** | Any of apex's registered indicators |
+| `asset_class` | instruments | all | Filter |
+| `q` | instruments | none | Symbol **prefix** filter (`_`/`%` are escaped) |
+
+### Error envelope
+
+Every failure returns `{"error": {"code", "message", "symbol"?, "asset_class"?}}`.
+
+| Code | Status | Meaning |
+|---|---|---|
+| `unsupported_timeframe` | 400 | Timeframe not in this class's ladder |
+| `unsupported_asset_class` | 400 | Unknown class, or a class whose payload is not bars |
+| `adjusted_not_supported` | 400 | `price_mode=adjusted` on a class with no Silver |
+| `unknown_symbol` | 404 | No artifact under that partition (or unknown indicator) |
+| `ambiguous_symbol` | 409 | `listing=any` on a ticker that is both live and delisted |
+| `not_yet_available` | 501 | Specified but blocked on upstream livewire work |
+| `provider_not_configured` | 503 | Provider / PG / coverage catalog unavailable |
+| `adjusted_unavailable` | 503 | Silver artifact missing or quarantined — retry later |
+
+`adjusted_unavailable` is a **503, not a 4xx**: a quarantined Silver artifact is an upstream
+condition livewire may repair, so the request was not wrong. 243 equity symbols are in this
+state, including HON, MMM, CMCSA, AIG, ECL, MSI, WY and LEN.
+
+### Deprecation
+
+The flat routes keep working and now emit `Deprecation: true`, `Sunset: Wed, 31 Dec 2026
+23:59:59 GMT`, and a `Link` header naming the successor.
+
+| Old | New |
+|---|---|
+| `GET /bars/AAPL` | `GET /v1/equity/AAPL/bars` |
+| `GET /indicators/AAPL?indicator=rsi` | `GET /v1/equity/AAPL/indicators?indicator=rsi` |
+| `GET /confluence/AAPL` | `GET /v1/equity/AAPL/confluence` |
+| `GET /signals/AAPL` | `GET /v1/equity/AAPL/signals` |
+
+### Two contract narrowings
+
+- **`vwap` is gone** from bar objects. No parquet in the lake carries that column, so it was
+  always `null`.
+- **The `timeframe` enum no longer accepts `15m`, `4h` or `1w`.** livewire warehouses none of
+  them, so those values could only ever `400`.
 
 ---
 

--- a/docs/argon-apex-api.md
+++ b/docs/argon-apex-api.md
@@ -173,19 +173,26 @@ Every route is `/v1/{asset_class}/{symbol}/...`. The flat routes in §3 still wo
 | `rates` | `1d` | `rates_series_payload` | n/a | A **yield**, not a price — no OHLC |
 
 `timeframes` is a per-**class** ceiling, not a per-symbol guarantee. A symbol that lacks a
-given timeframe returns `404 unknown_symbol`.
+given timeframe returns `404 unknown_symbol` — measured, not theoretical: `AACT` carries
+`1m/5m/30m/1h` in the live tree and no `1d` at all. Ask
+`GET /v1/{asset_class}/{symbol}` for the ladder a specific symbol actually has.
 
 ### Routes
 
 | Method · Path | Purpose | Key errors |
 |---|---|---|
 | `GET /v1/{asset_class}/{symbol}/bars` | OHLCV candles | `400` class/tf/mode · `404` no artifact · `409` ambiguous · `501` delisted · `503` no Silver |
-| `GET /v1/rates/{symbol}/series` | Treasury yield series | `503` no provider |
-| `GET /v1/{asset_class}/{symbol}/indicators` | Per-bar indicator series | `400` · `404` unknown indicator · `503` |
+| `GET /v1/rates/{symbol}/series` | Treasury yield series | `404` no artifact · `503` no provider |
+| `GET /v1/{asset_class}/{symbol}/indicators` | Per-bar indicator series | `400` bad class/tf/indicator · `404` no artifact · `503` |
 | `GET /v1/equity/{symbol}/confluence` | Multi-timeframe confluence (PG) | `503` no PG |
 | `GET /v1/equity/{symbol}/signals` | Signal backfill (PG) | `503` no PG |
 | `GET /v1/instruments` | Discovery across all classes | `400` bad class · `501` delisted · `503` no catalog |
 | `GET /v1/{asset_class}/{symbol}` | One instrument's metadata | `400` bad class · `404` no artifact · `503` |
+
+`GET /v1/{asset_class}/{symbol}` also returns `coverage_source`: `livewire_coverage_snapshot`
+when the catalog answered, `not_configured` or `unavailable` when it did not. Without it a
+null `first_date` would be ambiguous between "this symbol has no recorded coverage" and
+"apex could not read the catalog".
 | `GET /v1/equity/{symbol}/actions` | Corporate actions | **`501` always** — blocked on livewire |
 | `GET /v1/equity/{symbol}/delisting` | Delisting terminal state | **`501` always** — blocked on livewire |
 
@@ -197,7 +204,7 @@ given timeframe returns `404 unknown_symbol`.
 | `start` / `end` | all series | none | ISO-8601. Omit both → most recent `limit` bars |
 | `limit` | bars, indicators, confluence, instruments | `2000` (bars) | Tail-slice; `<=0` → full history |
 | `price_mode` | bars | provider default | `raw` \| `adjusted`. A **request**, not a hint |
-| `listing` | bars | `listed` | `listed` \| `delisted` \| `any` |
+| `listing` | bars, instruments | `listed` | `listed` \| `delisted` \| `any` |
 | `indicator` | indicators | **required** | Any of apex's registered indicators |
 | `asset_class` | instruments | all | Filter |
 | `q` | instruments | none | Symbol **prefix** filter (`_`/`%` are escaped) |
@@ -208,14 +215,24 @@ Every failure returns `{"error": {"code", "message", "symbol"?, "asset_class"?}}
 
 | Code | Status | Meaning |
 |---|---|---|
+| `invalid_parameter` | 400 | A query value is malformed: bad `listing`, bad `price_mode`, unknown `indicator`, `start` after `end` |
 | `unsupported_timeframe` | 400 | Timeframe not in this class's ladder |
 | `unsupported_asset_class` | 400 | Unknown class, or a class whose payload is not bars |
 | `adjusted_not_supported` | 400 | `price_mode=adjusted` on a class with no Silver |
-| `unknown_symbol` | 404 | No artifact under that partition (or unknown indicator) |
+| `unknown_symbol` | 404 | No artifact under that partition, in any tree the read would use |
 | `ambiguous_symbol` | 409 | `listing=any` on a ticker that is both live and delisted |
 | `not_yet_available` | 501 | Specified but blocked on upstream livewire work |
 | `provider_not_configured` | 503 | Provider / PG / coverage catalog unavailable |
 | `adjusted_unavailable` | 503 | Silver artifact missing or quarantined — retry later |
+| `internal_error` | 500 | Unanticipated failure (e.g. the lake volume went away) |
+
+Framework-level request validation (a non-integer `limit`, an unparseable date) keeps
+FastAPI's **422** status but uses this same envelope with `invalid_parameter`, so there is
+exactly one error shape on the surface rather than two.
+
+A code always names the thing that was wrong. A malformed query value is
+`invalid_parameter`, never `unknown_symbol` or `not_yet_available` — those would send
+you debugging a symbol or an upstream outage when the fault is a typo in the request.
 
 `adjusted_unavailable` is a **503, not a 4xx**: a quarantined Silver artifact is an upstream
 condition livewire may repair, so the request was not wrong. 243 equity symbols are in this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "mypy>=1.7.0",             # Static type checking
     "types-requests>=2.31.0",  # Type stubs for requests
     "types-pytz>=2024.1",      # Type stubs for pytz
+    "types-jsonschema>=4.20.0",  # Type stubs for jsonschema (used by payload/validate.py)
     "black>=23.12.0",          # Code formatting
     "isort>=5.13.0",           # Import sorting
     "flake8>=6.1.0",           # Linting

--- a/src/api/errors.py
+++ b/src/api/errors.py
@@ -13,14 +13,22 @@ import logging
 from enum import Enum
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
 
 
 class ApiErrorCode(str, Enum):
-    """Stable, machine-readable failure reasons. Values are part of the contract."""
+    """Stable, machine-readable failure reasons. Values are part of the contract.
 
+    A code names the thing that was wrong. ``INVALID_PARAMETER`` exists because a
+    malformed query value is not an unknown symbol and not an upstream outage --
+    reusing either code would send the caller debugging the wrong subject.
+    """
+
+    INVALID_PARAMETER = "invalid_parameter"
+    INTERNAL_ERROR = "internal_error"
     UNSUPPORTED_TIMEFRAME = "unsupported_timeframe"
     UNSUPPORTED_ASSET_CLASS = "unsupported_asset_class"
     ADJUSTED_NOT_SUPPORTED = "adjusted_not_supported"
@@ -35,6 +43,8 @@ class ApiErrorCode(str, Enum):
 # is an upstream condition livewire may repair, so "retry later" is the honest
 # semantic. A 4xx would tell the caller their request was wrong; it was not.
 STATUS_BY_CODE: dict[ApiErrorCode, int] = {
+    ApiErrorCode.INVALID_PARAMETER: 400,
+    ApiErrorCode.INTERNAL_ERROR: 500,
     ApiErrorCode.UNSUPPORTED_TIMEFRAME: 400,
     ApiErrorCode.UNSUPPORTED_ASSET_CLASS: 400,
     ApiErrorCode.ADJUSTED_NOT_SUPPORTED: 400,
@@ -79,9 +89,45 @@ def api_error_response(exc: ApiError) -> JSONResponse:
 
 
 def install_error_handlers(app: FastAPI) -> None:
-    """Register the ApiError handler so routes can raise instead of building responses."""
+    """Register the error handlers so routes can raise instead of building responses."""
 
     @app.exception_handler(ApiError)
     async def _handle(request: Request, exc: ApiError) -> JSONResponse:  # pragma: no cover
         logger.warning("api error %s on %s: %s", exc.code.value, request.url.path, exc.message)
         return api_error_response(exc)
+
+    @app.exception_handler(RequestValidationError)
+    async def _handle_validation(request: Request, exc: RequestValidationError) -> JSONResponse:
+        """FastAPI's own 422 body is ``{"detail": [...]}`` -- a second, undocumented
+        error shape on the same surface. Re-render it as the envelope so a consumer
+        parses one shape for every failure.
+
+        The 422 status is preserved: it is the documented FastAPI contract for request
+        validation and some callers already branch on it. Only the body changes.
+        """
+        detail = "; ".join(
+            f"{'.'.join(str(p) for p in e.get('loc', ())[1:])}: {e.get('msg', '')}".strip(": ")
+            for e in exc.errors()
+        )
+        logger.warning("request validation failed on %s: %s", request.url.path, detail)
+        return JSONResponse(
+            status_code=422,
+            content={"error": {"code": ApiErrorCode.INVALID_PARAMETER.value, "message": detail}},
+        )
+
+    @app.exception_handler(Exception)
+    async def _handle_unexpected(request: Request, exc: Exception) -> JSONResponse:
+        """Anything unanticipated still leaves as the envelope, never a bare 500.
+
+        The lake is a Parquet tree on an EXTERNAL volume read through DuckDB. If that
+        volume unmounts, a file is truncated mid-write, or a permission changes, DuckDB
+        raises and the exception would otherwise escape as an untyped 500 whose body
+        shape no consumer can parse -- the exact failure this module exists to remove.
+
+        The message is deliberately generic: ``exc`` carries absolute lake paths and SQL
+        text, and the client is not entitled to either. The detail goes to the log.
+        """
+        logger.exception("unhandled error on %s", request.url.path)
+        return api_error_response(
+            ApiError(ApiErrorCode.INTERNAL_ERROR, "internal error; see server logs")
+        )

--- a/src/api/errors.py
+++ b/src/api/errors.py
@@ -1,0 +1,87 @@
+"""Typed error envelope for the apex read surface.
+
+Every failure returns ``{"error": {"code": ..., "message": ..., ...}}`` with a stable
+machine-readable code, so a consumer can branch on the reason instead of guessing from
+a bare 500. Replaces the previous behaviour where ``AdjustedDataUnavailable`` escaped
+the route layer uncaught -- a condition 243 equity symbols hit in production, including
+HON, MMM, CMCSA, AIG, ECL, MSI, WY and LEN.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+class ApiErrorCode(str, Enum):
+    """Stable, machine-readable failure reasons. Values are part of the contract."""
+
+    UNSUPPORTED_TIMEFRAME = "unsupported_timeframe"
+    UNSUPPORTED_ASSET_CLASS = "unsupported_asset_class"
+    ADJUSTED_NOT_SUPPORTED = "adjusted_not_supported"
+    UNKNOWN_SYMBOL = "unknown_symbol"
+    AMBIGUOUS_SYMBOL = "ambiguous_symbol"
+    NOT_YET_AVAILABLE = "not_yet_available"
+    PROVIDER_NOT_CONFIGURED = "provider_not_configured"
+    ADJUSTED_UNAVAILABLE = "adjusted_unavailable"
+
+
+# 503 for ADJUSTED_UNAVAILABLE is deliberate: a missing or quarantined Silver artifact
+# is an upstream condition livewire may repair, so "retry later" is the honest
+# semantic. A 4xx would tell the caller their request was wrong; it was not.
+STATUS_BY_CODE: dict[ApiErrorCode, int] = {
+    ApiErrorCode.UNSUPPORTED_TIMEFRAME: 400,
+    ApiErrorCode.UNSUPPORTED_ASSET_CLASS: 400,
+    ApiErrorCode.ADJUSTED_NOT_SUPPORTED: 400,
+    ApiErrorCode.UNKNOWN_SYMBOL: 404,
+    ApiErrorCode.AMBIGUOUS_SYMBOL: 409,
+    ApiErrorCode.NOT_YET_AVAILABLE: 501,
+    ApiErrorCode.PROVIDER_NOT_CONFIGURED: 503,
+    ApiErrorCode.ADJUSTED_UNAVAILABLE: 503,
+}
+
+
+class ApiError(Exception):
+    """A read-surface failure with a typed reason code."""
+
+    def __init__(
+        self,
+        code: ApiErrorCode,
+        message: str,
+        *,
+        symbol: str | None = None,
+        asset_class: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.symbol = symbol
+        self.asset_class = asset_class
+
+    @property
+    def status_code(self) -> int:
+        return STATUS_BY_CODE[self.code]
+
+
+def api_error_response(exc: ApiError) -> JSONResponse:
+    """Render ``exc`` as the error envelope, omitting absent context fields."""
+    error: dict[str, str] = {"code": exc.code.value, "message": exc.message}
+    if exc.symbol is not None:
+        error["symbol"] = exc.symbol
+    if exc.asset_class is not None:
+        error["asset_class"] = exc.asset_class
+    return JSONResponse(status_code=exc.status_code, content={"error": error})
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    """Register the ApiError handler so routes can raise instead of building responses."""
+
+    @app.exception_handler(ApiError)
+    async def _handle(request: Request, exc: ApiError) -> JSONResponse:  # pragma: no cover
+        logger.warning("api error %s on %s: %s", exc.code.value, request.url.path, exc.message)
+        return api_error_response(exc)

--- a/src/api/payload/chart.py
+++ b/src/api/payload/chart.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List
 
+from src.infrastructure.adapters.livewire.asset_classes import get_asset_class
+
 
 def _iso(value: Any) -> Any:
     """ISO-8601 string, normalised to UTC so the chart contract matches the signal one.
@@ -23,7 +25,7 @@ def _iso(value: Any) -> Any:
     return value
 
 
-def _bar_to_dict(bar: Any) -> Dict[str, Any]:
+def _bar_to_dict(bar: Any, extra_fields: tuple[str, ...] = ()) -> Dict[str, Any]:
     # livewire bars set timestamp == bar_start; prefer timestamp, fall back to bar_start.
     when = bar.timestamp if getattr(bar, "timestamp", None) is not None else bar.bar_start
     row: Dict[str, Any] = {
@@ -34,9 +36,10 @@ def _bar_to_dict(bar: Any) -> Dict[str, Any]:
         "close": bar.close,
         "volume": bar.volume,
     }
-    # Futures-only columns. Omitted entirely for every other class rather than
-    # emitted as null noise on ~20M equity bars.
-    for extra in ("settlement", "open_interest"):
+    # Per-class extra columns, read from the registry rather than hardcoded -- the
+    # whole point of the registry is that a seventh class is a row, not an edit here.
+    # Omitted entirely where absent rather than emitted as null noise on ~20M bars.
+    for extra in extra_fields:
         value = getattr(bar, extra, None)
         if value is not None:
             row[extra] = value
@@ -61,7 +64,8 @@ def build_bars_payload(
     consumer written against ``listing_status == "listed"`` cannot later be handed
     delisted bars silently, and the adjustment basis is never left to inference.
     """
-    rows = [_bar_to_dict(b) for b in bars]
+    extra_fields = get_asset_class(asset_class).extra_bar_fields
+    rows = [_bar_to_dict(b, extra_fields) for b in bars]
     return {
         "symbol": symbol,
         "asset_class": asset_class,

--- a/src/api/payload/chart.py
+++ b/src/api/payload/chart.py
@@ -26,24 +26,50 @@ def _iso(value: Any) -> Any:
 def _bar_to_dict(bar: Any) -> Dict[str, Any]:
     # livewire bars set timestamp == bar_start; prefer timestamp, fall back to bar_start.
     when = bar.timestamp if getattr(bar, "timestamp", None) is not None else bar.bar_start
-    return {
+    row: Dict[str, Any] = {
         "time": _iso(when),
         "open": bar.open,
         "high": bar.high,
         "low": bar.low,
         "close": bar.close,
         "volume": bar.volume,
-        "vwap": bar.vwap,
     }
+    # Futures-only columns. Omitted entirely for every other class rather than
+    # emitted as null noise on ~20M equity bars.
+    for extra in ("settlement", "open_interest"):
+        value = getattr(bar, extra, None)
+        if value is not None:
+            row[extra] = value
+    return row
 
 
 def build_bars_payload(
-    symbol: str, timeframe: str, bars: Iterable[Any], *, generated_at: datetime
+    symbol: str,
+    timeframe: str,
+    bars: Iterable[Any],
+    *,
+    generated_at: datetime,
+    asset_class: str = "equity",
+    price_mode: str = "raw",
+    listing_status: str = "listed",
+    adjustment_revision: int | None = None,
+    contract: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
+    """Build the bars contract.
+
+    ``price_mode`` and ``listing_status`` are required and non-null by design: a
+    consumer written against ``listing_status == "listed"`` cannot later be handed
+    delisted bars silently, and the adjustment basis is never left to inference.
+    """
     rows = [_bar_to_dict(b) for b in bars]
     return {
         "symbol": symbol,
+        "asset_class": asset_class,
         "timeframe": timeframe,
+        "price_mode": price_mode,
+        "listing_status": listing_status,
+        "adjustment_revision": adjustment_revision,
+        "contract": contract,
         "bars": rows,
         "count": len(rows),
         "generated_at": generated_at.isoformat(),

--- a/src/api/payload/chart.py
+++ b/src/api/payload/chart.py
@@ -76,6 +76,26 @@ def build_bars_payload(
     }
 
 
+def build_rates_series_payload(
+    symbol: str, points: Iterable[Any], *, generated_at: datetime
+) -> Dict[str, Any]:
+    """Build the rates contract. Separate from bars because a yield has no OHLC and
+    cannot satisfy bars_payload.schema.json's numeric open/high/low/close."""
+    # Materialize once: `points` is an Iterable, and iterating it twice would leave
+    # tenor_years silently None for any generator caller.
+    materialized = list(points)
+    rows = [{"time": _iso(p.time), "yield_pct": p.yield_pct} for p in materialized]
+    tenors = {p.tenor_years for p in materialized}
+    return {
+        "symbol": symbol,
+        "asset_class": "rates",
+        "tenor_years": next(iter(tenors)) if len(tenors) == 1 else None,
+        "points": rows,
+        "count": len(rows),
+        "generated_at": generated_at.isoformat(),
+    }
+
+
 def build_indicator_payload(
     symbol: str,
     timeframe: str,

--- a/src/api/payload/validate.py
+++ b/src/api/payload/validate.py
@@ -22,8 +22,11 @@ class ValidationFailure(ValueError):
 
 
 @lru_cache(maxsize=None)
-def _schema(name: str = _DEFAULT_SCHEMA) -> dict:
-    return json.loads((_SCHEMA_DIR / f"{name}.schema.json").read_text(encoding="utf-8"))
+def _schema(name: str = _DEFAULT_SCHEMA) -> dict[str, Any]:
+    loaded: dict[str, Any] = json.loads(
+        (_SCHEMA_DIR / f"{name}.schema.json").read_text(encoding="utf-8")
+    )
+    return loaded
 
 
 def validate_payload(payload: dict[str, Any], schema: str = _DEFAULT_SCHEMA) -> None:

--- a/src/api/routes/_chart_guards.py
+++ b/src/api/routes/_chart_guards.py
@@ -1,0 +1,211 @@
+"""Validate and resolve a chart read request before anything touches the lake.
+
+Split out of ``chart.py`` when that file crossed the repo's 500-line budget. The seam
+is a responsibility, not a layer: everything here answers "is this request coherent,
+and which artifact would it read?" -- the questions that must be settled before a read,
+and that every chart route asks in the same order. ``chart.py`` keeps the routes and
+the response assembly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional, Tuple
+
+from fastapi import Request
+
+from src.api.errors import ApiError, ApiErrorCode
+from src.application.chart.indicator_compute import DEFAULT_TF_DELTA, TF_DELTAS
+from src.infrastructure.adapters.livewire.asset_classes import (
+    AssetClassSpec,
+    UnknownAssetClass,
+    get_asset_class,
+)
+from src.infrastructure.adapters.livewire.paths import (
+    daily_silver_path,
+    delisted_bronze_path,
+    parquet_path,
+)
+
+_DEFAULT_BARS = 2000
+_LOOKBACK_FUDGE = 10
+
+
+def _resolve_window(
+    timeframe: str,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    bars: int = _DEFAULT_BARS,
+) -> Tuple[datetime, datetime, Optional[int]]:
+    """Return (start, end, tail_limit). When start is omitted, fetch a generous
+    lookback and tail-slice to `bars`; an explicit start is honoured as-is."""
+    end = end or datetime.now(timezone.utc)
+    if start is not None and start > end:
+        # Otherwise this reads a real artifact, matches nothing, and answers 200 with
+        # zero rows -- reporting an impossible request as a quiet market.
+        raise ApiError(
+            ApiErrorCode.INVALID_PARAMETER,
+            f"start {start.isoformat()} is after end {end.isoformat()}",
+        )
+    if start is None:
+        if bars <= 0:  # full history: no tail-slice, fetch from the epoch
+            return datetime(1970, 1, 1, tzinfo=timezone.utc), end, None
+        delta = TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA)
+        start = end - delta * bars * _LOOKBACK_FUDGE
+        return start, end, bars
+    return start, end, None
+
+
+def _silver_revision(request: Request) -> Optional[int]:
+    """The revision the payload's adjusted prices were built from.
+
+    Sourced from the running watcher's ``last_fully_applied_revision`` -- NOT
+    ``observed_revision``, which may be a revision apex has seen but not finished
+    applying. There is no ``app.state.silver_revision``; the watcher owns this.
+    """
+    watcher = getattr(request.app.state, "revision_watcher", None)
+    return getattr(watcher, "last_fully_applied_revision", None) if watcher else None
+
+
+def _contract_identity(spec: AssetClassSpec, bars: list) -> Optional[dict]:
+    """Futures instrument identity, lifted off the first bar.
+
+    livewire stores contract_id / root_symbol / expiry_date as per-row columns on
+    asset_class=futures and they are constant across a contract's rows. Every other
+    class returns None.
+    """
+    if spec.name != "futures" or not bars:
+        return None
+    first = bars[0]
+    root = getattr(first, "root_symbol", None)
+    if root is None:
+        return None
+    return {
+        "contract_id": getattr(first, "contract_id", None),
+        "root_symbol": root,
+        "expiry_date": getattr(first, "expiry_date", None),  # already an ISO string
+    }
+
+
+def _provider_or_raise(request: Request) -> Any:
+    provider = getattr(request.app.state, "ohlc_provider", None)
+    if provider is None:
+        raise ApiError(ApiErrorCode.PROVIDER_NOT_CONFIGURED, "bar provider not configured")
+    return provider
+
+
+def _spec_or_raise(asset_class: str) -> AssetClassSpec:
+    try:
+        return get_asset_class(asset_class)
+    except UnknownAssetClass as exc:
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_ASSET_CLASS, str(exc), asset_class=asset_class
+        ) from exc
+
+
+def _require_bars_payload(spec: AssetClassSpec, symbol: str) -> None:
+    """Reject a class whose payload is not bars.
+
+    `rates` is registered in the asset-class registry (so paths and discovery work) but a
+    yield has no OHLC and cannot satisfy bars_payload.schema.json. Without this the generic
+    route would read the parquet, build a payload of null prices, and fail egress validation
+    as a 500 instead of telling the caller which route to use.
+    """
+    if spec.payload != "bars":
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_ASSET_CLASS,
+            f"{spec.name} is not an OHLCV class; use /v1/{spec.name}/{{symbol}}/series",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
+
+
+def _check_timeframe(spec: AssetClassSpec, timeframe: str) -> None:
+    if timeframe not in spec.timeframes:
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_TIMEFRAME,
+            f"unsupported timeframe {timeframe!r} for {spec.name} "
+            f"(have {list(spec.timeframes)})",
+            asset_class=spec.name,
+        )
+
+
+def _artifact_exists(
+    provider: Any, symbol: str, timeframe: str, spec: AssetClassSpec, price_mode: str
+) -> bool:
+    """Does an artifact exist for this read, in whichever tree the read would use?
+
+    Adjusted daily is served from Silver and Silver can outlive its Bronze source, so
+    probing Bronze alone would answer a real Silver-only symbol with 404 whenever the
+    requested window happened to be empty.
+    """
+    if (
+        price_mode == "adjusted"
+        and timeframe == "1d"
+        and spec.supports_adjusted
+        and provider.silver_root is not None
+        and daily_silver_path(provider.silver_root, symbol).exists()
+    ):
+        return True
+    return parquet_path(provider.bronze_root, symbol, timeframe, spec.name).exists()
+
+
+def _is_dual_resident(provider: Any, symbol: str, asset_class: str) -> bool:
+    """True when ``symbol`` exists in BOTH the live and delisted bronze trees.
+
+    Probes bronze-delisted/ directly rather than asking the provider: a provider hook
+    here would have no production implementation, so every test would exercise the hook
+    and nothing would exercise the path construction that actually runs.
+
+    With no delisted root configured, nothing is dual-resident.
+    """
+    delisted_root = getattr(provider, "delisted_root", None)
+    if delisted_root is None:
+        return False
+    # Pass the class through: bronze-delisted is overwhelmingly equity but not only
+    # equity (asset_class=fx holds USDEUR), and defaulting would silently answer the
+    # question for the wrong partition.
+    return delisted_bronze_path(delisted_root, symbol, asset_class=asset_class).exists()
+
+
+def _check_listing(provider: Any, listing: str, symbol: str, asset_class: str) -> str:
+    """Resolve the ``listing`` filter to a listing_status, or fail with a typed code.
+
+    ``delisted`` is specified but blocked upstream: livewire has no Silver tree for
+    bronze-delisted/, and no delisted symbol has correct corporate-action data
+    (measured 2026-08-23). Serving raw delisted bars would trade survivorship bias
+    for silent mis-adjustment, so we fail loudly instead.
+
+    ``any`` resolves to ``listed`` unless the ticker is genuinely dual-resident, in which
+    case it is a 409: 2,345 tickers exist in BOTH the live and delisted trees (ticker
+    reuse), so for those "either" has no single correct answer.
+    """
+    if listing == "listed":
+        return "listed"
+    if listing == "any":
+        # Only ambiguous when the ticker really is dual-resident. 2,345 of 8,620 delisted
+        # symbols are also live; for the other ~12,400 live symbols "any" has exactly one
+        # answer, so 409-ing all of them would be noise.
+        if _is_dual_resident(provider, symbol, asset_class):
+            raise ApiError(
+                ApiErrorCode.AMBIGUOUS_SYMBOL,
+                f"{symbol} resolves to both a live and a delisted entity; "
+                "request listing=listed or listing=delisted explicitly",
+                symbol=symbol,
+                asset_class=asset_class,
+            )
+        return "listed"
+    if listing != "delisted":
+        raise ApiError(
+            ApiErrorCode.INVALID_PARAMETER,
+            f"unknown listing filter {listing!r} (have listed, delisted, any)",
+            symbol=symbol,
+            asset_class=asset_class,
+        )
+    raise ApiError(
+        ApiErrorCode.NOT_YET_AVAILABLE,
+        "delisted coverage requires upstream livewire work "
+        "(instrument identity, corporate-action backfill, Silver over bronze-delisted)",
+        symbol=symbol,
+        asset_class=asset_class,
+    )

--- a/src/api/routes/chart.py
+++ b/src/api/routes/chart.py
@@ -1,8 +1,12 @@
 """Chart read surface for argon (stateless renderer pulls everything from apex).
 
-- GET /bars/{ticker}          -> OHLCV candles from livewire (full history)
-- GET /indicators/{ticker}    -> per-bar indicator series, compute-on-read (full depth)
-- GET /confluence/{ticker}    -> multi-timeframe confluence, DB-backed (persisted depth)
+- GET /v1/{asset_class}/{symbol}/bars        -> OHLCV candles from livewire
+- GET /v1/{asset_class}/{symbol}/indicators  -> per-bar indicator series, compute-on-read
+- GET /v1/rates/{symbol}/series              -> yield series (no OHLC)
+- GET /v1/equity/{symbol}/confluence         -> multi-timeframe confluence, DB-backed
+
+The flat routes (/bars/{ticker} etc.) are preserved as deprecated aliases so argon and
+signal-lab need no change; they carry Deprecation/Sunset/Link headers.
 
 Mirrors the signal contract: REST backfill + validate-on-egress on every response.
 """
@@ -10,14 +14,16 @@ Mirrors the signal contract: REST backfill + validate-on-egress on every respons
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Query, Request, Response
 
+from src.api.errors import ApiError, ApiErrorCode
 from src.api.payload.chart import (
     build_bars_payload,
     build_confluence_payload,
     build_indicator_payload,
+    build_rates_series_payload,
 )
 from src.api.payload.validate import validate_payload
 from src.application.chart.indicator_compute import (
@@ -27,7 +33,13 @@ from src.application.chart.indicator_compute import (
     compute_indicator_series,
 )
 from src.domain.signals.indicators.registry import get_indicator_registry
-from src.infrastructure.adapters.livewire.paths import SUPPORTED_TIMEFRAMES
+from src.infrastructure.adapters.livewire.asset_classes import (
+    AssetClassSpec,
+    UnknownAssetClass,
+    get_asset_class,
+)
+from src.infrastructure.adapters.livewire.ohlc_provider import AdjustedDataUnavailable
+from src.infrastructure.adapters.livewire.paths import delisted_bronze_path, parquet_path
 
 router = APIRouter(tags=["chart"])
 
@@ -37,15 +49,7 @@ router = APIRouter(tags=["chart"])
 _DEFAULT_BARS = 2000
 _LOOKBACK_FUDGE = 10
 
-
-def _require_supported_timeframe(timeframe: str) -> None:
-    """Livewire warehouses a narrower set than the schema enum -- reject early (400)
-    instead of letting parquet_path raise ValueError -> 500."""
-    if timeframe not in SUPPORTED_TIMEFRAMES:
-        raise HTTPException(
-            status_code=400,
-            detail=f"unsupported timeframe: {timeframe} (have {sorted(SUPPORTED_TIMEFRAMES)})",
-        )
+_SUNSET = "Wed, 31 Dec 2026 23:59:59 GMT"
 
 
 def _resolve_window(
@@ -66,82 +70,394 @@ def _resolve_window(
     return start, end, None
 
 
-@router.get("/bars/{ticker}")
-async def get_bars(
-    ticker: str,
-    request: Request,
-    timeframe: str = "1d",
-    start: Optional[datetime] = None,
-    end: Optional[datetime] = None,
-    limit: int = Query(
-        default=_DEFAULT_BARS,
-        description="tail-slice to N most recent bars; <=0 for full history",
-    ),
-) -> dict:
+def _silver_revision(request: Request) -> Optional[int]:
+    """The revision the payload's adjusted prices were built from.
+
+    Sourced from the running watcher's ``last_fully_applied_revision`` -- NOT
+    ``observed_revision``, which may be a revision apex has seen but not finished
+    applying. There is no ``app.state.silver_revision``; the watcher owns this.
+    """
+    watcher = getattr(request.app.state, "revision_watcher", None)
+    return getattr(watcher, "last_fully_applied_revision", None) if watcher else None
+
+
+def _contract_identity(spec: AssetClassSpec, bars: list) -> Optional[dict]:
+    """Futures instrument identity, lifted off the first bar.
+
+    livewire stores contract_id / root_symbol / expiry_date as per-row columns on
+    asset_class=futures and they are constant across a contract's rows. Every other
+    class returns None.
+    """
+    if spec.name != "futures" or not bars:
+        return None
+    first = bars[0]
+    root = getattr(first, "root_symbol", None)
+    if root is None:
+        return None
+    return {
+        "contract_id": getattr(first, "contract_id", None),
+        "root_symbol": root,
+        "expiry_date": getattr(first, "expiry_date", None),  # already an ISO string
+    }
+
+
+def _provider_or_raise(request: Request) -> Any:
     provider = getattr(request.app.state, "ohlc_provider", None)
     if provider is None:
-        raise HTTPException(status_code=503, detail="bar provider not configured")
-    _require_supported_timeframe(timeframe)
+        raise ApiError(ApiErrorCode.PROVIDER_NOT_CONFIGURED, "bar provider not configured")
+    return provider
+
+
+def _spec_or_raise(asset_class: str) -> AssetClassSpec:
+    try:
+        return get_asset_class(asset_class)
+    except UnknownAssetClass as exc:
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_ASSET_CLASS, str(exc), asset_class=asset_class
+        ) from exc
+
+
+def _require_bars_payload(spec: AssetClassSpec, symbol: str) -> None:
+    """Reject a class whose payload is not bars.
+
+    `rates` is registered in the asset-class registry (so paths and discovery work) but a
+    yield has no OHLC and cannot satisfy bars_payload.schema.json. Without this the generic
+    route would read the parquet, build a payload of null prices, and fail egress validation
+    as a 500 instead of telling the caller which route to use.
+    """
+    if spec.payload != "bars":
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_ASSET_CLASS,
+            f"{spec.name} is not an OHLCV class; use /v1/{spec.name}/{{symbol}}/series",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
+
+
+def _check_timeframe(spec: AssetClassSpec, timeframe: str) -> None:
+    if timeframe not in spec.timeframes:
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_TIMEFRAME,
+            f"unsupported timeframe {timeframe!r} for {spec.name} "
+            f"(have {list(spec.timeframes)})",
+            asset_class=spec.name,
+        )
+
+
+def _is_dual_resident(provider: Any, symbol: str) -> bool:
+    """True when ``symbol`` exists in BOTH the live and delisted bronze trees.
+
+    Prefers a provider-supplied answer so test doubles need no filesystem; falls back to
+    probing bronze-delisted/. With no delisted root configured, nothing is dual-resident.
+    """
+    probe = getattr(provider, "is_dual_resident", None)
+    if probe is not None:
+        return bool(probe(symbol))
+    delisted_root = getattr(provider, "delisted_root", None)
+    return delisted_root is not None and delisted_bronze_path(delisted_root, symbol).exists()
+
+
+def _check_listing(provider: Any, listing: str, symbol: str, asset_class: str) -> str:
+    """Resolve the ``listing`` filter to a listing_status, or fail with a typed code.
+
+    ``delisted`` is specified but blocked upstream: livewire has no Silver tree for
+    bronze-delisted/, and no delisted symbol has correct corporate-action data
+    (measured 2026-08-23). Serving raw delisted bars would trade survivorship bias
+    for silent mis-adjustment, so we fail loudly instead.
+
+    ``any`` resolves to ``listed`` unless the ticker is genuinely dual-resident, in which
+    case it is a 409: 2,345 tickers exist in BOTH the live and delisted trees (ticker
+    reuse), so for those "either" has no single correct answer.
+    """
+    if listing == "listed":
+        return "listed"
+    if listing == "any":
+        # Only ambiguous when the ticker really is dual-resident. 2,345 of 8,620 delisted
+        # symbols are also live; for the other ~12,400 live symbols "any" has exactly one
+        # answer, so 409-ing all of them would be noise.
+        if _is_dual_resident(provider, symbol):
+            raise ApiError(
+                ApiErrorCode.AMBIGUOUS_SYMBOL,
+                f"{symbol} resolves to both a live and a delisted entity; "
+                "request listing=listed or listing=delisted explicitly",
+                symbol=symbol,
+                asset_class=asset_class,
+            )
+        return "listed"
+    if listing != "delisted":
+        raise ApiError(
+            ApiErrorCode.UNKNOWN_SYMBOL,
+            f"unknown listing filter {listing!r} (have listed, delisted, any)",
+            symbol=symbol,
+            asset_class=asset_class,
+        )
+    raise ApiError(
+        ApiErrorCode.NOT_YET_AVAILABLE,
+        "delisted coverage requires upstream livewire work "
+        "(instrument identity, corporate-action backfill, Silver over bronze-delisted)",
+        symbol=symbol,
+        asset_class=asset_class,
+    )
+
+
+async def _bars_response(
+    request: Request,
+    asset_class: str,
+    symbol: str,
+    timeframe: str,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    limit: int,
+    price_mode: Optional[str],
+    listing: str,
+) -> dict:
+    provider = _provider_or_raise(request)
+    spec = _spec_or_raise(asset_class)
+    _require_bars_payload(spec, symbol)
+    _check_timeframe(spec, timeframe)
+    listing_status = _check_listing(provider, listing, symbol, spec.name)
+    if price_mode is not None and price_mode not in ("raw", "adjusted"):
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_ASSET_CLASS,
+            f"unknown price_mode {price_mode!r} (have raw, adjusted)",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
+    if price_mode == "adjusted" and not spec.supports_adjusted:
+        raise ApiError(
+            ApiErrorCode.ADJUSTED_NOT_SUPPORTED,
+            f"Silver exists only for equity; {spec.name} is served raw",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
+    # An explicit price_mode is a REQUEST, not a filter. `raw` is always satisfiable
+    # (bronze is the substrate under both modes) so it may override an adjusted-configured
+    # provider; `adjusted` is satisfiable only where Silver exists, already checked above.
+    # Accepting the parameter and then ignoring it would be worse than not offering it.
+    effective = price_mode or provider.effective_price_mode(spec.name)
     start, end, tail = _resolve_window(timeframe, start, end, limit)
-    bars = await provider.fetch_bars(ticker, timeframe, start, end)
+    try:
+        bars = await provider.fetch_bars(
+            symbol, timeframe, start, end, asset_class=spec.name, price_mode=effective
+        )
+    except AdjustedDataUnavailable as exc:
+        raise ApiError(
+            ApiErrorCode.ADJUSTED_UNAVAILABLE, str(exc), symbol=symbol, asset_class=spec.name
+        ) from exc
+    if not bars and not parquet_path(provider.bronze_root, symbol, timeframe, spec.name).exists():
+        # Distinguish "no artifact" from "artifact exists, window is empty". The second is a
+        # legitimate 200 with zero bars (a quiet window); the first is a 404.
+        raise ApiError(
+            ApiErrorCode.UNKNOWN_SYMBOL,
+            f"no artifact for {symbol} under {spec.partition}",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
     if tail is not None:
         bars = bars[-tail:]
-    payload = build_bars_payload(ticker, timeframe, bars, generated_at=datetime.now(timezone.utc))
+    payload = build_bars_payload(
+        symbol,
+        timeframe,
+        bars,
+        generated_at=datetime.now(timezone.utc),
+        asset_class=spec.name,
+        contract=_contract_identity(spec, bars),
+        price_mode=effective,
+        listing_status=listing_status,
+        adjustment_revision=_silver_revision(request) if effective == "adjusted" else None,
+    )
     validate_payload(payload, "bars_payload")
     return payload
 
 
-@router.get("/indicators/{ticker}")
-async def get_indicators(
-    ticker: str,
+async def _indicators_response(
     request: Request,
+    asset_class: str,
+    symbol: str,
     indicator: str,
-    timeframe: str = "1d",
-    start: Optional[datetime] = None,
-    end: Optional[datetime] = None,
-    limit: int = Query(
-        default=_DEFAULT_BARS,
-        description="tail-slice to N most recent bars; <=0 for full history",
-    ),
+    timeframe: str,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    limit: int,
 ) -> dict:
-    provider = getattr(request.app.state, "ohlc_provider", None)
-    if provider is None:
-        raise HTTPException(status_code=503, detail="bar provider not configured")
-    _require_supported_timeframe(timeframe)
+    provider = _provider_or_raise(request)
+    spec = _spec_or_raise(asset_class)
+    _check_timeframe(spec, timeframe)
     registry = getattr(request.app.state, "indicator_registry", None) or get_indicator_registry()
     start, end, tail = _resolve_window(timeframe, start, end, limit)
     try:
         points = await compute_indicator_series(
-            provider, registry, ticker, timeframe, indicator, start, end
+            provider,
+            registry,
+            symbol,
+            timeframe,
+            indicator,
+            start,
+            end,
+            asset_class=spec.name,
         )
-    except UnknownIndicatorError:
-        raise HTTPException(status_code=404, detail=f"unknown indicator: {indicator}")
+    except UnknownIndicatorError as exc:
+        raise ApiError(
+            ApiErrorCode.UNKNOWN_SYMBOL,
+            f"unknown indicator: {indicator}",
+            symbol=symbol,
+            asset_class=spec.name,
+        ) from exc
+    except AdjustedDataUnavailable as exc:
+        raise ApiError(
+            ApiErrorCode.ADJUSTED_UNAVAILABLE, str(exc), symbol=symbol, asset_class=spec.name
+        ) from exc
     if tail is not None:
         points = points[-tail:]
     payload = build_indicator_payload(
-        ticker, timeframe, indicator, points, generated_at=datetime.now(timezone.utc)
+        symbol, timeframe, indicator, points, generated_at=datetime.now(timezone.utc)
     )
     validate_payload(payload, "indicator_series_payload")
     return payload
 
 
-@router.get("/confluence/{ticker}")
-async def get_confluence(
-    ticker: str,
+async def _confluence_response(
+    request: Request,
+    symbol: str,
+    timeframe: str,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    limit: int,
+) -> dict:
+    repo = getattr(request.app.state, "signal_repo", None)
+    if repo is None:
+        raise ApiError(
+            ApiErrorCode.PROVIDER_NOT_CONFIGURED,
+            "signal persistence not configured",
+            symbol=symbol,
+        )
+    # Confluence is PG-backed (not livewire), so it accepts any timeframe the data has.
+    start, end, _ = _resolve_window(timeframe, start, end)
+    rows = await repo.get_confluence_history(symbol, timeframe, start, end, limit)
+    payload = build_confluence_payload(
+        symbol, timeframe, rows, generated_at=datetime.now(timezone.utc)
+    )
+    validate_payload(payload, "confluence_payload")
+    return payload
+
+
+def _mark_deprecated(response: Response, successor: str) -> None:
+    response.headers["Deprecation"] = "true"
+    response.headers["Sunset"] = _SUNSET
+    response.headers["Link"] = f'<{successor}>; rel="successor-version"'
+
+
+# --- /v1 routes -------------------------------------------------------------------
+
+
+@router.get("/v1/{asset_class}/{symbol}/bars")
+async def get_bars_v1(
+    asset_class: str,
+    symbol: str,
+    request: Request,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: int = Query(default=_DEFAULT_BARS, description="tail-slice to N bars; <=0 for all"),
+    price_mode: Optional[str] = Query(default=None, description="raw | adjusted"),
+    listing: str = Query(default="listed", description="listed | delisted | any"),
+) -> dict:
+    return await _bars_response(
+        request, asset_class, symbol, timeframe, start, end, limit, price_mode, listing
+    )
+
+
+@router.get("/v1/rates/{symbol}/series")
+async def get_rates_series_v1(
+    symbol: str,
+    request: Request,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> dict:
+    provider = _provider_or_raise(request)
+    start, end, _ = _resolve_window("1d", start, end, 0)
+    points = await provider.fetch_rate_series(symbol, start, end)
+    payload = build_rates_series_payload(symbol, points, generated_at=datetime.now(timezone.utc))
+    validate_payload(payload, "rates_series_payload")
+    return payload
+
+
+@router.get("/v1/{asset_class}/{symbol}/indicators")
+async def get_indicators_v1(
+    asset_class: str,
+    symbol: str,
+    request: Request,
+    indicator: str,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: int = Query(default=_DEFAULT_BARS, description="tail-slice to N bars; <=0 for all"),
+) -> dict:
+    return await _indicators_response(
+        request, asset_class, symbol, indicator, timeframe, start, end, limit
+    )
+
+
+@router.get("/v1/equity/{symbol}/confluence")
+async def get_confluence_v1(
+    symbol: str,
     request: Request,
     timeframe: str = "1d",
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
     limit: int = Query(default=500, ge=1, le=5000),
 ) -> dict:
-    repo = getattr(request.app.state, "signal_repo", None)
-    if repo is None:
-        raise HTTPException(status_code=503, detail="signal persistence not configured")
-    # Confluence is PG-backed (not livewire), so it accepts any timeframe the data has.
-    start, end, _ = _resolve_window(timeframe, start, end)
-    rows = await repo.get_confluence_history(ticker, timeframe, start, end, limit)
-    payload = build_confluence_payload(
-        ticker, timeframe, rows, generated_at=datetime.now(timezone.utc)
+    return await _confluence_response(request, symbol, timeframe, start, end, limit)
+
+
+# --- deprecated flat aliases ------------------------------------------------------
+
+
+@router.get("/bars/{ticker}")
+async def get_bars(
+    ticker: str,
+    request: Request,
+    response: Response,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: int = Query(default=_DEFAULT_BARS, description="tail-slice to N bars; <=0 for all"),
+) -> dict:
+    """DEPRECATED alias for /v1/equity/{symbol}/bars."""
+    _mark_deprecated(response, f"/v1/equity/{ticker}/bars")
+    return await _bars_response(
+        request, "equity", ticker, timeframe, start, end, limit, None, "listed"
     )
-    validate_payload(payload, "confluence_payload")
-    return payload
+
+
+@router.get("/indicators/{ticker}")
+async def get_indicators(
+    ticker: str,
+    request: Request,
+    response: Response,
+    indicator: str,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: int = Query(default=_DEFAULT_BARS, description="tail-slice to N bars; <=0 for all"),
+) -> dict:
+    """DEPRECATED alias for /v1/equity/{symbol}/indicators."""
+    _mark_deprecated(response, f"/v1/equity/{ticker}/indicators")
+    return await _indicators_response(
+        request, "equity", ticker, indicator, timeframe, start, end, limit
+    )
+
+
+@router.get("/confluence/{ticker}")
+async def get_confluence(
+    ticker: str,
+    request: Request,
+    response: Response,
+    timeframe: str = "1d",
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: int = Query(default=500, ge=1, le=5000),
+) -> dict:
+    """DEPRECATED alias for /v1/equity/{symbol}/confluence."""
+    _mark_deprecated(response, f"/v1/equity/{ticker}/confluence")
+    return await _confluence_response(request, ticker, timeframe, start, end, limit)

--- a/src/api/routes/chart.py
+++ b/src/api/routes/chart.py
@@ -14,7 +14,7 @@ Mirrors the signal contract: REST backfill + validate-on-egress on every respons
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Optional, Tuple
+from typing import Optional
 
 from fastapi import APIRouter, Query, Request, Response
 
@@ -26,178 +26,32 @@ from src.api.payload.chart import (
     build_rates_series_payload,
 )
 from src.api.payload.validate import validate_payload
+from src.api.routes._chart_guards import (
+    _DEFAULT_BARS,
+    _artifact_exists,
+    _check_listing,
+    _check_timeframe,
+    _contract_identity,
+    _provider_or_raise,
+    _require_bars_payload,
+    _resolve_window,
+    _silver_revision,
+    _spec_or_raise,
+)
 from src.application.chart.indicator_compute import (
-    DEFAULT_TF_DELTA,
-    TF_DELTAS,
     UnknownIndicatorError,
     compute_indicator_series,
 )
 from src.domain.signals.indicators.registry import get_indicator_registry
-from src.infrastructure.adapters.livewire.asset_classes import (
-    AssetClassSpec,
-    UnknownAssetClass,
-    get_asset_class,
-)
 from src.infrastructure.adapters.livewire.ohlc_provider import AdjustedDataUnavailable
-from src.infrastructure.adapters.livewire.paths import delisted_bronze_path, parquet_path
+from src.infrastructure.adapters.livewire.paths import parquet_path
 
 router = APIRouter(tags=["chart"])
 
 # Default no-arg window: the most recent N bars. We over-fetch in calendar time
 # (markets aren't 24/7, so N*delta would under-cover across closures) then tail-slice
 # to exactly N. Callers wanting an exact range pass start/end.
-_DEFAULT_BARS = 2000
-_LOOKBACK_FUDGE = 10
-
 _SUNSET = "Wed, 31 Dec 2026 23:59:59 GMT"
-
-
-def _resolve_window(
-    timeframe: str,
-    start: Optional[datetime],
-    end: Optional[datetime],
-    bars: int = _DEFAULT_BARS,
-) -> Tuple[datetime, datetime, Optional[int]]:
-    """Return (start, end, tail_limit). When start is omitted, fetch a generous
-    lookback and tail-slice to `bars`; an explicit start is honoured as-is."""
-    end = end or datetime.now(timezone.utc)
-    if start is None:
-        if bars <= 0:  # full history: no tail-slice, fetch from the epoch
-            return datetime(1970, 1, 1, tzinfo=timezone.utc), end, None
-        delta = TF_DELTAS.get(timeframe, DEFAULT_TF_DELTA)
-        start = end - delta * bars * _LOOKBACK_FUDGE
-        return start, end, bars
-    return start, end, None
-
-
-def _silver_revision(request: Request) -> Optional[int]:
-    """The revision the payload's adjusted prices were built from.
-
-    Sourced from the running watcher's ``last_fully_applied_revision`` -- NOT
-    ``observed_revision``, which may be a revision apex has seen but not finished
-    applying. There is no ``app.state.silver_revision``; the watcher owns this.
-    """
-    watcher = getattr(request.app.state, "revision_watcher", None)
-    return getattr(watcher, "last_fully_applied_revision", None) if watcher else None
-
-
-def _contract_identity(spec: AssetClassSpec, bars: list) -> Optional[dict]:
-    """Futures instrument identity, lifted off the first bar.
-
-    livewire stores contract_id / root_symbol / expiry_date as per-row columns on
-    asset_class=futures and they are constant across a contract's rows. Every other
-    class returns None.
-    """
-    if spec.name != "futures" or not bars:
-        return None
-    first = bars[0]
-    root = getattr(first, "root_symbol", None)
-    if root is None:
-        return None
-    return {
-        "contract_id": getattr(first, "contract_id", None),
-        "root_symbol": root,
-        "expiry_date": getattr(first, "expiry_date", None),  # already an ISO string
-    }
-
-
-def _provider_or_raise(request: Request) -> Any:
-    provider = getattr(request.app.state, "ohlc_provider", None)
-    if provider is None:
-        raise ApiError(ApiErrorCode.PROVIDER_NOT_CONFIGURED, "bar provider not configured")
-    return provider
-
-
-def _spec_or_raise(asset_class: str) -> AssetClassSpec:
-    try:
-        return get_asset_class(asset_class)
-    except UnknownAssetClass as exc:
-        raise ApiError(
-            ApiErrorCode.UNSUPPORTED_ASSET_CLASS, str(exc), asset_class=asset_class
-        ) from exc
-
-
-def _require_bars_payload(spec: AssetClassSpec, symbol: str) -> None:
-    """Reject a class whose payload is not bars.
-
-    `rates` is registered in the asset-class registry (so paths and discovery work) but a
-    yield has no OHLC and cannot satisfy bars_payload.schema.json. Without this the generic
-    route would read the parquet, build a payload of null prices, and fail egress validation
-    as a 500 instead of telling the caller which route to use.
-    """
-    if spec.payload != "bars":
-        raise ApiError(
-            ApiErrorCode.UNSUPPORTED_ASSET_CLASS,
-            f"{spec.name} is not an OHLCV class; use /v1/{spec.name}/{{symbol}}/series",
-            symbol=symbol,
-            asset_class=spec.name,
-        )
-
-
-def _check_timeframe(spec: AssetClassSpec, timeframe: str) -> None:
-    if timeframe not in spec.timeframes:
-        raise ApiError(
-            ApiErrorCode.UNSUPPORTED_TIMEFRAME,
-            f"unsupported timeframe {timeframe!r} for {spec.name} "
-            f"(have {list(spec.timeframes)})",
-            asset_class=spec.name,
-        )
-
-
-def _is_dual_resident(provider: Any, symbol: str) -> bool:
-    """True when ``symbol`` exists in BOTH the live and delisted bronze trees.
-
-    Prefers a provider-supplied answer so test doubles need no filesystem; falls back to
-    probing bronze-delisted/. With no delisted root configured, nothing is dual-resident.
-    """
-    probe = getattr(provider, "is_dual_resident", None)
-    if probe is not None:
-        return bool(probe(symbol))
-    delisted_root = getattr(provider, "delisted_root", None)
-    return delisted_root is not None and delisted_bronze_path(delisted_root, symbol).exists()
-
-
-def _check_listing(provider: Any, listing: str, symbol: str, asset_class: str) -> str:
-    """Resolve the ``listing`` filter to a listing_status, or fail with a typed code.
-
-    ``delisted`` is specified but blocked upstream: livewire has no Silver tree for
-    bronze-delisted/, and no delisted symbol has correct corporate-action data
-    (measured 2026-08-23). Serving raw delisted bars would trade survivorship bias
-    for silent mis-adjustment, so we fail loudly instead.
-
-    ``any`` resolves to ``listed`` unless the ticker is genuinely dual-resident, in which
-    case it is a 409: 2,345 tickers exist in BOTH the live and delisted trees (ticker
-    reuse), so for those "either" has no single correct answer.
-    """
-    if listing == "listed":
-        return "listed"
-    if listing == "any":
-        # Only ambiguous when the ticker really is dual-resident. 2,345 of 8,620 delisted
-        # symbols are also live; for the other ~12,400 live symbols "any" has exactly one
-        # answer, so 409-ing all of them would be noise.
-        if _is_dual_resident(provider, symbol):
-            raise ApiError(
-                ApiErrorCode.AMBIGUOUS_SYMBOL,
-                f"{symbol} resolves to both a live and a delisted entity; "
-                "request listing=listed or listing=delisted explicitly",
-                symbol=symbol,
-                asset_class=asset_class,
-            )
-        return "listed"
-    if listing != "delisted":
-        raise ApiError(
-            ApiErrorCode.UNKNOWN_SYMBOL,
-            f"unknown listing filter {listing!r} (have listed, delisted, any)",
-            symbol=symbol,
-            asset_class=asset_class,
-        )
-    raise ApiError(
-        ApiErrorCode.NOT_YET_AVAILABLE,
-        "delisted coverage requires upstream livewire work "
-        "(instrument identity, corporate-action backfill, Silver over bronze-delisted)",
-        symbol=symbol,
-        asset_class=asset_class,
-    )
 
 
 async def _bars_response(
@@ -211,14 +65,17 @@ async def _bars_response(
     price_mode: Optional[str],
     listing: str,
 ) -> dict:
-    provider = _provider_or_raise(request)
+    # Request validation first: a malformed request is malformed whether or not the
+    # provider happens to be up, and answering it with 503 tells the caller to retry
+    # something that can never succeed.
     spec = _spec_or_raise(asset_class)
     _require_bars_payload(spec, symbol)
     _check_timeframe(spec, timeframe)
+    provider = _provider_or_raise(request)
     listing_status = _check_listing(provider, listing, symbol, spec.name)
     if price_mode is not None and price_mode not in ("raw", "adjusted"):
         raise ApiError(
-            ApiErrorCode.UNSUPPORTED_ASSET_CLASS,
+            ApiErrorCode.INVALID_PARAMETER,
             f"unknown price_mode {price_mode!r} (have raw, adjusted)",
             symbol=symbol,
             asset_class=spec.name,
@@ -244,7 +101,7 @@ async def _bars_response(
         raise ApiError(
             ApiErrorCode.ADJUSTED_UNAVAILABLE, str(exc), symbol=symbol, asset_class=spec.name
         ) from exc
-    if not bars and not parquet_path(provider.bronze_root, symbol, timeframe, spec.name).exists():
+    if not bars and not _artifact_exists(provider, symbol, timeframe, spec, effective):
         # Distinguish "no artifact" from "artifact exists, window is empty". The second is a
         # legitimate 200 with zero bars (a quiet window); the first is a 404.
         raise ApiError(
@@ -280,9 +137,13 @@ async def _indicators_response(
     end: Optional[datetime],
     limit: int,
 ) -> dict:
-    provider = _provider_or_raise(request)
     spec = _spec_or_raise(asset_class)
+    # A yield has no OHLC. Without this the rates parquet is read into BarData with
+    # null prices and the indicator computes over them, returning 200 and null
+    # bar_close -- a number-shaped answer to a question that has no answer.
+    _require_bars_payload(spec, symbol)
     _check_timeframe(spec, timeframe)
+    provider = _provider_or_raise(request)
     registry = getattr(request.app.state, "indicator_registry", None) or get_indicator_registry()
     start, end, tail = _resolve_window(timeframe, start, end, limit)
     try:
@@ -297,8 +158,10 @@ async def _indicators_response(
             asset_class=spec.name,
         )
     except UnknownIndicatorError as exc:
+        # The symbol is fine; the `indicator` QUERY VALUE is not. Reporting this as
+        # unknown_symbol sent callers to check their ticker.
         raise ApiError(
-            ApiErrorCode.UNKNOWN_SYMBOL,
+            ApiErrorCode.INVALID_PARAMETER,
             f"unknown indicator: {indicator}",
             symbol=symbol,
             asset_class=spec.name,
@@ -307,6 +170,18 @@ async def _indicators_response(
         raise ApiError(
             ApiErrorCode.ADJUSTED_UNAVAILABLE, str(exc), symbol=symbol, asset_class=spec.name
         ) from exc
+    if not points and not _artifact_exists(
+        provider, symbol, timeframe, spec, provider.effective_price_mode(spec.name)
+    ):
+        # Same rule as /bars, and probed only on an empty result so the happy path
+        # costs no extra stat(): no artifact is a 404, an empty window over a real
+        # one is a legitimate 200.
+        raise ApiError(
+            ApiErrorCode.UNKNOWN_SYMBOL,
+            f"no artifact for {symbol} under {spec.partition}",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
     if tail is not None:
         points = points[-tail:]
     payload = build_indicator_payload(
@@ -375,8 +250,19 @@ async def get_rates_series_v1(
     end: Optional[datetime] = None,
 ) -> dict:
     provider = _provider_or_raise(request)
+    spec = _spec_or_raise("rates")
     start, end, _ = _resolve_window("1d", start, end, 0)
     points = await provider.fetch_rate_series(symbol, start, end)
+    if not points and not parquet_path(provider.bronze_root, symbol, "1d", spec.name).exists():
+        # Same rule as /bars: no artifact is a 404, an empty window over a real
+        # artifact is a legitimate 200. Without this an unknown series answers 200
+        # with zero points, which reads as "this yield had no observations".
+        raise ApiError(
+            ApiErrorCode.UNKNOWN_SYMBOL,
+            f"no artifact for {symbol} under {spec.partition}",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
     payload = build_rates_series_payload(symbol, points, generated_at=datetime.now(timezone.utc))
     validate_payload(payload, "rates_series_payload")
     return payload

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -28,7 +28,7 @@ async def health(request: Request) -> dict:
             "effective_price_mode": provider.price_mode if provider is not None else None,
             # From the artifacts, not livewire's 11:00 UTC coverage snapshot -- that
             # under-reports by design and would show a lag that does not exist.
-            "recency": provider.get_recency() if provider is not None else None,
+            "recency": provider.fetch_recency() if provider is not None else None,
         },
         "silver_revision": watcher.health() if watcher is not None else {"enabled": False},
     }

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -26,6 +26,9 @@ async def health(request: Request) -> dict:
             "configured": provider is not None,
             "configured_price_mode": getattr(request.app.state, "livewire_price_mode", "raw"),
             "effective_price_mode": provider.price_mode if provider is not None else None,
+            # From the artifacts, not livewire's 11:00 UTC coverage snapshot -- that
+            # under-reports by design and would show a lag that does not exist.
+            "recency": provider.get_recency() if provider is not None else None,
         },
         "silver_revision": watcher.health() if watcher is not None else {"enabled": False},
     }

--- a/src/api/routes/instruments.py
+++ b/src/api/routes/instruments.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -12,6 +14,8 @@ from src.api.payload.validate import validate_payload
 from src.infrastructure.adapters.livewire.asset_classes import UnknownAssetClass, get_asset_class
 from src.infrastructure.adapters.livewire.coverage import CoverageUnavailable
 from src.infrastructure.adapters.livewire.paths import daily_silver_path, parquet_path
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["instruments"])
 
@@ -35,6 +39,11 @@ async def list_instruments(
     limit: int = Query(default=500, ge=1, le=5000),
 ) -> dict:
     catalog = _catalog_or_raise(request)
+    if listing not in ("listed", "delisted", "any"):
+        raise ApiError(
+            ApiErrorCode.INVALID_PARAMETER,
+            f"unknown listing filter {listing!r} (have listed, delisted, any)",
+        )
     if listing != "listed":
         # The coverage table measures the live tree only; bronze-delisted/ is not in it.
         raise ApiError(
@@ -50,8 +59,14 @@ async def list_instruments(
                 ApiErrorCode.UNSUPPORTED_ASSET_CLASS, str(exc), asset_class=asset_class
             ) from exc
     try:
-        rows = catalog.list_instruments(  # type: ignore[attr-defined]
-            asset_class=asset_class, query=q, limit=limit
+        # DuckDB is synchronous and the catalog lives on the same external volume
+        # as the lake; running it inline stalls every other request on this worker
+        # for the duration of the read. Same treatment the bars path already gets.
+        rows = await asyncio.to_thread(
+            catalog.list_instruments,  # type: ignore[attr-defined]
+            asset_class=asset_class,
+            query=q,
+            limit=limit,
         )
     except CoverageUnavailable as exc:
         # An unreadable catalog is NOT an empty universe. Reporting zero instruments
@@ -138,10 +153,18 @@ async def get_instrument(asset_class: str, symbol: str, request: Request) -> dic
     # Probe the artifacts: the coverage table measures no equity intraday, so it
     # cannot answer this. Five exists() calls is fine for one symbol; it is exactly
     # why the LIST endpoint does not do it 14,746 times.
+    silver_daily = (
+        spec.supports_adjusted
+        and provider.silver_root is not None
+        and daily_silver_path(provider.silver_root, symbol).exists()
+    )
     timeframes = [
         tf
         for tf in spec.timeframes
+        # Silver can outlive its Bronze source, so a Bronze-only probe would omit "1d"
+        # from a symbol that /bars will happily serve in adjusted mode.
         if parquet_path(provider.bronze_root, symbol, tf, spec.name).exists()
+        or (tf == "1d" and silver_daily)
     ]
     if not timeframes:
         raise ApiError(
@@ -150,23 +173,30 @@ async def get_instrument(asset_class: str, symbol: str, request: Request) -> dic
             symbol=symbol,
             asset_class=spec.name,
         )
-    silver_available = False
-    if spec.supports_adjusted and provider.silver_root is not None:
-        silver_available = daily_silver_path(provider.silver_root, symbol).exists()
+    silver_available = silver_daily
     catalog = getattr(request.app.state, "coverage_catalog", None)
     dates = None
+    # Names WHY first_date/last_date are null, so an unreadable catalog cannot hide
+    # behind a symbol that genuinely has no recorded coverage. Not fatal here:
+    # timeframes and silver_available came from disk and are still correct.
+    coverage_source = "not_configured" if catalog is None else "livewire_coverage_snapshot"
     if catalog is not None:
         try:
-            dates = catalog.get_instrument(symbol, spec.name)
-        except CoverageUnavailable:
+            dates = await asyncio.to_thread(catalog.get_instrument, symbol, spec.name)
+        except CoverageUnavailable as exc:
             # Detail degrades to artifact-only facts rather than failing: the
-            # timeframes above came from disk and are still correct.
+            # timeframes above came from disk and are still correct. Logged, not
+            # swallowed -- silently nulling the dates would hide a broken catalog
+            # mount behind a 200.
+            logger.warning("coverage catalog unreadable, serving %s without dates: %s", symbol, exc)
             dates = None
+            coverage_source = "unavailable"
     return {
         "symbol": symbol,
         "asset_class": spec.name,
         "listing_status": "listed",
         "timeframes": timeframes,
+        "coverage_source": coverage_source,
         "first_date": dates.first_date if dates else None,
         "last_date": dates.last_date if dates else None,
         "silver_available": silver_available,

--- a/src/api/routes/instruments.py
+++ b/src/api/routes/instruments.py
@@ -80,6 +80,44 @@ async def list_instruments(
     return payload
 
 
+_UPSTREAM_BLOCKER = (
+    "blocked on livewire: permanent instrument identity, corporate-action backfill "
+    "for the delisted universe, and Silver over bronze-delisted"
+)
+
+
+@router.get("/v1/equity/{symbol}/actions")
+async def get_corporate_actions(symbol: str) -> dict:
+    """Corporate actions behind a symbol's adjustment.
+
+    Not yet served: the store is ticker-keyed and scoped to the live universe, so it
+    cannot be trusted for any symbol whose ticker was reused. Measured 2026-08-23 --
+    6,275 delisted symbols have no corporate-action data at all, and the 2,345 that
+    appear to are ticker reuses whose actions belong to a different, living company.
+    """
+    raise ApiError(
+        ApiErrorCode.NOT_YET_AVAILABLE,
+        f"corporate actions are not exposed yet -- {_UPSTREAM_BLOCKER}",
+        symbol=symbol,
+        asset_class="equity",
+    )
+
+
+@router.get("/v1/equity/{symbol}/delisting")
+async def get_delisting(symbol: str) -> dict:
+    """Terminal state: delist date, reason, final consideration.
+
+    Nothing in the lake records these today, and serving delisted bars without them
+    turns a bankruptcy into a flat exit.
+    """
+    raise ApiError(
+        ApiErrorCode.NOT_YET_AVAILABLE,
+        f"delisting metadata does not exist upstream yet -- {_UPSTREAM_BLOCKER}",
+        symbol=symbol,
+        asset_class="equity",
+    )
+
+
 # Route ordering is NOT a constraint here: Starlette matches on the whole path pattern,
 # so /v1/{asset_class}/{symbol} (two segments) can never shadow /v1/instruments (one)
 # nor /v1/equity/{symbol}/bars (three). Verified empirically in both registration orders.

--- a/src/api/routes/instruments.py
+++ b/src/api/routes/instruments.py
@@ -11,6 +11,7 @@ from src.api.errors import ApiError, ApiErrorCode
 from src.api.payload.validate import validate_payload
 from src.infrastructure.adapters.livewire.asset_classes import UnknownAssetClass, get_asset_class
 from src.infrastructure.adapters.livewire.coverage import CoverageUnavailable
+from src.infrastructure.adapters.livewire.paths import daily_silver_path, parquet_path
 
 router = APIRouter(tags=["instruments"])
 
@@ -77,3 +78,69 @@ async def list_instruments(
     }
     validate_payload(payload, "instruments_payload")
     return payload
+
+
+# Route ordering is NOT a constraint here: Starlette matches on the whole path pattern,
+# so /v1/{asset_class}/{symbol} (two segments) can never shadow /v1/instruments (one)
+# nor /v1/equity/{symbol}/bars (three). Verified empirically in both registration orders.
+@router.get("/v1/{asset_class}/{symbol}")
+async def get_instrument(asset_class: str, symbol: str, request: Request) -> dict:
+    """One instrument's detail, including the timeframes that actually exist on disk."""
+    try:
+        spec = get_asset_class(asset_class)
+    except UnknownAssetClass as exc:
+        raise ApiError(
+            ApiErrorCode.UNSUPPORTED_ASSET_CLASS, str(exc), asset_class=asset_class
+        ) from exc
+    provider = getattr(request.app.state, "ohlc_provider", None)
+    if provider is None:
+        raise ApiError(
+            ApiErrorCode.PROVIDER_NOT_CONFIGURED, "bar provider not configured", symbol=symbol
+        )
+    # Probe the artifacts: the coverage table measures no equity intraday, so it
+    # cannot answer this. Five exists() calls is fine for one symbol; it is exactly
+    # why the LIST endpoint does not do it 14,746 times.
+    timeframes = [
+        tf
+        for tf in spec.timeframes
+        if parquet_path(provider.bronze_root, symbol, tf, spec.name).exists()
+    ]
+    if not timeframes:
+        raise ApiError(
+            ApiErrorCode.UNKNOWN_SYMBOL,
+            f"no artifact for {symbol} under {spec.partition}",
+            symbol=symbol,
+            asset_class=spec.name,
+        )
+    silver_available = False
+    if spec.supports_adjusted and provider.silver_root is not None:
+        silver_available = daily_silver_path(provider.silver_root, symbol).exists()
+    catalog = getattr(request.app.state, "coverage_catalog", None)
+    dates = None
+    if catalog is not None:
+        try:
+            dates = catalog.get_instrument(symbol, spec.name)
+        except CoverageUnavailable:
+            # Detail degrades to artifact-only facts rather than failing: the
+            # timeframes above came from disk and are still correct.
+            dates = None
+    return {
+        "symbol": symbol,
+        "asset_class": spec.name,
+        "listing_status": "listed",
+        "timeframes": timeframes,
+        "first_date": dates.first_date if dates else None,
+        "last_date": dates.last_date if dates else None,
+        "silver_available": silver_available,
+        "price_mode": provider.effective_price_mode(spec.name),
+        "adjustment_revision": (
+            getattr(
+                getattr(request.app.state, "revision_watcher", None),
+                "last_fully_applied_revision",
+                None,
+            )
+            if silver_available
+            else None
+        ),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/src/api/routes/instruments.py
+++ b/src/api/routes/instruments.py
@@ -1,0 +1,79 @@
+"""Discovery: what does apex hold, and which symbols would fail in adjusted mode."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Query, Request
+
+from src.api.errors import ApiError, ApiErrorCode
+from src.api.payload.validate import validate_payload
+from src.infrastructure.adapters.livewire.asset_classes import UnknownAssetClass, get_asset_class
+from src.infrastructure.adapters.livewire.coverage import CoverageUnavailable
+
+router = APIRouter(tags=["instruments"])
+
+
+def _catalog_or_raise(request: Request) -> object:
+    catalog = getattr(request.app.state, "coverage_catalog", None)
+    if catalog is None:
+        raise ApiError(
+            ApiErrorCode.PROVIDER_NOT_CONFIGURED,
+            "coverage catalog not configured (set APEX_LIVEWIRE_COVERAGE_DB)",
+        )
+    return catalog
+
+
+@router.get("/v1/instruments")
+async def list_instruments(
+    request: Request,
+    asset_class: Optional[str] = None,
+    q: Optional[str] = Query(default=None, description="symbol prefix filter"),
+    listing: str = Query(default="listed", description="listed | delisted"),
+    limit: int = Query(default=500, ge=1, le=5000),
+) -> dict:
+    catalog = _catalog_or_raise(request)
+    if listing != "listed":
+        # The coverage table measures the live tree only; bronze-delisted/ is not in it.
+        raise ApiError(
+            ApiErrorCode.NOT_YET_AVAILABLE,
+            "delisted discovery requires upstream livewire work "
+            "(instrument identity, corporate-action backfill, Silver over bronze-delisted)",
+        )
+    if asset_class is not None:
+        try:
+            get_asset_class(asset_class)
+        except UnknownAssetClass as exc:
+            raise ApiError(
+                ApiErrorCode.UNSUPPORTED_ASSET_CLASS, str(exc), asset_class=asset_class
+            ) from exc
+    try:
+        rows = catalog.list_instruments(  # type: ignore[attr-defined]
+            asset_class=asset_class, query=q, limit=limit
+        )
+    except CoverageUnavailable as exc:
+        # An unreadable catalog is NOT an empty universe. Reporting zero instruments
+        # would let a broken deployment masquerade as a correct one.
+        raise ApiError(ApiErrorCode.PROVIDER_NOT_CONFIGURED, str(exc)) from exc
+    payload = {
+        "instruments": [
+            {
+                "symbol": r.symbol,
+                "asset_class": r.asset_class,
+                "listing_status": r.listing_status,
+                "first_date": r.first_date,
+                "last_date": r.last_date,
+                "silver_available": r.silver_available,
+                "price_mode": r.price_mode,
+            }
+            for r in rows
+        ],
+        "count": len(rows),
+        # These dates come from livewire's 11:00 UTC coverage snapshot, not from the
+        # artifacts. Labelled so a consumer does not mistake them for live values.
+        "source": "livewire_coverage_snapshot",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    validate_payload(payload, "instruments_payload")
+    return payload

--- a/src/api/routes/signals.py
+++ b/src/api/routes/signals.py
@@ -5,22 +5,44 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request, Response
 
+from src.api.errors import ApiError, ApiErrorCode
 from src.api.payload.builder import build_payload
 from src.api.payload.validate import validate_payload
 
 router = APIRouter(tags=["signals"])
 
+_SUNSET = "Wed, 31 Dec 2026 23:59:59 GMT"
 
-@router.get("/signals/{ticker}")
-async def get_signals(ticker: str, request: Request, since: Optional[datetime] = None) -> dict:
+
+async def _signals_payload(ticker: str, request: Request, since: Optional[datetime]) -> dict:
     repo = getattr(request.app.state, "signal_repo", None)
     if repo is None:
         # No Postgres configured -> backfill unavailable (the live WS push still
         # works). Be explicit rather than 500 on a None repo.
-        raise HTTPException(status_code=503, detail="signal persistence not configured")
+        raise ApiError(
+            ApiErrorCode.PROVIDER_NOT_CONFIGURED,
+            "signal persistence not configured",
+            symbol=ticker,
+        )
     rows = await repo.fetch_signals(ticker, since=since)
     payload = build_payload(rows, generated_at=datetime.now(timezone.utc))
     validate_payload(payload)  # contract guarantee on every REST response
     return payload
+
+
+@router.get("/v1/equity/{symbol}/signals")
+async def get_signals_v1(symbol: str, request: Request, since: Optional[datetime] = None) -> dict:
+    return await _signals_payload(symbol, request, since)
+
+
+@router.get("/signals/{ticker}")
+async def get_signals(
+    ticker: str, request: Request, response: Response, since: Optional[datetime] = None
+) -> dict:
+    """DEPRECATED alias for /v1/equity/{symbol}/signals."""
+    response.headers["Deprecation"] = "true"
+    response.headers["Sunset"] = _SUNSET
+    response.headers["Link"] = f'</v1/equity/{ticker}/signals>; rel="successor-version"'
+    return await _signals_payload(ticker, request, since)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -57,6 +57,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     livewire_root = os.environ.get("APEX_LIVEWIRE_ROOT")
     silver_root = os.environ.get("APEX_LIVEWIRE_SILVER_ROOT")
     livewire_price_mode = os.environ.get("APEX_LIVEWIRE_PRICE_MODE", "raw")
+    # Residency probe only -- detects ticker reuse for listing=any. apex never
+    # serves bars from the delisted tree (blocked on livewire, spec 2.3).
+    delisted_root = os.environ.get("APEX_LIVEWIRE_DELISTED_ROOT")
     if livewire_price_mode not in ("raw", "adjusted"):
         raise ValueError(f"unsupported Livewire price mode: {livewire_price_mode!r}")
     app.state.livewire_price_mode = livewire_price_mode
@@ -117,6 +120,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     bronze_root=Path(livewire_root),
                     silver_root=Path(silver_root) if silver_root else None,
                     price_mode=cast("PriceMode", livewire_price_mode),
+                    delisted_root=Path(delisted_root) if delisted_root else None,
                 )
                 logger.info("Bar provider ready (chart read surface enabled)")
         if getattr(app.state, "indicator_registry", None) is None:

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -123,6 +123,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     delisted_root=Path(delisted_root) if delisted_root else None,
                 )
                 logger.info("Bar provider ready (chart read surface enabled)")
+        if getattr(app.state, "coverage_catalog", None) is None:
+            app.state.coverage_catalog = None
+            coverage_db = os.environ.get("APEX_LIVEWIRE_COVERAGE_DB")
+            if coverage_db:
+                from pathlib import Path
+
+                from src.infrastructure.adapters.livewire.coverage import CoverageCatalog
+
+                app.state.coverage_catalog = CoverageCatalog(Path(coverage_db))
+                logger.info("Coverage catalog ready (/v1/instruments enabled)")
         if getattr(app.state, "indicator_registry", None) is None:
             from src.domain.signals.indicators.registry import get_indicator_registry
 
@@ -277,6 +287,10 @@ def create_app() -> FastAPI:
     from src.api.routes.chart import router as chart_router
 
     app.include_router(chart_router)
+
+    from src.api.routes.instruments import router as instruments_router
+
+    app.include_router(instruments_router)
 
     # Routes raise ApiError; this renders it as the typed envelope instead of a bare 500.
     install_error_handlers(app)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -11,6 +11,7 @@ import asyncpg
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from src.api.errors import install_error_handlers
 from src.api.jobs.manager import JobManager
 from src.api.routes.backtest import router as backtest_router
 from src.api.routes.health import router as health_router
@@ -272,6 +273,9 @@ def create_app() -> FastAPI:
     from src.api.routes.chart import router as chart_router
 
     app.include_router(chart_router)
+
+    # Routes raise ApiError; this renders it as the typed envelope instead of a bare 500.
+    install_error_handlers(app)
 
     return app
 

--- a/src/application/chart/indicator_compute.py
+++ b/src/application/chart/indicator_compute.py
@@ -65,10 +65,12 @@ async def compute_indicator_series(
     end: datetime,
     *,
     safety: int = 3,
+    asset_class: str = "equity",
 ) -> List[Dict[str, Any]]:
     """Return ``[{time, state, bar_close}]`` for ``indicator`` over ``[start, end]``.
 
-    ``provider`` must expose ``async fetch_bars(symbol, timeframe, start, end)``;
+    ``provider`` must expose
+    ``async fetch_bars(symbol, timeframe, start, end, asset_class=...)``;
     ``registry`` must expose ``get(name)``. ``safety`` multiplies the warmup lead to
     cover non-trading gaps (weekends/holidays) when converting bar-count to time.
     """
@@ -80,7 +82,7 @@ async def compute_indicator_series(
     warmup = max(int(getattr(ind, "warmup_periods", 0)), 0)
     fetch_start = start - delta * warmup * max(safety, 1)
 
-    bars = await provider.fetch_bars(symbol, timeframe, fetch_start, end)
+    bars = await provider.fetch_bars(symbol, timeframe, fetch_start, end, asset_class=asset_class)
     if not bars:
         return []
 

--- a/src/domain/events/domain_events.py
+++ b/src/domain/events/domain_events.py
@@ -221,6 +221,18 @@ class BarData(DomainEvent):
     vwap: Optional[float] = None  # Volume-weighted average price
     trade_count: Optional[int] = None  # Number of trades in bar
 
+    # Futures-only extras, from livewire's asset_class=futures partition. Every field
+    # needs a default: BarData is frozen+slots, so the generated __init__ forbids a
+    # non-default after a default, and a slots class has no __dict__ to patch later.
+    settlement: Optional[float] = None
+    open_interest: Optional[int] = None
+    contract_id: Optional[int] = None
+    root_symbol: Optional[str] = None  # e.g. "BZ"
+    # ISO string, NOT a date. to_dict() serializes via asdict() and special-cases only
+    # datetime and Enum; a bare date would survive as a live object and break JSON
+    # persistence. datetime subclasses date, so the datetime branch does not catch it.
+    expiry_date: Optional[str] = None
+
     # Bar time boundaries
     bar_start: Optional[datetime] = None
     bar_end: Optional[datetime] = None

--- a/src/infrastructure/adapters/livewire/asset_classes.py
+++ b/src/infrastructure/adapters/livewire/asset_classes.py
@@ -1,0 +1,112 @@
+"""The asset-class registry: one row per partition livewire publishes.
+
+This module is the seam that makes the read surface extendible. Route dispatch,
+path construction, timeframe validation, payload selection and adjustment policy all
+resolve through ``get_asset_class`` -- adding a seventh class is a row here, not a
+new route.
+
+Verified against the production lake (macmini:/Volumes/DATA_LAKE/livewire/data-lake)
+on 2026-08-23. Three distinct parquet schemas exist:
+
+  * OHLCV        equity, volatility, fx, cmdty
+  * OHLCV+       futures, which adds settlement / open_interest / contract identity
+  * rates        trade_date + tenor_years + yield_pct -- a yield, not a price
+
+``timeframes`` is the ladder the *class* publishes, measured by enumerating every
+symbol directory in each non-equity partition. It is a capability ceiling, not a
+per-symbol guarantee: 30 of 44 volatility symbols carry only ``1d``, and a request
+for a timeframe a given symbol lacks reads an absent file and yields no bars.
+
+Silver exists ONLY under asset_class=equity, so no other class may serve adjusted
+prices. ``supports_adjusted`` encodes that; it is not a preference.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEFAULT_ASSET_CLASS = "equity"
+
+
+class UnknownAssetClass(ValueError):
+    """Raised when a caller names an asset class the lake does not publish."""
+
+
+@dataclass(frozen=True)
+class AssetClassSpec:
+    """Everything the read path needs to know about one lake partition."""
+
+    name: str
+    partition: str
+    timeframes: tuple[str, ...]
+    payload: str
+    supports_adjusted: bool
+    extra_bar_fields: tuple[str, ...] = ()
+
+
+# Ordered finest-to-coarsest; error messages and consumers both rely on the order.
+_FULL_LADDER = ("1m", "5m", "30m", "1h", "1d")
+# Measured union across all 44 volatility symbols -- no 1m file exists anywhere.
+_VOLATILITY_LADDER = ("5m", "30m", "1h", "1d")
+_DAILY_ONLY = ("1d",)
+
+
+def _daily_ohlcv(name: str) -> AssetClassSpec:
+    return AssetClassSpec(
+        name=name,
+        partition=f"asset_class={name}",
+        timeframes=_DAILY_ONLY,
+        payload="bars",
+        supports_adjusted=False,
+    )
+
+
+ASSET_CLASSES: dict[str, AssetClassSpec] = {
+    "equity": AssetClassSpec(
+        name="equity",
+        partition="asset_class=equity",
+        timeframes=_FULL_LADDER,
+        payload="bars",
+        supports_adjusted=True,
+    ),
+    "volatility": AssetClassSpec(
+        name="volatility",
+        partition="asset_class=volatility",
+        timeframes=_VOLATILITY_LADDER,
+        payload="bars",
+        supports_adjusted=False,
+    ),
+    "fx": AssetClassSpec(
+        name="fx",
+        partition="asset_class=fx",
+        timeframes=_FULL_LADDER,
+        payload="bars",
+        supports_adjusted=False,
+    ),
+    "cmdty": _daily_ohlcv("cmdty"),
+    "futures": AssetClassSpec(
+        name="futures",
+        partition="asset_class=futures",
+        timeframes=_DAILY_ONLY,
+        payload="bars",
+        supports_adjusted=False,
+        extra_bar_fields=("settlement", "open_interest"),
+    ),
+    "rates": AssetClassSpec(
+        name="rates",
+        partition="asset_class=rates",
+        timeframes=_DAILY_ONLY,
+        payload="rates_series",
+        supports_adjusted=False,
+    ),
+}
+
+
+def get_asset_class(name: str) -> AssetClassSpec:
+    """Return the spec for ``name``, or raise ``UnknownAssetClass``."""
+    try:
+        return ASSET_CLASSES[name]
+    except KeyError:
+        raise UnknownAssetClass(
+            f"unknown asset class: {name!r} (have {sorted(ASSET_CLASSES)})"
+        ) from None

--- a/src/infrastructure/adapters/livewire/coverage.py
+++ b/src/infrastructure/adapters/livewire/coverage.py
@@ -130,6 +130,19 @@ class CoverageCatalog:
             con.close()
         return [self._to_row(r) for r in rows]
 
+    def get_instrument(self, symbol: str, asset_class: str) -> Optional[InstrumentRow]:
+        """Exact-match lookup for one instrument.
+
+        Not ``list_instruments(limit=1)``: that filters by PREFIX, so "AA" would
+        return whichever of AA/AAL/AAPL sorts first.
+        """
+        rows = [
+            r
+            for r in self.list_instruments(asset_class=asset_class, query=symbol, limit=50)
+            if r.symbol == symbol
+        ]
+        return rows[0] if rows else None
+
     @staticmethod
     def _to_row(row: dict) -> InstrumentRow:
         asset_class = _VIEW_TO_CLASS[row["view_name"]]

--- a/src/infrastructure/adapters/livewire/coverage.py
+++ b/src/infrastructure/adapters/livewire/coverage.py
@@ -1,0 +1,146 @@
+"""Read livewire's coverage catalog to answer "what does apex hold?".
+
+livewire's scheduled coverage job (com.livewire.coverage, 11:00 UTC) writes one row
+per (view_name, symbol) into analytics.duckdb. Reading it is the only affordable way
+to answer discovery: measured on the production lake 2026-08-23, one scandir of
+bronze/asset_class=equity costs 5.5s for 14,756 entries, and descending into symbols
+to read date ranges costs 78ms each -- roughly 19 minutes for the full set.
+
+The table is a SNAPSHOT, so first_date/last_date lag reality by up to a day. Callers
+must present these as snapshot-derived, not live. Measured 2026-08-23: the table is
+also incomplete -- it covers 7 of the 13 views livewire's duckdb_catalog declares, so
+equity intraday coverage is invisible here.
+
+An unreadable catalog RAISES rather than returning an empty list. That distinction is
+load-bearing: on the mini, binding a catalog path outside colima's VM mount set makes
+Docker fabricate an empty directory at that path, and Path.exists() answers True for a
+directory. Degrading to [] would make a broken deployment indistinguishable from a
+genuinely empty lake.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+# coverage.view_name -> asset class. Silver views are folded into the equity rows as
+# the silver_available flag rather than listed as their own class.
+_VIEW_TO_CLASS = {
+    "bronze_equity_1d": "equity",
+    "bronze_volatility_1d": "volatility",
+    "bronze_fx_1d": "fx",
+    "bronze_futures_1d": "futures",
+    "bronze_cmdty_1d": "cmdty",
+    "bronze_rates_1d": "rates",
+}
+_SILVER_VIEW = "silver_equity_1d"
+
+
+class CoverageUnavailable(RuntimeError):
+    """Raised when the coverage catalog cannot be read at all.
+
+    Distinct from "the catalog is readable and matched nothing", which is an empty list.
+    """
+
+
+@dataclass(frozen=True)
+class InstrumentRow:
+    """One instrument's coverage, as of livewire's last snapshot."""
+
+    symbol: str
+    asset_class: str
+    listing_status: str
+    first_date: Optional[str]
+    last_date: Optional[str]
+    silver_available: bool
+    price_mode: str
+
+
+class CoverageCatalog:
+    """Read-only view over livewire's coverage table."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    def list_instruments(
+        self,
+        asset_class: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = 500,
+    ) -> List[InstrumentRow]:
+        """Return coverage rows, filtered and capped.
+
+        Raises ``CoverageUnavailable`` when the catalog is absent or unreadable.
+        """
+        # is_file(), NOT exists(): a broken bind mount leaves a DIRECTORY here, and
+        # exists() would happily accept it.
+        if not self._db_path.is_file():
+            raise CoverageUnavailable(f"coverage catalog is not a readable file: {self._db_path}")
+        views = (
+            [v for v, c in _VIEW_TO_CLASS.items() if c == asset_class]
+            if asset_class
+            else list(_VIEW_TO_CLASS)
+        )
+        if not views:
+            return []
+        placeholders = ", ".join("?" for _ in views)
+        sql = f"""
+            SELECT b.view_name, b.symbol, b.first_date, b.last_date,
+                   (s.symbol IS NOT NULL) AS has_silver
+            FROM coverage b
+            LEFT JOIN coverage s
+              ON s.view_name = '{_SILVER_VIEW}' AND s.symbol = b.symbol
+            WHERE b.view_name IN ({placeholders})
+              AND (? IS NULL OR b.symbol LIKE ? ESCAPE '\\')
+            ORDER BY b.symbol
+            LIMIT ?
+        """
+        # '_' and '%' are LIKE wildcards, and futures symbols contain '_'
+        # (BZ_202609). Verified against the real catalog: LIKE 'BRK_B' matches
+        # 'BRK.B'. Escape them or a prefix search silently over-matches.
+        like = (
+            query.upper().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%"
+            if query
+            else None
+        )
+        params: list[object] = [*views, like, like, limit]
+        try:
+            # read_only: the catalog is bind-mounted :ro in production, and a
+            # read-write connect would try to take a lock and fail.
+            con = duckdb.connect(str(self._db_path), read_only=True)
+        except duckdb.Error as exc:
+            logger.error("cannot open coverage catalog %s: %s", self._db_path, exc)
+            raise CoverageUnavailable(f"cannot open coverage catalog: {exc}") from exc
+        try:
+            rows = con.execute(sql, params).fetch_arrow_table().to_pylist()
+        except duckdb.Error as exc:
+            logger.error("coverage query failed: %s", exc)
+            raise CoverageUnavailable(f"coverage query failed: {exc}") from exc
+        finally:
+            con.close()
+        return [self._to_row(r) for r in rows]
+
+    @staticmethod
+    def _to_row(row: dict) -> InstrumentRow:
+        asset_class = _VIEW_TO_CLASS[row["view_name"]]
+        has_silver = bool(row["has_silver"]) and asset_class == "equity"
+        return InstrumentRow(
+            symbol=row["symbol"],
+            asset_class=asset_class,
+            listing_status="listed",
+            first_date=str(row["first_date"]) if row["first_date"] is not None else None,
+            last_date=str(row["last_date"]) if row["last_date"] is not None else None,
+            silver_available=has_silver,
+            # Silver exists only for equity, so nothing else can be served adjusted.
+            price_mode="adjusted" if has_silver else "raw",
+        )

--- a/src/infrastructure/adapters/livewire/factory.py
+++ b/src/infrastructure/adapters/livewire/factory.py
@@ -13,8 +13,10 @@ def build_livewire_provider(config: Any) -> LivewireOhlcProvider:
     if not root:
         raise ValueError("livewire_bronze_root is not configured")
     silver_root = getattr(config, "livewire_silver_root", None)
+    delisted_root = getattr(config, "livewire_delisted_root", None)
     return LivewireOhlcProvider(
         bronze_root=Path(root),
         silver_root=Path(silver_root) if silver_root else None,
         price_mode=getattr(config, "livewire_price_mode", "raw"),
+        delisted_root=Path(delisted_root) if delisted_root else None,
     )

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -18,6 +18,7 @@ OHLCV at the right instants.
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -32,6 +33,8 @@ from .paths import SUPPORTED_TIMEFRAMES, daily_silver_path, factor_path, parquet
 # livewire keys daily bars by `trade_date` (a DATE) and intraday bars by
 # `bar_timestamp` (a tz-aware UTC TIMESTAMP). OHLCV columns are read by name; extra
 # columns (symbol_id, adj_close) are ignored.
+logger = logging.getLogger(__name__)
+
 _DAILY_TS_COLUMN = "trade_date"
 _INTRADAY_TS_COLUMN = "bar_timestamp"
 
@@ -224,6 +227,46 @@ class LivewireOhlcProvider:
             )
             for r in rows
         ]
+
+    def get_recency(self, reference_symbol: str = "AAPL") -> dict[str, Any]:
+        """Last trade_date in bronze and silver for a liquid reference symbol.
+
+        Read from the ARTIFACTS, not livewire's coverage table -- that table is an
+        11:00 UTC snapshot and under-reports by design. AAPL is the default probe
+        because it trades every session the market is open.
+        """
+        bronze_last = self._last_trade_date(parquet_path(self._bronze_root, reference_symbol, "1d"))
+        silver_last = (
+            self._last_trade_date(daily_silver_path(self._silver_root, reference_symbol))
+            if self._silver_root is not None
+            else None
+        )
+        lag: int | None = None
+        if bronze_last is not None and silver_last is not None:
+            # Calendar days, NOT trading sessions -- apex has no exchange calendar
+            # here, and calling a Friday/Monday gap "3 sessions" would be a lie.
+            lag = (date.fromisoformat(bronze_last) - date.fromisoformat(silver_last)).days
+        return {
+            "bronze_last_trade_date": bronze_last,
+            "silver_last_trade_date": silver_last,
+            "lag_days": lag,
+        }
+
+    @staticmethod
+    def _last_trade_date(path: Path) -> str | None:
+        if not path.exists():
+            return None
+        con = duckdb.connect(database=":memory:")
+        try:
+            row = con.execute(
+                f"SELECT max(trade_date) FROM read_parquet('{path.as_posix()}')"
+            ).fetchone()
+        except duckdb.Error as exc:
+            logger.error("recency probe failed for %s: %s", path, exc)
+            return None
+        finally:
+            con.close()
+        return str(row[0]) if row and row[0] is not None else None
 
     # --- internals ---
     def _query(

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -216,13 +216,17 @@ class LivewireOhlcProvider:
 
     def _query_rates(self, path: Path, start: datetime, end: datetime) -> List[RatePoint]:
         sql = (
-            f"SELECT trade_date, tenor_years, yield_pct "
-            f"FROM read_parquet('{path.as_posix()}') "
-            f"WHERE trade_date >= ? AND trade_date <= ? ORDER BY trade_date ASC"
+            "SELECT trade_date, tenor_years, yield_pct "
+            "FROM read_parquet(?) "
+            "WHERE trade_date >= ? AND trade_date <= ? ORDER BY trade_date ASC"
         )
         con = duckdb.connect(database=":memory:")
         try:
-            rows = con.execute(sql, [start.date(), end.date()]).fetch_arrow_table().to_pylist()
+            rows = (
+                con.execute(sql, [path.as_posix(), start.date(), end.date()])
+                .fetch_arrow_table()
+                .to_pylist()
+            )
         finally:
             con.close()
         return [
@@ -268,7 +272,7 @@ class LivewireOhlcProvider:
         con = duckdb.connect(database=":memory:")
         try:
             row = con.execute(
-                f"SELECT max(trade_date) FROM read_parquet('{path.as_posix()}')"
+                "SELECT max(trade_date) FROM read_parquet(?)", [path.as_posix()]
             ).fetchone()
         except duckdb.Error as exc:
             logger.error("recency probe failed for %s: %s", path, exc)
@@ -287,17 +291,20 @@ class LivewireOhlcProvider:
         end: datetime,
     ) -> List[BarData]:
         ts_col = _timestamp_column(timeframe)
-        # NOTE: read_parquet path is inlined (NOT a bound parameter) -- DuckDB does
-        # not accept a prepared-statement parameter for the parquet path. The path
-        # is constructed by us from a validated symbol/timeframe, not user SQL.
+        # The parquet path is a BOUND parameter, not interpolated. An earlier comment
+        # here claimed DuckDB could not bind it; measured against duckdb 1.4.3 it can,
+        # including a path containing a quote. `ts_col` is still interpolated because
+        # an identifier cannot be a parameter -- it comes from _timestamp_column, which
+        # returns one of two module constants, never caller input.
         sql = (
-            f"SELECT * FROM read_parquet('{path.as_posix()}') "
+            f"SELECT * FROM read_parquet(?) "
             f"WHERE {ts_col} >= ? AND {ts_col} <= ? ORDER BY {ts_col} ASC"
         )
         # Daily `trade_date` is a DATE -- bind calendar-date params so the comparison
         # is tz-agnostic (avoids DATE-vs-TIMESTAMPTZ session-tz surprises). Intraday
         # `bar_timestamp` is TIMESTAMPTZ -- bind the tz-aware datetimes directly.
-        params = [start.date(), end.date()] if timeframe == "1d" else [start, end]
+        window = [start.date(), end.date()] if timeframe == "1d" else [start, end]
+        params: List[Any] = [path.as_posix(), *window]
         con = duckdb.connect(database=":memory:")
         try:
             rows = con.execute(sql, params).fetch_arrow_table().to_pylist()

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -25,6 +25,7 @@ from typing import Any, List, Literal
 import duckdb
 
 from ....domain.events.domain_events import BarData
+from .asset_classes import DEFAULT_ASSET_CLASS, get_asset_class
 from .paths import SUPPORTED_TIMEFRAMES, daily_silver_path, factor_path, parquet_path
 
 # livewire keys daily bars by `trade_date` (a DATE) and intraday bars by
@@ -87,12 +88,16 @@ class LivewireOhlcProvider:
         bronze_root: Path,
         silver_root: Path | None = None,
         price_mode: PriceMode = "raw",
+        delisted_root: Path | None = None,
     ) -> None:
         if price_mode not in ("raw", "adjusted"):
             raise ValueError(f"unsupported Livewire price mode: {price_mode!r}")
         self._bronze_root = Path(bronze_root)
         self._silver_root = Path(silver_root) if silver_root is not None else None
         self._price_mode = price_mode
+        # Residency probe only -- used to detect ticker reuse for listing=any. apex
+        # never serves bars from the delisted tree; that is blocked on livewire.
+        self._delisted_root = Path(delisted_root) if delisted_root is not None else None
 
     # --- HistoricalSourcePort ---
     @property
@@ -102,6 +107,10 @@ class LivewireOhlcProvider:
     @property
     def bronze_root(self) -> Path:
         return self._bronze_root
+
+    @property
+    def delisted_root(self) -> Path | None:
+        return self._delisted_root
 
     @property
     def silver_root(self) -> Path | None:
@@ -117,15 +126,33 @@ class LivewireOhlcProvider:
     def get_supported_timeframes(self) -> List[str]:
         return list(SUPPORTED_TIMEFRAMES)
 
+    def effective_price_mode(self, asset_class: str = DEFAULT_ASSET_CLASS) -> PriceMode:
+        """The mode this provider can actually serve for ``asset_class``.
+
+        Silver exists only under asset_class=equity, so every other class is raw
+        regardless of the configured mode. Callers put this in the payload -- the
+        consumer must never have to infer the basis.
+        """
+        if self._price_mode == "adjusted" and get_asset_class(asset_class).supports_adjusted:
+            return "adjusted"
+        return "raw"
+
     async def fetch_bars(
         self,
         symbol: str,
         timeframe: str,
         start: datetime,
         end: datetime,
+        asset_class: str = DEFAULT_ASSET_CLASS,
+        price_mode: PriceMode | None = None,
     ) -> List[BarData]:
-        bronze_path = parquet_path(self._bronze_root, symbol, timeframe)
-        if self._price_mode == "raw":
+        # An explicit price_mode is a per-call override (the route passes the mode it
+        # already validated); None falls back to what this provider can serve.
+        resolved = price_mode or self.effective_price_mode(asset_class)
+        if resolved == "adjusted" and not get_asset_class(asset_class).supports_adjusted:
+            raise AdjustedDataUnavailable(f"Silver does not exist for {asset_class}")
+        bronze_path = parquet_path(self._bronze_root, symbol, timeframe, asset_class)
+        if resolved == "raw":
             if not bronze_path.exists():
                 return []
             return await asyncio.to_thread(
@@ -245,6 +272,7 @@ class LivewireOhlcProvider:
         ts = _to_utc_datetime(row[_timestamp_column(timeframe)])
         end = ts + _TF_DELTAS.get(timeframe, timedelta(0))
         vol = row.get("volume")
+        oi = row.get("open_interest")
         return BarData(
             symbol=symbol,
             timeframe=timeframe,
@@ -254,6 +282,12 @@ class LivewireOhlcProvider:
             close=row.get("close"),
             volume=int(vol) if vol is not None else None,
             vwap=row.get("vwap"),
+            settlement=row.get("settlement"),
+            open_interest=int(oi) if oi is not None else None,
+            contract_id=row.get("contract_id"),
+            root_symbol=row.get("root_symbol"),
+            # str(), not the raw value: asdict() would leak a live date into JSON.
+            expiry_date=(str(row["expiry_date"]) if row.get("expiry_date") is not None else None),
             bar_start=ts,
             bar_end=end,
             timestamp=ts,  # event time = bar time, NOT construction-time now()

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -18,6 +18,7 @@ OHLCV at the right instants.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, List, Literal
@@ -39,6 +40,15 @@ PriceMode = Literal["raw", "adjusted"]
 
 class AdjustedDataUnavailable(RuntimeError):
     """Raised when adjusted mode cannot prove complete Silver coverage."""
+
+
+@dataclass(frozen=True)
+class RatePoint:
+    """One observation from asset_class=rates. Not a bar -- there is no OHLC."""
+
+    time: datetime
+    tenor_years: float
+    yield_pct: float
 
 
 def _timestamp_column(timeframe: str) -> str:
@@ -185,6 +195,35 @@ class LivewireOhlcProvider:
             start,
             end,
         )
+
+    async def fetch_rate_series(
+        self, symbol: str, start: datetime, end: datetime
+    ) -> List[RatePoint]:
+        """Read a yield series. Rates are never adjusted -- a yield has no split."""
+        path = parquet_path(self._bronze_root, symbol, "1d", "rates")
+        if not path.exists():
+            return []
+        return await asyncio.to_thread(self._query_rates, path, start, end)
+
+    def _query_rates(self, path: Path, start: datetime, end: datetime) -> List[RatePoint]:
+        sql = (
+            f"SELECT trade_date, tenor_years, yield_pct "
+            f"FROM read_parquet('{path.as_posix()}') "
+            f"WHERE trade_date >= ? AND trade_date <= ? ORDER BY trade_date ASC"
+        )
+        con = duckdb.connect(database=":memory:")
+        try:
+            rows = con.execute(sql, [start.date(), end.date()]).fetch_arrow_table().to_pylist()
+        finally:
+            con.close()
+        return [
+            RatePoint(
+                time=_to_utc_datetime(r["trade_date"]),
+                tenor_years=float(r["tenor_years"]),
+                yield_pct=float(r["yield_pct"]),
+            )
+            for r in rows
+        ]
 
     # --- internals ---
     def _query(

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -181,6 +181,12 @@ class LivewireOhlcProvider:
         if timeframe == "1d":
             path = daily_silver_path(self._silver_root, symbol)
             if not path.exists():
+                # No Silver AND no Bronze means the symbol does not exist at all -- an
+                # unknown ticker, which the route turns into 404. Raising here instead
+                # would answer a typo with "retry later" and the caller would retry
+                # forever. Only a symbol that HAS bronze is genuinely quarantined.
+                if not bronze_path.exists():
+                    return []
                 raise AdjustedDataUnavailable(f"Silver daily artifact is missing for {symbol}")
             return await asyncio.to_thread(self._query, path, symbol, timeframe, start, end)
 

--- a/src/infrastructure/adapters/livewire/ohlc_provider.py
+++ b/src/infrastructure/adapters/livewire/ohlc_provider.py
@@ -234,8 +234,11 @@ class LivewireOhlcProvider:
             for r in rows
         ]
 
-    def get_recency(self, reference_symbol: str = "AAPL") -> dict[str, Any]:
+    def fetch_recency(self, reference_symbol: str = "AAPL") -> dict[str, Any]:
         """Last trade_date in bronze and silver for a liquid reference symbol.
+
+        ``fetch_`` not ``get_``: this touches the disk on every call (two DuckDB reads),
+        it is not a cache lookup.
 
         Read from the ARTIFACTS, not livewire's coverage table -- that table is an
         11:00 UTC snapshot and under-reports by design. AAPL is the default probe

--- a/src/infrastructure/adapters/livewire/paths.py
+++ b/src/infrastructure/adapters/livewire/paths.py
@@ -1,19 +1,24 @@
-"""Resolve (symbol, timeframe) to a livewire bronze parquet path.
+"""Resolve (asset_class, symbol, timeframe) to a livewire parquet path.
 
 The per-ticker Hive layout IS the read contract, confirmed against livewire's
-``clients/bronze_client.py`` + ``clients/intraday_bronze_client.py`` (2026-06-14):
+``clients/bronze_client.py`` + ``clients/intraday_bronze_client.py`` (2026-06-14) and
+re-verified across all six asset classes on 2026-08-23:
 
-  <root>/asset_class=equity/symbol=<encode_symbol(SYM)>/<tf>.parquet
+  <root>/asset_class=<class>/symbol=<encode_symbol(SYM)>/<tf>.parquet
 
 where ``<root>`` is livewire's ``data-lake/bronze`` directory (``APEX_LIVEWIRE_ROOT``).
+Silver is equity-only, so the two silver builders take no asset_class.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# Timeframes livewire warehouses for equities: daily via BronzeClient (1d), intraday
-# via IntradayBronzeClient (1m/5m/30m/1h). Matches livewire's INTRADAY_TIMEFRAMES + 1d.
+from .asset_classes import DEFAULT_ASSET_CLASS, get_asset_class
+
+# Retained for backward compatibility: the equity timeframe ladder. New code should
+# read ``get_asset_class(name).timeframes`` -- ladders differ per class (cmdty,
+# futures and rates are daily-only; volatility has no 1m).
 SUPPORTED_TIMEFRAMES = ("1m", "5m", "30m", "1h", "1d")
 
 # Mirrors livewire's clients/symbol_paths.py exactly: keep these characters literal,
@@ -22,8 +27,12 @@ SUPPORTED_TIMEFRAMES = ("1m", "5m", "30m", "1h", "1d")
 _CASE_SAFE = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
 
 
+class UnsupportedTimeframe(ValueError):
+    """Raised when a timeframe is not warehoused for the requested asset class."""
+
+
 def encode_symbol(symbol: str) -> str:
-    """Encode a symbol to its livewire bronze partition name (matches livewire 1:1)."""
+    """Encode a symbol to its livewire partition name (matches livewire 1:1)."""
     parts: list[str] = []
     for character in symbol:
         if character in _CASE_SAFE:
@@ -33,24 +42,47 @@ def encode_symbol(symbol: str) -> str:
     return "".join(parts)
 
 
-def parquet_path(bronze_root: Path, symbol: str, timeframe: str) -> Path:
-    if timeframe not in SUPPORTED_TIMEFRAMES:
-        raise ValueError(f"unsupported timeframe: {timeframe!r} (have {SUPPORTED_TIMEFRAMES})")
+def parquet_path(
+    bronze_root: Path,
+    symbol: str,
+    timeframe: str,
+    asset_class: str = DEFAULT_ASSET_CLASS,
+) -> Path:
+    """Return the bronze artifact path, raising on an unknown class or timeframe."""
+    spec = get_asset_class(asset_class)
+    if timeframe not in spec.timeframes:
+        raise UnsupportedTimeframe(
+            f"unsupported timeframe {timeframe!r} for {spec.name} "
+            f"(have {list(spec.timeframes)})"
+        )
+    return bronze_root / spec.partition / f"symbol={encode_symbol(symbol)}" / f"{timeframe}.parquet"
+
+
+def delisted_bronze_path(
+    delisted_root: Path,
+    symbol: str,
+    timeframe: str = "1d",
+    asset_class: str = DEFAULT_ASSET_CLASS,
+) -> Path:
+    """Return the archived-delisted artifact path.
+
+    livewire's ``archive_otc_symbols.py`` moves symbols under bronze-delisted/. The tree
+    is overwhelmingly equity (8620 symbols on 2026-08-23) but is NOT equity-only --
+    asset_class=fx holds USDEUR -- so the partition is parameterized rather than fixed.
+    """
+    spec = get_asset_class(asset_class)
     return (
-        bronze_root
-        / "asset_class=equity"
-        / f"symbol={encode_symbol(symbol)}"
-        / f"{timeframe}.parquet"
+        delisted_root / spec.partition / f"symbol={encode_symbol(symbol)}" / f"{timeframe}.parquet"
     )
 
 
 def daily_silver_path(silver_root: Path, symbol: str) -> Path:
-    """Return the materialized adjusted-daily artifact for ``symbol``."""
+    """Return the materialized adjusted-daily artifact for ``symbol`` (equity only)."""
     return silver_root / "asset_class=equity" / f"symbol={encode_symbol(symbol)}" / "1d.parquet"
 
 
 def factor_path(silver_root: Path, symbol: str) -> Path:
-    """Return the compact adjustment-factor artifact for ``symbol``."""
+    """Return the compact adjustment-factor artifact for ``symbol`` (equity only)."""
     return (
         silver_root
         / "adjustments"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and fixtures."""
 
 from datetime import datetime
+from pathlib import Path
 from typing import Dict
 
 import pytest
@@ -116,3 +117,34 @@ def sample_risk_config() -> Dict:
             "soft_breach_threshold": 0.80,
         }
     }
+
+
+@pytest.fixture()
+def catalog_db(tmp_path: Path) -> Path:
+    """Mirror livewire's real coverage table shape, with real measured rows
+    (frozen 2026-08-23 from ~/market-warehouse/analytics.duckdb).
+
+    Verified against the production catalog: the table is exactly
+    (view_name VARCHAR, symbol VARCHAR, n_rows BIGINT, first_date DATE, last_date DATE).
+    """
+    import duckdb
+
+    db = tmp_path / "analytics.duckdb"
+    con = duckdb.connect(str(db))
+    con.execute(
+        "CREATE TABLE coverage ("
+        "view_name VARCHAR, symbol VARCHAR, n_rows BIGINT, "
+        "first_date DATE, last_date DATE)"
+    )
+    con.executemany(
+        "INSERT INTO coverage VALUES (?, ?, ?, ?, ?)",
+        [
+            ("bronze_equity_1d", "AAPL", 11514, "1980-12-12", "2026-08-21"),
+            ("silver_equity_1d", "AAPL", 11514, "1980-12-12", "2026-08-21"),
+            ("bronze_equity_1d", "HON", 11000, "1980-01-02", "2026-08-21"),
+            ("bronze_volatility_1d", "VIX", 9256, "1990-01-02", "2026-08-21"),
+            ("bronze_rates_1d", "DGS10", 16144, "1962-01-02", "2026-08-20"),
+        ],
+    )
+    con.close()
+    return db

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -10,11 +10,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, List
 
+import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.api.payload.validate import validate_payload
 from src.api.server import create_app
 from src.domain.events.domain_events import BarData
+from src.infrastructure.adapters.livewire.ohlc_provider import AdjustedDataUnavailable
 
 _DAY = timedelta(days=1)
 _T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -44,22 +46,32 @@ def _series(n: int) -> List[BarData]:
 
 
 class _FakeProvider:
-    def __init__(self, bars: List[BarData], dual_resident: set[str] | None = None) -> None:
+    def __init__(
+        self,
+        bars: List[BarData],
+        delisted_root: Path | None = None,
+        rates: List[Any] | None = None,
+        silver_root: Path | None = None,
+        price_mode: str = "raw",
+    ) -> None:
         self._bars = bars
+        self._rates = rates or []
         # A real path that does not exist: _bars_response probes it to tell "no artifact"
         # (404) apart from "artifact exists, window empty" (200 with zero bars).
         self.bronze_root = Path("/nonexistent")
-        self.delisted_root = None
-        self._dual = dual_resident or set()
+        self.delisted_root = delisted_root
+        self.silver_root = silver_root
+        self._price_mode = price_mode
 
     def effective_price_mode(self, asset_class: str = "equity") -> str:
-        return "raw"
-
-    def is_dual_resident(self, symbol: str) -> bool:
-        return symbol in self._dual
+        return self._price_mode
 
     async def fetch_rate_series(self, symbol: str, start: datetime, end: datetime) -> list:
-        return []
+        # Keys on symbol: the real provider reads a per-symbol parquet, so a fake that
+        # served the same series for every ticker would hide the unknown-symbol path.
+        if symbol != "DGS10":
+            return []
+        return [p for p in self._rates if start <= p.time <= end]
 
     async def fetch_bars(
         self,
@@ -121,6 +133,20 @@ class _FakeRepo:
                 "dominant_direction": "bullish",
             }
         ]
+
+
+def _rates_series() -> List[Any]:
+    """Real FRED DGS10 observations, frozen 2026-08-23 from bronze/asset_class=rates."""
+    from src.infrastructure.adapters.livewire.ohlc_provider import RatePoint
+
+    return [
+        RatePoint(
+            time=datetime(2026, 8, 18, tzinfo=timezone.utc), tenor_years=10.0, yield_pct=4.71
+        ),
+        RatePoint(
+            time=datetime(2026, 8, 19, tzinfo=timezone.utc), tenor_years=10.0, yield_pct=4.65
+        ),
+    ]
 
 
 def _client(app) -> AsyncClient:
@@ -212,12 +238,17 @@ async def test_get_indicators_returns_valid_payload() -> None:
     assert "value" in payload["points"][0]["state"]
 
 
-async def test_get_indicators_404_on_unknown_indicator() -> None:
+async def test_unknown_indicator_names_the_parameter_not_the_symbol() -> None:
+    """AAPL is a perfectly good symbol; `indicator=not_real` is the bad input.
+
+    This used to answer 404 unknown_symbol, which sent callers to check their ticker.
+    """
     app = create_app()
     app.state.ohlc_provider = _FakeProvider(_series(50))
     async with _client(app) as c:
         resp = await c.get("/indicators/AAPL", params={"timeframe": "1d", "indicator": "not_real"})
-    assert resp.status_code == 404
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_parameter"
 
 
 async def test_get_indicators_503_when_provider_unconfigured() -> None:
@@ -278,13 +309,7 @@ async def test_get_confluence_rejects_out_of_range_limit() -> None:
     assert resp.status_code == 422
 
 
-# --- Task 8: /v1 routes and deprecated aliases -------------------------------------
-
-import pytest  # noqa: E402
-
-from src.infrastructure.adapters.livewire.ohlc_provider import (  # noqa: E402
-    AdjustedDataUnavailable,
-)
+# --- /v1 routes and deprecated aliases --------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -404,13 +429,51 @@ async def test_rates_through_the_bars_route_is_redirected_not_500() -> None:
 @pytest.mark.asyncio
 async def test_rates_series_route_serves_the_yield_shape() -> None:
     app = create_app()
-    app.state.ohlc_provider = _FakeProvider([])
+    app.state.ohlc_provider = _FakeProvider([], rates=_rates_series())
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.get("/v1/rates/DGS10/series")
     assert r.status_code == 200
     body = r.json()
     assert body["asset_class"] == "rates"
+    assert body["tenor_years"] == 10.0
+    assert body["points"][0]["yield_pct"] == 4.71
     validate_payload(body, "rates_series_payload")
+
+
+@pytest.mark.asyncio
+async def test_unknown_rates_symbol_is_404_not_an_empty_200() -> None:
+    """An empty 200 would read as "this yield had no observations" -- it is a typo.
+
+    /bars already draws this distinction; /series must draw the same one or the two
+    halves of the same contract disagree about what "not found" looks like.
+    """
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([], rates=_rates_series())
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/rates/NOTAYIELD/series")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "unknown_symbol"
+
+
+@pytest.mark.asyncio
+async def test_bad_listing_value_names_the_parameter_not_the_symbol() -> None:
+    """A typo in ?listing= is a 400 about the parameter, not a 404 about the symbol."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL/bars?listing=lsited")
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "invalid_parameter"
+
+
+@pytest.mark.asyncio
+async def test_bad_price_mode_names_the_parameter_not_the_asset_class() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL/bars?price_mode=adjsuted")
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "invalid_parameter"
 
 
 @pytest.mark.asyncio
@@ -448,11 +511,20 @@ async def test_adjusted_requested_on_non_equity_is_400() -> None:
 
 
 @pytest.mark.asyncio
-async def test_listing_any_is_409_because_tickers_are_reused() -> None:
+async def test_listing_any_is_409_because_tickers_are_reused(tmp_path: Path) -> None:
     """2,345 tickers exist in both the live and delisted trees (measured 2026-08-23).
-    Only those are ambiguous; a live-only symbol under listing=any is served normally."""
+    Only those are ambiguous; a live-only symbol under listing=any is served normally.
+
+    Builds a real bronze-delisted tree so the route's own path construction is what
+    gets exercised, not a test-only shortcut on the provider.
+    """
+    from src.infrastructure.adapters.livewire.paths import delisted_bronze_path
+
+    artifact = delisted_bronze_path(tmp_path, "BBBY")
+    artifact.parent.mkdir(parents=True)
+    artifact.touch()
     app = create_app()
-    app.state.ohlc_provider = _FakeProvider(_series(5), dual_resident={"BBBY"})
+    app.state.ohlc_provider = _FakeProvider(_series(5), delisted_root=tmp_path)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         ambiguous = await c.get("/v1/equity/BBBY/bars", params={"listing": "any"})
         unambiguous = await c.get("/v1/equity/AAPL/bars", params={"listing": "any"})
@@ -481,3 +553,160 @@ async def test_missing_artifact_is_404_not_an_empty_200() -> None:
         r = await c.get("/v1/equity/NOSUCHTICKER/bars")
     assert r.status_code == 404
     assert r.json()["error"]["code"] == "unknown_symbol"
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_provider_error_is_a_typed_500_not_a_bare_one() -> None:
+    """The lake sits on an external volume: an unmount or a truncated parquet makes
+    DuckDB raise. That must still leave as the envelope, and must not echo the path."""
+
+    class _Exploding:
+        bronze_root = Path("/Volumes/DATA_LAKE/livewire/data-lake/bronze")
+        delisted_root = None
+
+        def effective_price_mode(self, asset_class: str = "equity") -> str:
+            return "raw"
+
+        async def fetch_bars(self, *a: Any, **k: Any) -> List[BarData]:
+            raise OSError("[Errno 5] Input/output error: /Volumes/DATA_LAKE/.../1d.parquet")
+
+    app = create_app()
+    app.state.ohlc_provider = _Exploding()
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL/bars")
+    assert r.status_code == 500
+    body = r.json()
+    assert body["error"]["code"] == "internal_error"
+    assert "/Volumes" not in body["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_parquet_is_a_typed_500_through_the_real_provider(tmp_path: Path) -> None:
+    """The catch-all with a REAL DuckDB failure, not a stand-in exception.
+
+    A truncated or partially-written artifact is the realistic form of this on a lake
+    that a separate process writes to. The file must EXIST (so the 404 probe passes)
+    and be unreadable as parquet (so DuckDB raises inside the worker thread).
+    """
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+    from src.infrastructure.adapters.livewire.paths import parquet_path
+
+    artifact = parquet_path(tmp_path, "AAPL", "1d")
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"PAR1 this is not a parquet file")
+
+    app = create_app()
+    app.state.ohlc_provider = LivewireOhlcProvider(bronze_root=tmp_path, price_mode="raw")
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL/bars")
+    assert r.status_code == 500
+    assert r.json()["error"]["code"] == "internal_error"
+    # The DuckDB message embeds the absolute artifact path; it must not reach the client.
+    assert str(tmp_path) not in r.text
+
+
+@pytest.mark.asyncio
+async def test_indicators_on_a_missing_symbol_is_404_not_an_empty_200() -> None:
+    """An empty series over a symbol that does not exist reads as "no signal fired"."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])  # bronze_root is /nonexistent
+    async with _client(app) as c:
+        r = await c.get("/v1/equity/ZZZZNOPE/indicators", params={"indicator": "rsi"})
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "unknown_symbol"
+
+
+@pytest.mark.asyncio
+async def test_indicators_reject_rates_rather_than_computing_over_null_prices() -> None:
+    """A yield has no OHLC. Computing an indicator over null closes returns a
+    number-shaped answer to a question that has none."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with _client(app) as c:
+        r = await c.get("/v1/rates/DGS10/indicators", params={"indicator": "rsi"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "unsupported_asset_class"
+
+
+@pytest.mark.asyncio
+async def test_a_reversed_window_is_a_400_not_a_quiet_market() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with _client(app) as c:
+        r = await c.get(
+            "/v1/equity/AAPL/bars",
+            params={"start": "2026-08-20T00:00:00Z", "end": "2026-01-01T00:00:00Z"},
+        )
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "invalid_parameter"
+
+
+@pytest.mark.asyncio
+async def test_framework_validation_errors_use_the_same_envelope() -> None:
+    """FastAPI's own 422 body is {"detail": [...]} -- a second error shape on the
+    same surface. One shape, or a consumer needs two parsers."""
+    app = create_app()
+    app.state.signal_repo = _FakeRepo()
+    async with _client(app) as c:
+        r = await c.get("/v1/equity/AAPL/confluence", params={"limit": "0"})
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "invalid_parameter"
+    assert "detail" not in r.json()
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_request_is_400_even_with_no_provider() -> None:
+    """503 says "retry later"; a 4h timeframe will never exist however long you wait."""
+    app = create_app()
+    app.state.ohlc_provider = None
+    async with _client(app) as c:
+        bad_tf = await c.get("/v1/equity/AAPL/bars", params={"timeframe": "4h"})
+        bad_class = await c.get("/v1/notaclass/AAPL/bars")
+        real = await c.get("/v1/equity/AAPL/bars")
+    assert bad_tf.status_code == 400
+    assert bad_class.status_code == 400
+    assert real.status_code == 503  # the genuinely-unconfigured case still reports itself
+
+
+@pytest.mark.asyncio
+async def test_dual_residency_probes_the_requested_class_not_always_equity(
+    tmp_path: Path,
+) -> None:
+    """bronze-delisted is overwhelmingly equity but NOT only equity: asset_class=fx
+    holds USDEUR. Defaulting the partition answers the question for the wrong tree."""
+    from src.infrastructure.adapters.livewire.paths import delisted_bronze_path
+
+    fx = delisted_bronze_path(tmp_path, "USDEUR", asset_class="fx")
+    fx.parent.mkdir(parents=True)
+    fx.touch()
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5), delisted_root=tmp_path)
+    async with _client(app) as c:
+        as_fx = await c.get("/v1/fx/USDEUR/bars", params={"listing": "any"})
+        # The same ticker under equity is NOT dual-resident -- no equity artifact exists.
+        as_equity = await c.get("/v1/equity/USDEUR/bars", params={"listing": "any"})
+    assert as_fx.status_code == 409
+    assert as_fx.json()["error"]["code"] == "ambiguous_symbol"
+    assert as_equity.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_silver_only_symbol_is_not_a_false_404(tmp_path: Path) -> None:
+    """Silver can outlive its Bronze source. Probing Bronze alone answers a real
+    adjusted symbol with 404 whenever the requested window happens to be empty."""
+    from src.infrastructure.adapters.livewire.paths import daily_silver_path
+
+    silver_root = tmp_path / "silver"
+    artifact = daily_silver_path(silver_root, "AAPL")
+    artifact.parent.mkdir(parents=True)
+    artifact.touch()
+
+    app = create_app()
+    # Empty window, bronze_root deliberately nonexistent: only Silver backs this symbol.
+    app.state.ohlc_provider = _FakeProvider([], silver_root=silver_root, price_mode="adjusted")
+    async with _client(app) as c:
+        r = await c.get("/v1/equity/AAPL/bars", params={"timeframe": "1d"})
+    assert r.status_code == 200
+    assert r.json()["count"] == 0

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -7,6 +7,7 @@ route reads off app.state (ohlc_provider / signal_repo).
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, List
 
 from httpx import ASGITransport, AsyncClient
@@ -43,8 +44,22 @@ def _series(n: int) -> List[BarData]:
 
 
 class _FakeProvider:
-    def __init__(self, bars: List[BarData]) -> None:
+    def __init__(self, bars: List[BarData], dual_resident: set[str] | None = None) -> None:
         self._bars = bars
+        # A real path that does not exist: _bars_response probes it to tell "no artifact"
+        # (404) apart from "artifact exists, window empty" (200 with zero bars).
+        self.bronze_root = Path("/nonexistent")
+        self.delisted_root = None
+        self._dual = dual_resident or set()
+
+    def effective_price_mode(self, asset_class: str = "equity") -> str:
+        return "raw"
+
+    def is_dual_resident(self, symbol: str) -> bool:
+        return symbol in self._dual
+
+    async def fetch_rate_series(self, symbol: str, start: datetime, end: datetime) -> list:
+        return []
 
     async def fetch_bars(
         self,
@@ -261,3 +276,208 @@ async def test_get_confluence_rejects_out_of_range_limit() -> None:
     async with _client(app) as c:
         resp = await c.get("/confluence/AAPL", params={"timeframe": "1d", "limit": "0"})
     assert resp.status_code == 422
+
+
+# --- Task 8: /v1 routes and deprecated aliases -------------------------------------
+
+import pytest  # noqa: E402
+
+from src.infrastructure.adapters.livewire.ohlc_provider import (  # noqa: E402
+    AdjustedDataUnavailable,
+)
+
+
+@pytest.mark.asyncio
+async def test_v1_bars_route_serves_equity() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL/bars", params={"timeframe": "1d"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["asset_class"] == "equity"
+    assert body["price_mode"] == "raw"
+    assert body["listing_status"] == "listed"
+    validate_payload(body, "bars_payload")
+
+
+@pytest.mark.asyncio
+async def test_flat_alias_matches_v1_and_is_marked_deprecated() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        legacy = await c.get("/bars/AAPL", params={"timeframe": "1d"})
+        v1 = await c.get("/v1/equity/AAPL/bars", params={"timeframe": "1d"})
+    assert legacy.json()["bars"] == v1.json()["bars"]
+    assert legacy.headers["Deprecation"] == "true"
+    assert "Sunset" in legacy.headers
+    assert "successor-version" in legacy.headers["Link"]
+
+
+@pytest.mark.asyncio
+async def test_v1_indicators_route_works_off_equity() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(300))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get(
+            "/v1/equity/AAPL/indicators", params={"indicator": "rsi", "timeframe": "1d"}
+        )
+    assert r.status_code == 200
+    validate_payload(r.json(), "indicator_series_payload")
+
+
+@pytest.mark.asyncio
+async def test_v1_confluence_route_is_registered() -> None:
+    """PG-backed and equity-only: with no repo configured it must be a typed 503,
+    not a 404 -- proving the route exists."""
+    app = create_app()
+    app.state.signal_repo = None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL/confluence")
+    assert r.status_code == 503
+    assert r.json()["error"]["code"] == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_unknown_asset_class_is_400_with_a_code() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/crypto/BTC/bars")
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "unsupported_asset_class"
+
+
+@pytest.mark.asyncio
+async def test_intraday_on_a_daily_only_class_is_400_with_a_code() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/volatility/VIX/bars", params={"timeframe": "1m"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "unsupported_timeframe"
+
+
+# Explicit window covering the fixture series: the no-arg default window is anchored
+# to now(), and a 1m default lookback (~14 days) would not reach a Jan-2026 fixture.
+_WINDOW = {"start": _T0.isoformat(), "end": (_T0 + 30 * _DAY).isoformat()}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeframe", ["5m", "30m", "1h", "1d"])
+async def test_volatility_intraday_is_accepted(timeframe: str) -> None:
+    """Measured on the production lake: volatility publishes 5m/30m/1h/1d (never 1m).
+    Rejecting the intraday ladder would make real parquet files unreachable."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/volatility/VIX/bars", params={"timeframe": timeframe, **_WINDOW})
+    assert r.status_code == 200, r.text
+    assert r.json()["asset_class"] == "volatility"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeframe", ["1m", "5m", "30m", "1h", "1d"])
+async def test_fx_intraday_is_accepted(timeframe: str) -> None:
+    """All 21 production FX pairs publish the full 1m/5m/30m/1h/1d ladder."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/fx/DXY/bars", params={"timeframe": timeframe, **_WINDOW})
+    assert r.status_code == 200, r.text
+    assert r.json()["asset_class"] == "fx"
+
+
+@pytest.mark.asyncio
+async def test_rates_through_the_bars_route_is_redirected_not_500() -> None:
+    """A yield has no OHLC; the bars route must name the right route rather than
+    building a null-price payload that fails egress validation as a 500."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/rates/DGS10/bars")
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "unsupported_asset_class"
+    assert "series" in r.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_rates_series_route_serves_the_yield_shape() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/rates/DGS10/series")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["asset_class"] == "rates"
+    validate_payload(body, "rates_series_payload")
+
+
+@pytest.mark.asyncio
+async def test_adjusted_unavailable_is_503_not_500() -> None:
+    """The 243 symbols with bronze but no Silver must be distinguishable from a crash."""
+
+    class _Quarantined:
+        bronze_root = Path("/nonexistent")
+        delisted_root = None
+
+        def effective_price_mode(self, asset_class: str = "equity") -> str:
+            return "adjusted"
+
+        async def fetch_bars(self, *a: object, **kw: object) -> list:
+            raise AdjustedDataUnavailable("Silver daily artifact is missing for HON")
+
+    app = create_app()
+    app.state.ohlc_provider = _Quarantined()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/HON/bars")
+    assert r.status_code == 503
+    body = r.json()["error"]
+    assert body["code"] == "adjusted_unavailable"
+    assert body["symbol"] == "HON"
+
+
+@pytest.mark.asyncio
+async def test_adjusted_requested_on_non_equity_is_400() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/fx/DXY/bars", params={"price_mode": "adjusted"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "adjusted_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_listing_any_is_409_because_tickers_are_reused() -> None:
+    """2,345 tickers exist in both the live and delisted trees (measured 2026-08-23).
+    Only those are ambiguous; a live-only symbol under listing=any is served normally."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider(_series(5), dual_resident={"BBBY"})
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        ambiguous = await c.get("/v1/equity/BBBY/bars", params={"listing": "any"})
+        unambiguous = await c.get("/v1/equity/AAPL/bars", params={"listing": "any"})
+    assert ambiguous.status_code == 409
+    assert ambiguous.json()["error"]["code"] == "ambiguous_symbol"
+    assert unambiguous.status_code == 200
+    assert unambiguous.json()["listing_status"] == "listed"
+
+
+@pytest.mark.asyncio
+async def test_delisted_is_a_typed_501_not_a_silent_empty() -> None:
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/BBBY/bars", params={"listing": "delisted"})
+    assert r.status_code == 501
+    assert r.json()["error"]["code"] == "not_yet_available"
+
+
+@pytest.mark.asyncio
+async def test_missing_artifact_is_404_not_an_empty_200() -> None:
+    """An absent parquet is a 404; an existing parquet with a quiet window is a 200."""
+    app = create_app()
+    app.state.ohlc_provider = _FakeProvider([])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/NOSUCHTICKER/bars")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "unknown_symbol"

--- a/tests/integration/api/test_chart_routes.py
+++ b/tests/integration/api/test_chart_routes.py
@@ -47,7 +47,13 @@ class _FakeProvider:
         self._bars = bars
 
     async def fetch_bars(
-        self, symbol: str, timeframe: str, start: datetime, end: datetime
+        self,
+        symbol: str,
+        timeframe: str,
+        start: datetime,
+        end: datetime,
+        asset_class: str = "equity",
+        price_mode: str | None = None,
     ) -> List[BarData]:
         return [b for b in self._bars if start <= b.timestamp <= end]
 

--- a/tests/integration/api/test_instruments_routes.py
+++ b/tests/integration/api/test_instruments_routes.py
@@ -91,3 +91,58 @@ async def test_silver_availability_is_visible_before_requesting_bars(catalog_db:
     assert by_symbol["AAPL"]["price_mode"] == "adjusted"
     assert by_symbol["HON"]["silver_available"] is False
     assert by_symbol["HON"]["price_mode"] == "raw"
+
+
+@pytest.mark.asyncio
+async def test_instrument_detail_probes_actual_timeframes(tmp_path: Path, catalog_db: Path) -> None:
+    """The coverage table measures no equity intraday, so per-symbol timeframes come
+    from artifact probes -- five Path.exists() calls, affordable for one symbol."""
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+    d = tmp_path / "asset_class=equity" / "symbol=AAPL"
+    d.mkdir(parents=True, exist_ok=True)
+    for tf in ("1d", "1h"):
+        (d / f"{tf}.parquet").write_bytes(b"")
+
+    app = create_app()
+    app.state.coverage_catalog = CoverageCatalog(catalog_db)
+    app.state.ohlc_provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/AAPL")
+    assert r.status_code == 200
+    body = r.json()
+    assert sorted(body["timeframes"]) == ["1d", "1h"]
+    assert body["asset_class"] == "equity"
+    assert body["first_date"] == "1980-12-12"
+
+
+@pytest.mark.asyncio
+async def test_instrument_detail_unknown_symbol_is_404(tmp_path: Path, catalog_db: Path) -> None:
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+    app = create_app()
+    app.state.coverage_catalog = CoverageCatalog(catalog_db)
+    app.state.ohlc_provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/equity/NOTAREALTICKER")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "unknown_symbol"
+
+
+@pytest.mark.asyncio
+async def test_detail_does_not_shadow_the_list_route(catalog_db: Path) -> None:
+    """/v1/instruments is one segment, /v1/{asset_class}/{symbol} is two -- Starlette
+    matches whole patterns, so registration order cannot make them collide."""
+    app = _app(catalog_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments")
+    assert r.status_code == 200
+    assert "instruments" in r.json()
+
+
+@pytest.mark.asyncio
+async def test_exact_match_not_prefix_match(tmp_path: Path, catalog_db: Path) -> None:
+    """get_instrument must not return AAPL when asked for AA."""
+    catalog = CoverageCatalog(catalog_db)
+    assert catalog.get_instrument("AA", "equity") is None
+    assert catalog.get_instrument("AAPL", "equity").symbol == "AAPL"

--- a/tests/integration/api/test_instruments_routes.py
+++ b/tests/integration/api/test_instruments_routes.py
@@ -1,0 +1,93 @@
+"""Discovery routes: /v1/instruments and the per-instrument detail endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.api.payload.validate import validate_payload
+from src.api.server import create_app
+from src.infrastructure.adapters.livewire.coverage import CoverageCatalog
+
+
+def _app(catalog_db: Path | None) -> object:
+    app = create_app()
+    app.state.coverage_catalog = CoverageCatalog(catalog_db) if catalog_db else None
+    return app
+
+
+@pytest.mark.asyncio
+async def test_instruments_route_returns_schema_valid_payload(catalog_db: Path) -> None:
+    app = _app(catalog_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments")
+    assert r.status_code == 200
+    body = r.json()
+    validate_payload(body, "instruments_payload")
+    assert body["source"] == "livewire_coverage_snapshot"
+    assert {i["symbol"] for i in body["instruments"]} == {"AAPL", "HON", "VIX", "DGS10"}
+
+
+@pytest.mark.asyncio
+async def test_instruments_without_catalog_is_503_with_a_code() -> None:
+    app = _app(None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments")
+    assert r.status_code == 503
+    assert r.json()["error"]["code"] == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_unreadable_catalog_is_503_not_an_empty_universe(tmp_path: Path) -> None:
+    """The exact production failure: a bind mount outside colima's VM mount set leaves
+    a DIRECTORY at the catalog path. Reporting zero instruments would let a broken
+    deployment masquerade as a correct one."""
+    fake = tmp_path / "analytics.duckdb"
+    fake.mkdir()
+    app = _app(fake)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments")
+    assert r.status_code == 503
+    assert r.json()["error"]["code"] == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_filters_by_asset_class(catalog_db: Path) -> None:
+    app = _app(catalog_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments", params={"asset_class": "rates"})
+    assert [i["symbol"] for i in r.json()["instruments"]] == ["DGS10"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_asset_class_filter_is_400(catalog_db: Path) -> None:
+    app = _app(catalog_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments", params={"asset_class": "crypto"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "unsupported_asset_class"
+
+
+@pytest.mark.asyncio
+async def test_delisted_discovery_is_a_typed_501(catalog_db: Path) -> None:
+    app = _app(catalog_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments", params={"listing": "delisted"})
+    assert r.status_code == 501
+    assert r.json()["error"]["code"] == "not_yet_available"
+
+
+@pytest.mark.asyncio
+async def test_silver_availability_is_visible_before_requesting_bars(catalog_db: Path) -> None:
+    """HON has bronze but no Silver; a consumer must learn that here rather than by
+    taking a 503 on /bars."""
+    app = _app(catalog_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/instruments")
+    by_symbol = {i["symbol"]: i for i in r.json()["instruments"]}
+    assert by_symbol["AAPL"]["silver_available"] is True
+    assert by_symbol["AAPL"]["price_mode"] == "adjusted"
+    assert by_symbol["HON"]["silver_available"] is False
+    assert by_symbol["HON"]["price_mode"] == "raw"

--- a/tests/integration/api/test_instruments_routes.py
+++ b/tests/integration/api/test_instruments_routes.py
@@ -146,3 +146,43 @@ async def test_exact_match_not_prefix_match(tmp_path: Path, catalog_db: Path) ->
     catalog = CoverageCatalog(catalog_db)
     assert catalog.get_instrument("AA", "equity") is None
     assert catalog.get_instrument("AAPL", "equity").symbol == "AAPL"
+
+
+@pytest.mark.asyncio
+async def test_actions_and_delisting_are_typed_501s() -> None:
+    """Specified now so the contract is stable; blocked on livewire L1/L2/L4.
+
+    Measured 2026-08-23: no delisted symbol in the lake has correct corporate-action
+    data (6,275 have none; the 2,345 that do are ticker reuses whose actions belong
+    to a different, living company).
+    """
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        for path in ("/v1/equity/BBBY/actions", "/v1/equity/BBBY/delisting"):
+            r = await c.get(path)
+            assert r.status_code == 501, path
+            assert r.json()["error"]["code"] == "not_yet_available", path
+            assert r.json()["error"]["symbol"] == "BBBY", path
+
+
+@pytest.mark.asyncio
+async def test_three_segment_routes_do_not_shadow_the_two_segment_detail(
+    tmp_path: Path, catalog_db: Path
+) -> None:
+    """/v1/equity/{symbol}/actions (three segments) and /v1/{asset_class}/{symbol}
+    (two) coexist -- Starlette matches whole patterns, not prefixes."""
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+    d = tmp_path / "asset_class=equity" / "symbol=AAPL"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "1d.parquet").write_bytes(b"")
+
+    app = create_app()
+    app.state.coverage_catalog = CoverageCatalog(catalog_db)
+    app.state.ohlc_provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        detail = await c.get("/v1/equity/AAPL")
+        actions = await c.get("/v1/equity/AAPL/actions")
+    assert detail.status_code == 200
+    assert detail.json()["timeframes"] == ["1d"]
+    assert actions.status_code == 501

--- a/tests/integration/api/test_signals_rest.py
+++ b/tests/integration/api/test_signals_rest.py
@@ -57,3 +57,31 @@ async def test_get_signals_503_when_repo_unconfigured() -> None:
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/signals/AAPL")
     assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_v1_signals_route_matches_the_alias() -> None:
+    """The /v1 path and the flat alias share one implementation; the alias is marked."""
+    app = create_app()
+    app.state.signal_repo = _FakeRepo()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        v1 = await client.get("/v1/equity/AAPL/signals")
+        legacy = await client.get("/signals/AAPL")
+    assert v1.status_code == 200
+    validate_payload(v1.json())
+    assert v1.json()["signals"] == legacy.json()["signals"]
+    assert legacy.headers["Deprecation"] == "true"
+    assert "Sunset" in legacy.headers
+
+
+@pytest.mark.asyncio
+async def test_signals_503_carries_a_typed_code() -> None:
+    """The bare HTTPException detail became the typed envelope."""
+    app = create_app()
+    app.state.signal_repo = None
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/v1/equity/AAPL/signals")
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "provider_not_configured"

--- a/tests/unit/api/test_chart_payload.py
+++ b/tests/unit/api/test_chart_payload.py
@@ -98,3 +98,118 @@ def test_signal_payload_validation_still_defaults_to_signal_schema() -> None:
     """Backward-compat: validate_payload with no schema arg uses the signal contract."""
     payload = {"signals": [], "timestamp": _NOW.isoformat(), "symbol_count": 0}
     validate_payload(payload)
+
+
+# --- Task 6: basis, listing status and futures identity ----------------------------
+
+_GEN = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+def test_bars_payload_states_basis_and_listing_explicitly() -> None:
+    """price_mode and listing_status are REQUIRED and non-null. A consumer must never
+    have to infer the adjustment basis, and must not be silently handed delisted bars."""
+    payload = build_bars_payload("AAPL", "1d", [], generated_at=_GEN)
+    assert payload["price_mode"] == "raw"
+    assert payload["listing_status"] == "listed"
+    assert payload["asset_class"] == "equity"
+    assert payload["adjustment_revision"] is None
+
+
+def test_bars_payload_carries_adjustment_revision_when_adjusted() -> None:
+    payload = build_bars_payload(
+        "AAPL", "1d", [], generated_at=_GEN, price_mode="adjusted", adjustment_revision=33
+    )
+    assert (payload["price_mode"], payload["adjustment_revision"]) == ("adjusted", 33)
+
+
+def test_bars_payload_drops_vwap() -> None:
+    """No parquet in the lake carries a vwap column; it served null forever.
+
+    Real AAPL bar, frozen 2026-08-23 from bronze/asset_class=equity.
+    """
+    bar = BarData(
+        symbol="AAPL",
+        timeframe="1d",
+        open=312.05,
+        high=312.38,
+        low=307.01,
+        close=309.35,
+        volume=48591536,
+        timestamp=datetime(2026, 8, 21, tzinfo=timezone.utc),
+        bar_start=datetime(2026, 8, 21, tzinfo=timezone.utc),
+    )
+    payload = build_bars_payload("AAPL", "1d", [bar], generated_at=_GEN)
+    assert "vwap" not in payload["bars"][0]
+    assert payload["bars"][0]["close"] == 309.35
+
+
+def test_futures_payload_carries_contract_identity() -> None:
+    payload = build_bars_payload(
+        "BZ_202609",
+        "1d",
+        [],
+        generated_at=_GEN,
+        asset_class="futures",
+        contract={
+            "contract_id": 3871332472656972,
+            "root_symbol": "BZ",
+            "expiry_date": "2026-09-01",
+        },
+    )
+    assert payload["contract"]["root_symbol"] == "BZ"
+
+
+def test_futures_bar_carries_settlement_and_open_interest() -> None:
+    """Real ICE Brent bar, frozen 2026-08-23 from bronze/asset_class=futures."""
+    bar = BarData(
+        symbol="BZ_202609",
+        timeframe="1d",
+        open=71.86,
+        high=72.23,
+        low=71.04,
+        close=71.57,
+        volume=7303,
+        settlement=71.57,
+        open_interest=0,
+        timestamp=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        bar_start=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+    row = build_bars_payload("BZ_202609", "1d", [bar], generated_at=_GEN, asset_class="futures")[
+        "bars"
+    ][0]
+    assert row["settlement"] == 71.57
+    assert row["open_interest"] == 0
+
+
+def test_equity_bars_omit_futures_columns_entirely() -> None:
+    """Emitting them as null would add noise to every equity bar in the lake."""
+    bar = BarData(
+        symbol="AAPL",
+        timeframe="1d",
+        open=312.05,
+        high=312.38,
+        low=307.01,
+        close=309.35,
+        volume=48591536,
+        timestamp=datetime(2026, 8, 21, tzinfo=timezone.utc),
+        bar_start=datetime(2026, 8, 21, tzinfo=timezone.utc),
+    )
+    row = build_bars_payload("AAPL", "1d", [bar], generated_at=_GEN)["bars"][0]
+    assert "settlement" not in row
+    assert "open_interest" not in row
+
+
+def test_every_shape_validates_against_the_schema() -> None:
+    for kwargs in (
+        {},
+        {"price_mode": "adjusted", "adjustment_revision": 33},
+        {
+            "asset_class": "futures",
+            "contract": {"contract_id": 1, "root_symbol": "BZ", "expiry_date": "2026-09-01"},
+        },
+        {"listing_status": "delisted"},
+        {"asset_class": "fx", "timeframe": "1h"},
+    ):
+        timeframe = kwargs.pop("timeframe", "1d")
+        payload = build_bars_payload("AAPL", timeframe, [], generated_at=_GEN, **kwargs)
+        validate_payload(payload, "bars_payload")

--- a/tests/unit/api/test_chart_payload.py
+++ b/tests/unit/api/test_chart_payload.py
@@ -8,6 +8,7 @@ from src.api.payload.chart import (
     build_bars_payload,
     build_confluence_payload,
     build_indicator_payload,
+    build_rates_series_payload,
 )
 from src.api.payload.validate import validate_payload
 from src.domain.events.domain_events import BarData
@@ -213,3 +214,49 @@ def test_every_shape_validates_against_the_schema() -> None:
         timeframe = kwargs.pop("timeframe", "1d")
         payload = build_bars_payload("AAPL", timeframe, [], generated_at=_GEN, **kwargs)
         validate_payload(payload, "bars_payload")
+
+
+def test_rates_payload_validates() -> None:
+    """Real FRED DGS10 observations, frozen 2026-08-23."""
+    from src.infrastructure.adapters.livewire.ohlc_provider import RatePoint
+
+    points = [
+        RatePoint(
+            time=datetime(2026, 8, 18, tzinfo=timezone.utc), tenor_years=10.0, yield_pct=4.71
+        ),
+        RatePoint(
+            time=datetime(2026, 8, 19, tzinfo=timezone.utc), tenor_years=10.0, yield_pct=4.65
+        ),
+    ]
+    payload = build_rates_series_payload("DGS10", points, generated_at=_GEN)
+    assert payload["tenor_years"] == 10.0
+    assert payload["points"][0]["yield_pct"] == 4.71
+    validate_payload(payload, "rates_series_payload")
+
+
+def test_rates_payload_accepts_a_generator() -> None:
+    """points is an Iterable; iterating it twice would silently null tenor_years."""
+    from src.infrastructure.adapters.livewire.ohlc_provider import RatePoint
+
+    def gen():
+        yield RatePoint(
+            time=datetime(2026, 8, 20, tzinfo=timezone.utc), tenor_years=10.0, yield_pct=4.69
+        )
+
+    payload = build_rates_series_payload("DGS10", gen(), generated_at=_GEN)
+    assert payload["tenor_years"] == 10.0
+    assert payload["count"] == 1
+
+
+def test_rates_payload_nulls_tenor_when_mixed() -> None:
+    from src.infrastructure.adapters.livewire.ohlc_provider import RatePoint
+
+    points = [
+        RatePoint(
+            time=datetime(2026, 8, 18, tzinfo=timezone.utc), tenor_years=10.0, yield_pct=4.71
+        ),
+        RatePoint(time=datetime(2026, 8, 18, tzinfo=timezone.utc), tenor_years=5.0, yield_pct=3.9),
+    ]
+    payload = build_rates_series_payload("MIXED", points, generated_at=_GEN)
+    assert payload["tenor_years"] is None
+    validate_payload(payload, "rates_series_payload")

--- a/tests/unit/api/test_chart_payload.py
+++ b/tests/unit/api/test_chart_payload.py
@@ -260,3 +260,29 @@ def test_rates_payload_nulls_tenor_when_mixed() -> None:
     payload = build_rates_series_payload("MIXED", points, generated_at=_GEN)
     assert payload["tenor_years"] is None
     validate_payload(payload, "rates_series_payload")
+
+
+def test_extra_bar_fields_come_from_the_registry_not_a_hardcoded_tuple() -> None:
+    """Adding a seventh asset class must be a registry row. If the payload hardcodes
+    which columns are 'extra', a new class with extra columns silently drops them."""
+    from src.infrastructure.adapters.livewire.asset_classes import get_asset_class
+
+    assert get_asset_class("futures").extra_bar_fields == ("settlement", "open_interest")
+    assert get_asset_class("equity").extra_bar_fields == ()
+
+    class _Bar:
+        open = high = low = close = 1.0
+        volume = 1
+        timestamp = bar_start = datetime(2026, 8, 21, tzinfo=timezone.utc)
+        settlement = 74.2
+        open_interest = 1234
+
+    # Same bar object, two classes: the registry alone decides what is emitted.
+    as_futures = build_bars_payload(
+        "BZ_202609", "1d", [_Bar()], generated_at=_GEN, asset_class="futures"
+    )["bars"][0]
+    as_equity = build_bars_payload("AAPL", "1d", [_Bar()], generated_at=_GEN, asset_class="equity")[
+        "bars"
+    ][0]
+    assert as_futures["settlement"] == 74.2 and as_futures["open_interest"] == 1234
+    assert "settlement" not in as_equity and "open_interest" not in as_equity

--- a/tests/unit/api/test_errors.py
+++ b/tests/unit/api/test_errors.py
@@ -65,6 +65,8 @@ def test_envelope_omits_absent_context() -> None:
 def test_code_values_are_stable_contract() -> None:
     """These strings are published to argon; renaming one is a breaking change."""
     assert {c.value for c in ApiErrorCode} == {
+        "invalid_parameter",
+        "internal_error",
         "unsupported_timeframe",
         "unsupported_asset_class",
         "adjusted_not_supported",

--- a/tests/unit/api/test_errors.py
+++ b/tests/unit/api/test_errors.py
@@ -1,0 +1,115 @@
+"""Every failure mode carries a machine-readable code, never a bare 500."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.api.errors import STATUS_BY_CODE, ApiError, ApiErrorCode, api_error_response
+
+
+def test_every_code_has_a_status() -> None:
+    assert set(STATUS_BY_CODE) == set(ApiErrorCode)
+
+
+@pytest.mark.parametrize(
+    ("code", "status"),
+    [
+        (ApiErrorCode.UNSUPPORTED_TIMEFRAME, 400),
+        (ApiErrorCode.UNSUPPORTED_ASSET_CLASS, 400),
+        (ApiErrorCode.ADJUSTED_NOT_SUPPORTED, 400),
+        (ApiErrorCode.UNKNOWN_SYMBOL, 404),
+        (ApiErrorCode.AMBIGUOUS_SYMBOL, 409),
+        (ApiErrorCode.NOT_YET_AVAILABLE, 501),
+        (ApiErrorCode.PROVIDER_NOT_CONFIGURED, 503),
+        (ApiErrorCode.ADJUSTED_UNAVAILABLE, 503),
+    ],
+)
+def test_status_mapping(code: ApiErrorCode, status: int) -> None:
+    assert ApiError(code, "boom").status_code == status
+
+
+def test_adjusted_unavailable_is_503_not_500() -> None:
+    """503 is deliberate: Silver quarantine is an upstream condition livewire may
+    repair, so 'retry later' is the honest semantic."""
+    exc = ApiError(
+        ApiErrorCode.ADJUSTED_UNAVAILABLE,
+        "no Silver artifact; symbol is quarantined upstream",
+        symbol="HON",
+        asset_class="equity",
+    )
+    assert exc.status_code == 503
+
+
+def test_envelope_shape() -> None:
+    exc = ApiError(
+        ApiErrorCode.ADJUSTED_UNAVAILABLE, "quarantined", symbol="HON", asset_class="equity"
+    )
+    body = json.loads(api_error_response(exc).body)
+    assert body == {
+        "error": {
+            "code": "adjusted_unavailable",
+            "message": "quarantined",
+            "symbol": "HON",
+            "asset_class": "equity",
+        }
+    }
+
+
+def test_envelope_omits_absent_context() -> None:
+    body = json.loads(api_error_response(ApiError(ApiErrorCode.PROVIDER_NOT_CONFIGURED, "x")).body)
+    assert body["error"] == {"code": "provider_not_configured", "message": "x"}
+
+
+def test_code_values_are_stable_contract() -> None:
+    """These strings are published to argon; renaming one is a breaking change."""
+    assert {c.value for c in ApiErrorCode} == {
+        "unsupported_timeframe",
+        "unsupported_asset_class",
+        "adjusted_not_supported",
+        "unknown_symbol",
+        "ambiguous_symbol",
+        "not_yet_available",
+        "provider_not_configured",
+        "adjusted_unavailable",
+    }
+
+
+def test_response_status_matches_the_code() -> None:
+    resp = api_error_response(ApiError(ApiErrorCode.AMBIGUOUS_SYMBOL, "two of them", symbol="AAC"))
+    assert resp.status_code == 409
+
+
+def test_handler_is_installed_and_renders_the_envelope() -> None:
+    """Wiring test: a route that raises ApiError must produce the envelope and the
+    mapped status, not a bare 500 from Starlette's default handler."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from src.api.errors import install_error_handlers
+
+    app = FastAPI()
+
+    @app.get("/boom")
+    async def boom() -> dict[str, str]:
+        raise ApiError(ApiErrorCode.ADJUSTED_UNAVAILABLE, "quarantined upstream", symbol="HON")
+
+    install_error_handlers(app)
+
+    response = TestClient(app, raise_server_exceptions=False).get("/boom")
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {
+            "code": "adjusted_unavailable",
+            "message": "quarantined upstream",
+            "symbol": "HON",
+        }
+    }
+
+
+def test_real_app_registers_the_handler() -> None:
+    """create_app() must install it; otherwise every raise becomes a 500 in production."""
+    from src.api.server import create_app
+
+    assert ApiError in create_app().exception_handlers

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -26,6 +28,7 @@ async def test_health_returns_ok():
         "configured": False,
         "configured_price_mode": "raw",
         "effective_price_mode": None,
+        "recency": None,
     }
     # version must reflect the real running build, not a hardcoded literal
     assert data["version"] == APEX_VERSION
@@ -71,4 +74,64 @@ async def test_health_reports_configured_and_effective_price_mode(tmp_path):
         "configured": True,
         "configured_price_mode": "adjusted",
         "effective_price_mode": "adjusted",
+        # A tmp_path provider whose artifacts do not exist: nulls, not an error.
+        "recency": {
+            "bronze_last_trade_date": None,
+            "silver_last_trade_date": None,
+            "lag_days": None,
+        },
     }
+
+
+def test_health_reports_zero_lag_when_silver_matches_bronze(tmp_path: Path) -> None:
+    """Real production state 2026-08-23: bronze and silver are both at 2026-08-21."""
+    import datetime as dt
+
+    import pandas as pd
+
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+    dates = [dt.date(2026, 8, 19), dt.date(2026, 8, 20), dt.date(2026, 8, 21)]
+    ohlc = {
+        "open": [310.140, 317.455, 312.050],
+        "high": [319.2799, 320.2800, 312.3800],
+        "low": [309.60, 310.65, 307.01],
+        "close": [316.83, 311.30, 309.35],
+        "volume": [51405496, 40959127, 48591536],
+    }
+    bronze = tmp_path / "bronze" / "asset_class=equity" / "symbol=AAPL"
+    silver = tmp_path / "silver" / "asset_class=equity" / "symbol=AAPL"
+    for d in (bronze, silver):
+        d.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame({"trade_date": dates, **ohlc}).to_parquet(d / "1d.parquet")
+
+    provider = LivewireOhlcProvider(
+        bronze_root=tmp_path / "bronze", silver_root=tmp_path / "silver", price_mode="adjusted"
+    )
+    recency = provider.get_recency("AAPL")
+    assert recency["bronze_last_trade_date"] == "2026-08-21"
+    assert recency["silver_last_trade_date"] == "2026-08-21"
+    assert recency["lag_days"] == 0
+
+
+def test_recency_is_null_when_artifacts_are_absent(tmp_path: Path) -> None:
+    from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
+
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    assert provider.get_recency("AAPL") == {
+        "bronze_last_trade_date": None,
+        "silver_last_trade_date": None,
+        "lag_days": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_exposes_recency() -> None:
+    """A consumer must be able to see how stale the lake is without a second call."""
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        data = (await client.get("/health")).json()
+    assert "recency" in data["livewire"]
+    # No provider configured in this app, so recency is null rather than absent.
+    assert data["livewire"]["recency"] is None

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -108,7 +108,7 @@ def test_health_reports_zero_lag_when_silver_matches_bronze(tmp_path: Path) -> N
     provider = LivewireOhlcProvider(
         bronze_root=tmp_path / "bronze", silver_root=tmp_path / "silver", price_mode="adjusted"
     )
-    recency = provider.get_recency("AAPL")
+    recency = provider.fetch_recency("AAPL")
     assert recency["bronze_last_trade_date"] == "2026-08-21"
     assert recency["silver_last_trade_date"] == "2026-08-21"
     assert recency["lag_days"] == 0
@@ -118,7 +118,7 @@ def test_recency_is_null_when_artifacts_are_absent(tmp_path: Path) -> None:
     from src.infrastructure.adapters.livewire.ohlc_provider import LivewireOhlcProvider
 
     provider = LivewireOhlcProvider(bronze_root=tmp_path)
-    assert provider.get_recency("AAPL") == {
+    assert provider.fetch_recency("AAPL") == {
         "bronze_last_trade_date": None,
         "silver_last_trade_date": None,
         "lag_days": None,

--- a/tests/unit/application/chart/test_indicator_compute.py
+++ b/tests/unit/application/chart/test_indicator_compute.py
@@ -56,7 +56,13 @@ class _FakeProvider:
         self.calls: List[Tuple[datetime, datetime]] = []
 
     async def fetch_bars(
-        self, symbol: str, timeframe: str, start: datetime, end: datetime
+        self,
+        symbol: str,
+        timeframe: str,
+        start: datetime,
+        end: datetime,
+        asset_class: str = "equity",
+        price_mode: str | None = None,
     ) -> List[BarData]:
         self.calls.append((start, end))
         return [b for b in self._bars if start <= b.timestamp <= end]

--- a/tests/unit/application/test_ta_signal_service_revisions.py
+++ b/tests/unit/application/test_ta_signal_service_revisions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import Any, cast
 
 import pytest
 
@@ -51,7 +52,7 @@ class _RecordingAggregator:
 def _running_service(*, max_ticks: int = 10_000) -> tuple[TASignalService, _RecordingAggregator]:
     service = TASignalService(event_bus=object(), refresh_buffer_max_ticks=max_ticks)
     aggregator = _RecordingAggregator()
-    service._bar_aggregators = {"1m": aggregator}
+    service._bar_aggregators = {"1m": cast(Any, aggregator)}
     service._running = True
     return service, aggregator
 

--- a/tests/unit/infrastructure/livewire/test_asset_classes.py
+++ b/tests/unit/infrastructure/livewire/test_asset_classes.py
@@ -1,0 +1,83 @@
+"""The asset-class registry is the single seam every other layer reads from.
+
+Timeframe ladders are NOT guesses. They were measured exhaustively against the
+production lake (macmini:/Volumes/DATA_LAKE/livewire/data-lake) on 2026-08-23 by
+enumerating every symbol directory in each non-equity partition:
+
+    volatility  44 symbols  union {1d, 1h, 30m, 5m}   (13 carry full intraday)
+    fx          21 symbols  union {1d, 1h, 1m, 30m, 5m}  (all 21 carry it)
+    cmdty        1 symbol   union {1d}
+    futures     14 symbols  union {1d}
+    rates        4 symbols  union {1d}
+
+A registry that declared every non-equity class daily-only would make 126 real
+parquet files unreachable through the API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.infrastructure.adapters.livewire.asset_classes import (
+    ASSET_CLASSES,
+    DEFAULT_ASSET_CLASS,
+    UnknownAssetClass,
+    get_asset_class,
+)
+
+
+def test_all_six_lake_classes_are_registered() -> None:
+    assert set(ASSET_CLASSES) == {"equity", "volatility", "fx", "cmdty", "futures", "rates"}
+
+
+def test_equity_is_the_default_and_the_only_adjusted_class() -> None:
+    assert DEFAULT_ASSET_CLASS == "equity"
+    adjusted = {name for name, spec in ASSET_CLASSES.items() if spec.supports_adjusted}
+    assert adjusted == {"equity"}, "Silver exists only for equity; nothing else may claim adjusted"
+
+
+def test_equity_carries_the_full_intraday_ladder() -> None:
+    assert get_asset_class("equity").timeframes == ("1m", "5m", "30m", "1h", "1d")
+
+
+def test_fx_carries_the_full_intraday_ladder() -> None:
+    """All 21 production FX pairs publish 1m/5m/30m/1h/1d."""
+    assert get_asset_class("fx").timeframes == ("1m", "5m", "30m", "1h", "1d")
+
+
+def test_volatility_carries_intraday_but_no_one_minute() -> None:
+    """Measured union across all 44 volatility symbols: no 1m file exists anywhere."""
+    assert get_asset_class("volatility").timeframes == ("5m", "30m", "1h", "1d")
+
+
+def test_genuinely_daily_only_classes() -> None:
+    for name in ("cmdty", "futures", "rates"):
+        assert get_asset_class(name).timeframes == ("1d",), name
+
+
+def test_partition_matches_the_hive_layout() -> None:
+    assert get_asset_class("futures").partition == "asset_class=futures"
+
+
+def test_rates_uses_the_series_payload_everything_else_uses_bars() -> None:
+    assert get_asset_class("rates").payload == "rates_series"
+    for name in ("equity", "volatility", "fx", "cmdty", "futures"):
+        assert get_asset_class(name).payload == "bars", name
+
+
+def test_futures_declares_its_extra_columns() -> None:
+    assert get_asset_class("futures").extra_bar_fields == ("settlement", "open_interest")
+    assert get_asset_class("equity").extra_bar_fields == ()
+
+
+def test_timeframes_are_ordered_finest_to_coarsest() -> None:
+    """Ordering is load-bearing: error messages list them and consumers render them."""
+    order = ["1m", "5m", "30m", "1h", "1d"]
+    for name, spec in ASSET_CLASSES.items():
+        idx = [order.index(t) for t in spec.timeframes]
+        assert idx == sorted(idx), f"{name} timeframes out of order: {spec.timeframes}"
+
+
+def test_unknown_class_raises() -> None:
+    with pytest.raises(UnknownAssetClass, match="crypto"):
+        get_asset_class("crypto")

--- a/tests/unit/infrastructure/livewire/test_coverage.py
+++ b/tests/unit/infrastructure/livewire/test_coverage.py
@@ -1,0 +1,97 @@
+"""Discovery reads livewire's coverage snapshot, not a filesystem walk.
+
+A recursive scan of ~14.7K symbol dirs on the external volume is not viable
+per-request -- measured 2026-08-23 on the production lake, one scandir of
+bronze/asset_class=equity takes 5.5s and descending into symbols to read date
+ranges costs 78ms each (~19 minutes for the full set). The lake also carries
+macOS AppleDouble siblings (._symbol=DXY) that break a naive listdir join.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.infrastructure.adapters.livewire.coverage import CoverageCatalog, CoverageUnavailable
+
+
+def test_lists_every_asset_class(catalog_db: Path) -> None:
+    rows = CoverageCatalog(catalog_db).list_instruments()
+    assert {r.asset_class for r in rows} == {"equity", "volatility", "rates"}
+
+
+def test_silver_available_flags_the_symbols_that_would_503(catalog_db: Path) -> None:
+    """HON has bronze but no silver -- adjusted mode 503s on it. Consumers must be
+    able to learn that up front instead of by making the request."""
+    by_symbol = {r.symbol: r for r in CoverageCatalog(catalog_db).list_instruments()}
+    assert by_symbol["AAPL"].silver_available is True
+    assert by_symbol["HON"].silver_available is False
+
+
+def test_non_equity_is_always_raw(catalog_db: Path) -> None:
+    by_symbol = {r.symbol: r for r in CoverageCatalog(catalog_db).list_instruments()}
+    assert by_symbol["VIX"].price_mode == "raw"
+
+
+def test_filter_by_asset_class(catalog_db: Path) -> None:
+    rows = CoverageCatalog(catalog_db).list_instruments(asset_class="rates")
+    assert [r.symbol for r in rows] == ["DGS10"]
+
+
+def test_query_filters_by_symbol_prefix(catalog_db: Path) -> None:
+    rows = CoverageCatalog(catalog_db).list_instruments(query="AAP")
+    assert [r.symbol for r in rows] == ["AAPL"]
+
+
+def test_query_escapes_like_wildcards(catalog_db: Path) -> None:
+    """'_' is a LIKE wildcard and futures symbols contain it (BZ_202609).
+    Verified against the production catalog: LIKE 'BRK_B' matches 'BRK.B'."""
+    assert CoverageCatalog(catalog_db).list_instruments(query="A_PL") == []
+
+
+def test_missing_database_raises_rather_than_reporting_an_empty_universe() -> None:
+    """An absent catalog must NOT look like "apex holds nothing".
+
+    Verified on the mini 2026-08-23: binding a catalog path that is outside colima's
+    VM mount set produces an empty directory in the container, not the database. If
+    that degraded to an empty list, a broken deployment would be indistinguishable
+    from a genuinely empty lake -- and a consumer would cache the wrong answer.
+    """
+    with pytest.raises(CoverageUnavailable):
+        CoverageCatalog(Path("/nonexistent/nope.duckdb")).list_instruments()
+
+
+def test_a_directory_at_the_db_path_raises(tmp_path: Path) -> None:
+    """This is the EXACT production failure mode: Docker fabricates a directory when
+    the bind source is unreachable, and Path.exists() returns True for a directory."""
+    fake = tmp_path / "analytics.duckdb"
+    fake.mkdir()
+    with pytest.raises(CoverageUnavailable):
+        CoverageCatalog(fake).list_instruments()
+
+
+def test_empty_but_valid_catalog_is_not_an_error(tmp_path: Path) -> None:
+    """A real catalog with no matching rows is a legitimate empty result."""
+    import duckdb
+
+    db = tmp_path / "analytics.duckdb"
+    con = duckdb.connect(str(db))
+    con.execute(
+        "CREATE TABLE coverage (view_name VARCHAR, symbol VARCHAR, n_rows BIGINT, "
+        "first_date DATE, last_date DATE)"
+    )
+    con.close()
+    assert CoverageCatalog(db).list_instruments() == []
+
+
+def test_opens_read_only(catalog_db: Path) -> None:
+    """The catalog is mounted :ro in production; a read-write connect would fail."""
+    import os
+    import stat
+
+    os.chmod(catalog_db, stat.S_IRUSR)
+    try:
+        assert CoverageCatalog(catalog_db).list_instruments()
+    finally:
+        os.chmod(catalog_db, stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -347,3 +347,179 @@ def test_provider_satisfies_historical_source_port(bronze_root: Path) -> None:
     assert p.source_name == "livewire"
     assert p.supports_timeframe("1d") is True
     assert p.supports_timeframe("3m") is False
+
+
+# --- Task 5: per-asset-class reads -------------------------------------------------
+#
+# Fixture values are REAL production bars frozen 2026-08-23 from
+# macmini:/Volumes/DATA_LAKE/livewire/data-lake. Do not round or extend them.
+
+_AC_START = datetime(2026, 8, 1, tzinfo=timezone.utc)
+_AC_END = datetime(2026, 8, 31, tzinfo=timezone.utc)
+
+
+def _write_vix(root: Path) -> None:
+    """Real CBOE VIX daily bars from bronze/asset_class=volatility."""
+    d = root / "asset_class=volatility" / "symbol=VIX"
+    d.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "trade_date": [dt.date(2026, 8, 19), dt.date(2026, 8, 20), dt.date(2026, 8, 21)],
+            "symbol_id": [13486153039336466] * 3,
+            "open": [15.92, 14.91, 15.82],
+            "high": [15.95, 16.14, 15.88],
+            "low": [14.77, 14.91, 15.08],
+            "close": [14.89, 16.01, 15.13],
+            "adj_close": [14.89, 16.01, 15.13],
+            "volume": [0, 0, 0],
+        }
+    ).to_parquet(d / "1d.parquet")
+
+
+def _write_futures(root: Path) -> None:
+    """Real ICE Brent BZ_202609 daily bars from bronze/asset_class=futures."""
+    d = root / "asset_class=futures" / "symbol=BZ_202609"
+    d.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "trade_date": [dt.date(2026, 7, 1), dt.date(2026, 7, 2)],
+            "contract_id": [3871332472656972] * 2,
+            "root_symbol": ["BZ", "BZ"],
+            "expiry_date": [dt.date(2026, 9, 1)] * 2,
+            "open": [71.86, 70.78],
+            "high": [72.23, 71.91],
+            "low": [71.04, 70.44],
+            "close": [71.57, 71.80],
+            "settlement": [71.57, 71.80],
+            "volume": [7303, 5353],
+            "open_interest": [0, 0],
+        }
+    ).to_parquet(d / "1d.parquet")
+
+
+def _write_dxy_hourly(root: Path) -> None:
+    """Real DXY 1h bars from bronze/asset_class=fx. All 21 FX pairs carry intraday."""
+    d = root / "asset_class=fx" / "symbol=DXY"
+    d.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "bar_timestamp": pd.to_datetime(
+                [
+                    "2026-08-21T18:00:00Z",
+                    "2026-08-21T19:00:00Z",
+                    "2026-08-21T20:00:00Z",
+                ]
+            ),
+            "symbol_id": [1919363639481568] * 3,
+            "open": [98.81700134277344, 98.80000305175781, 98.83100128173828],
+            "high": [98.82099914550781, 98.83799743652344, 98.85900115966797],
+            "low": [98.78800201416016, 98.7969970703125, 98.82499694824219],
+            "close": [98.80000305175781, 98.83200073242188, 98.83899688720703],
+            "volume": [0, 0, 0],
+        }
+    ).to_parquet(d / "1h.parquet")
+
+
+@pytest.mark.asyncio
+async def test_volatility_reads_its_own_partition(tmp_path: Path) -> None:
+    _write_vix(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars("VIX", "1d", _AC_START, _AC_END, asset_class="volatility")
+    assert [b.close for b in bars] == [14.89, 16.01, 15.13]
+
+
+@pytest.mark.asyncio
+async def test_equity_partition_is_not_consulted_for_volatility(tmp_path: Path) -> None:
+    _write_vix(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    # No asset_class=equity/symbol=VIX exists; the default class must miss, not fall through.
+    assert await provider.fetch_bars("VIX", "1d", _AC_START, _AC_END) == []
+
+
+@pytest.mark.asyncio
+async def test_futures_reads_composite_contract_symbol(tmp_path: Path) -> None:
+    _write_futures(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars(
+        "BZ_202609",
+        "1d",
+        datetime(2026, 7, 1, tzinfo=timezone.utc),
+        datetime(2026, 7, 31, tzinfo=timezone.utc),
+        asset_class="futures",
+    )
+    assert [b.close for b in bars] == [71.57, 71.80]
+
+
+@pytest.mark.asyncio
+async def test_futures_carries_its_extra_columns(tmp_path: Path) -> None:
+    """settlement/open_interest/contract identity are real columns livewire publishes;
+    dropping them would make the futures payload indistinguishable from an equity one."""
+    _write_futures(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars(
+        "BZ_202609",
+        "1d",
+        datetime(2026, 7, 1, tzinfo=timezone.utc),
+        datetime(2026, 7, 31, tzinfo=timezone.utc),
+        asset_class="futures",
+    )
+    first = bars[0]
+    assert first.settlement == 71.57
+    assert first.open_interest == 0
+    assert first.root_symbol == "BZ"
+    assert first.contract_id == 3871332472656972
+    # ISO string, not a date: DomainEvent.to_dict() only special-cases datetime and Enum.
+    assert first.expiry_date == "2026-09-01"
+    assert isinstance(first.expiry_date, str)
+
+
+@pytest.mark.asyncio
+async def test_fx_intraday_reads_bar_timestamp(tmp_path: Path) -> None:
+    """fx publishes the full 1m/5m/30m/1h/1d ladder on all 21 pairs, keyed by
+    bar_timestamp exactly like equity intraday."""
+    _write_dxy_hourly(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars(
+        "DXY",
+        "1h",
+        datetime(2026, 8, 21, tzinfo=timezone.utc),
+        datetime(2026, 8, 22, tzinfo=timezone.utc),
+        asset_class="fx",
+    )
+    assert [b.close for b in bars] == [
+        98.80000305175781,
+        98.83200073242188,
+        98.83899688720703,
+    ]
+    assert bars[0].bar_start == datetime(2026, 8, 21, 18, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_non_equity_is_raw_even_when_provider_is_adjusted(tmp_path: Path) -> None:
+    """Silver exists only for equity. An adjusted-mode provider must serve non-equity
+    raw and say so, not raise AdjustedDataUnavailable."""
+    _write_vix(tmp_path)
+    provider = LivewireOhlcProvider(
+        bronze_root=tmp_path, silver_root=tmp_path / "silver", price_mode="adjusted"
+    )
+    assert provider.effective_price_mode("volatility") == "raw"
+    assert provider.effective_price_mode("equity") == "adjusted"
+    bars = await provider.fetch_bars("VIX", "1d", _AC_START, _AC_END, asset_class="volatility")
+    assert len(bars) == 3
+
+
+@pytest.mark.asyncio
+async def test_explicit_adjusted_on_non_equity_raises(tmp_path: Path) -> None:
+    """An explicit per-call override must not silently downgrade to raw."""
+    _write_vix(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    with pytest.raises(AdjustedDataUnavailable, match="volatility"):
+        await provider.fetch_bars(
+            "VIX", "1d", _AC_START, _AC_END, asset_class="volatility", price_mode="adjusted"
+        )
+
+
+def test_delisted_root_defaults_to_none(tmp_path: Path) -> None:
+    assert LivewireOhlcProvider(bronze_root=tmp_path).delisted_root is None
+    provider = LivewireOhlcProvider(bronze_root=tmp_path, delisted_root=tmp_path / "d")
+    assert provider.delisted_root == tmp_path / "d"

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -523,3 +523,43 @@ def test_delisted_root_defaults_to_none(tmp_path: Path) -> None:
     assert LivewireOhlcProvider(bronze_root=tmp_path).delisted_root is None
     provider = LivewireOhlcProvider(bronze_root=tmp_path, delisted_root=tmp_path / "d")
     assert provider.delisted_root == tmp_path / "d"
+
+
+def _write_dgs10(root: Path) -> None:
+    """Real FRED DGS10 rows, frozen 2026-08-23 from bronze/asset_class=rates."""
+    d = root / "asset_class=rates" / "symbol=DGS10"
+    d.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "trade_date": [dt.date(2026, 8, 18), dt.date(2026, 8, 19), dt.date(2026, 8, 20)],
+            "symbol_id": [5866486538776591] * 3,
+            "tenor_years": [10.0, 10.0, 10.0],
+            "yield_pct": [4.71, 4.65, 4.69],
+            "source": ["fred", "fred", "fred"],
+        }
+    ).to_parquet(d / "1d.parquet")
+
+
+@pytest.mark.asyncio
+async def test_rates_series_returns_yields_not_bars(tmp_path: Path) -> None:
+    _write_dgs10(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    points = await provider.fetch_rate_series("DGS10", _AC_START, _AC_END)
+    assert [p.yield_pct for p in points] == [4.71, 4.65, 4.69]
+    assert {p.tenor_years for p in points} == {10.0}
+
+
+@pytest.mark.asyncio
+async def test_rates_series_is_empty_when_absent(tmp_path: Path) -> None:
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    assert await provider.fetch_rate_series("DGS10", _AC_START, _AC_END) == []
+
+
+@pytest.mark.asyncio
+async def test_rates_through_fetch_bars_yields_no_ohlc(tmp_path: Path) -> None:
+    """A rates row has no open/high/low/close. Reading it as bars produces all-None
+    OHLC, which is exactly why rates gets its own route and payload."""
+    _write_dgs10(tmp_path)
+    provider = LivewireOhlcProvider(bronze_root=tmp_path)
+    bars = await provider.fetch_bars("DGS10", "1d", _AC_START, _AC_END, asset_class="rates")
+    assert bars and all(b.close is None for b in bars)

--- a/tests/unit/infrastructure/livewire/test_ohlc_provider.py
+++ b/tests/unit/infrastructure/livewire/test_ohlc_provider.py
@@ -563,3 +563,44 @@ async def test_rates_through_fetch_bars_yields_no_ohlc(tmp_path: Path) -> None:
     provider = LivewireOhlcProvider(bronze_root=tmp_path)
     bars = await provider.fetch_bars("DGS10", "1d", _AC_START, _AC_END, asset_class="rates")
     assert bars and all(b.close is None for b in bars)
+
+
+@pytest.mark.asyncio
+async def test_unknown_symbol_in_adjusted_mode_is_empty_not_quarantined(tmp_path: Path) -> None:
+    """A ticker with neither Bronze nor Silver does not exist -- the route must be able
+    to answer 404. Raising AdjustedDataUnavailable would answer a typo with 503
+    "retry later", and the caller would retry forever.
+
+    Caught by production verification against the real lake on 2026-08-23.
+    """
+    provider = LivewireOhlcProvider(
+        bronze_root=tmp_path / "bronze",
+        silver_root=tmp_path / "silver",
+        price_mode="adjusted",
+    )
+    assert await provider.fetch_bars("NOTAREALTICKER", "1d", _AC_START, _AC_END) == []
+
+
+@pytest.mark.asyncio
+async def test_bronze_without_silver_still_raises(tmp_path: Path) -> None:
+    """The genuinely-quarantined case must keep its 503: the symbol exists in Bronze
+    but has no Silver artifact. 243 production symbols are in this state."""
+    bronze = tmp_path / "bronze" / "asset_class=equity" / "symbol=HON"
+    bronze.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "trade_date": [dt.date(2026, 8, 21)],
+            "open": [200.0],
+            "high": [201.0],
+            "low": [199.0],
+            "close": [200.5],
+            "volume": [1000],
+        }
+    ).to_parquet(bronze / "1d.parquet")
+    provider = LivewireOhlcProvider(
+        bronze_root=tmp_path / "bronze",
+        silver_root=tmp_path / "silver",
+        price_mode="adjusted",
+    )
+    with pytest.raises(AdjustedDataUnavailable, match="HON"):
+        await provider.fetch_bars("HON", "1d", _AC_START, _AC_END)

--- a/tests/unit/infrastructure/livewire/test_paths.py
+++ b/tests/unit/infrastructure/livewire/test_paths.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 import pytest
 
+from src.infrastructure.adapters.livewire.asset_classes import UnknownAssetClass
 from src.infrastructure.adapters.livewire.paths import (
     SUPPORTED_TIMEFRAMES,
+    UnsupportedTimeframe,
     daily_silver_path,
+    delisted_bronze_path,
     encode_symbol,
     factor_path,
     parquet_path,
@@ -54,3 +57,72 @@ def test_unsupported_timeframe_raises() -> None:
 
 def test_supported_timeframes_match_livewire() -> None:
     assert SUPPORTED_TIMEFRAMES == ("1m", "5m", "30m", "1h", "1d")
+
+
+def test_parquet_path_defaults_to_equity() -> None:
+    root = Path("/data/bronze")
+    assert parquet_path(root, "AAPL", "1d") == (
+        root / "asset_class=equity" / "symbol=AAPL" / "1d.parquet"
+    )
+
+
+def test_parquet_path_resolves_each_asset_class() -> None:
+    root = Path("/data/bronze")
+    assert parquet_path(root, "VIX", "1d", "volatility") == (
+        root / "asset_class=volatility" / "symbol=VIX" / "1d.parquet"
+    )
+    assert parquet_path(root, "DGS10", "1d", "rates") == (
+        root / "asset_class=rates" / "symbol=DGS10" / "1d.parquet"
+    )
+    assert parquet_path(root, "BZ_202609", "1d", "futures") == (
+        root / "asset_class=futures" / "symbol=BZ_202609" / "1d.parquet"
+    )
+    assert parquet_path(root, "XAUUSD", "1d", "cmdty") == (
+        root / "asset_class=cmdty" / "symbol=XAUUSD" / "1d.parquet"
+    )
+
+
+def test_fx_intraday_resolves() -> None:
+    """All 21 production FX pairs publish the full ladder; rejecting it would
+    make 84 real parquet files unreachable."""
+    root = Path("/data/bronze")
+    for timeframe in ("1m", "5m", "30m", "1h"):
+        assert parquet_path(root, "DXY", timeframe, "fx") == (
+            root / "asset_class=fx" / "symbol=DXY" / f"{timeframe}.parquet"
+        )
+
+
+def test_volatility_serves_intraday_but_not_one_minute() -> None:
+    """Measured union across all 44 volatility symbols: 5m/30m/1h/1d, never 1m."""
+    root = Path("/data/bronze")
+    assert parquet_path(root, "VIX", "5m", "volatility") == (
+        root / "asset_class=volatility" / "symbol=VIX" / "5m.parquet"
+    )
+    with pytest.raises(UnsupportedTimeframe, match="volatility"):
+        parquet_path(root, "VIX", "1m", "volatility")
+
+
+def test_intraday_is_rejected_for_daily_only_classes() -> None:
+    for asset_class, symbol in (("cmdty", "XAUUSD"), ("futures", "BZ_202609"), ("rates", "DGS10")):
+        with pytest.raises(UnsupportedTimeframe, match=asset_class):
+            parquet_path(Path("/data/bronze"), symbol, "1h", asset_class)
+
+
+def test_unknown_asset_class_raises() -> None:
+    with pytest.raises(UnknownAssetClass):
+        parquet_path(Path("/data/bronze"), "AAPL", "1d", "crypto")
+
+
+def test_delisted_path_layout() -> None:
+    root = Path("/data/bronze-delisted")
+    assert delisted_bronze_path(root, "BBBY", "1d") == (
+        root / "asset_class=equity" / "symbol=BBBY" / "1d.parquet"
+    )
+
+
+def test_delisted_path_is_not_equity_only() -> None:
+    """bronze-delisted holds asset_class=equity (8620) and asset_class=fx (USDEUR)."""
+    root = Path("/data/bronze-delisted")
+    assert delisted_bronze_path(root, "USDEUR", "1d", "fx") == (
+        root / "asset_class=fx" / "symbol=USDEUR" / "1d.parquet"
+    )


### PR DESCRIPTION
> **Stacked on #156** — base is `fix/deploy-compose-drift`, which declares the delisted mount this
> PR reads. #156 must merge *and deploy* first; GitHub will retarget this to `master` automatically.

**Spec:** `docs/superpowers/specs/2026-08-22-apex-datalake-api-design.md`
**Plan:** `docs/superpowers/plans/2026-08-22-apex-datalake-api.md` (13 tasks, all complete)

## Why

apex reads one asset class out of a lake that holds seven. `/bars/{ticker}` hardcodes
`asset_class=equity` into the parquet path, so a request for `VIX`, `EURUSD` or `BZ_202609`
resolves to a file that does not exist and returns an empty payload — indistinguishable from
"this symbol had no trades". There is no way to ask what apex holds, and every failure is an
untyped 500 or a bare string detail.

## What this adds

**A `/v1/{asset_class}/...` surface** over all six OHLC-bearing classes:

| Class | Symbols | Timeframes | Adjusted? |
|---|---|---|---|
| `equity` | ~14.7k listed + 8.6k delisted | 1m 5m 30m 1h 1d | yes |
| `fx` | 21 | 1m 5m 30m 1h 1d | no |
| `volatility` | 44 | 5m 30m 1h 1d | no |
| `cmdty` | 1 | 1d | no |
| `futures` | 14 | 1d | no |
| `rates` | 4 | — (yield series) | no |

- `/v1/{asset_class}/{symbol}/bars`, `/indicators`, `/confluence`
- `/v1/rates/{symbol}/series` — a Treasury yield has no OHLC, so it gets its own payload shape
- `/v1/instruments` and `/v1/{asset_class}/{symbol}` for discovery
- `/v1/equity/{symbol}/signals`
- `/v1/equity/{symbol}/actions` and `/delisting` — **specified and returning a typed 501**, so
  argon can code against the contract before livewire publishes the data

**A typed error envelope** on every failure — 8 machine-readable codes
(`unsupported_timeframe`, `unknown_symbol`, `adjusted_not_supported`, `adjusted_unavailable`,
`provider_not_configured`, `unsupported_asset_class`, `ambiguous_symbol`, `not_yet_available`)
so a client can distinguish "retry later" from "you asked for something that cannot exist".

**Truthful payloads** — `price_mode`, `listing_status`, `asset_class`, `adjustment_revision` on
every bars response; futures carry `settlement`, `open_interest` and contract identity; `vwap` is
gone (it was always null — no parquet in the lake carries the column).

**Flat routes stay, deprecated.** `/bars/{ticker}` etc. are aliases sharing one implementation and
emitting `Deprecation: true`, `Sunset: Wed, 31 Dec 2026 23:59:59 GMT`, and a `Link` to the
successor. Nothing argon calls today breaks.

## Two places the plan was wrong, corrected by measuring production

**1. The timeframe table.** The plan declared every non-equity class daily-only. An exhaustive
enumeration of the real lake showed fx carries the full `1m/5m/30m/1h/1d` ladder on **all 21
pairs**, and volatility carries `5m/30m/1h/1d` on 13 of 44 symbols. Implementing the plan verbatim
would have made **126 real parquet files unreachable**. The registry
(`src/infrastructure/adapters/livewire/asset_classes.py`) encodes the measured ladders.

**2. The coverage catalog.** The plan assumed it could be bind-mounted. It cannot (see #156). The
reader is therefore hardened rather than optimistic: it checks `is_file()` — a broken mount leaves
a *directory*, which `exists()` accepts — and **raises** `CoverageUnavailable` instead of
returning `[]`, so a misconfiguration can never masquerade as "apex holds nothing".
`/v1/instruments` will return `503 provider_not_configured` in production until livewire relocates
the catalog.

## A real bug found by running against production

`/v1/equity/NOTAREALTICKER/bars` in adjusted mode returned **503 `adjusted_unavailable`** — the
missing Silver artifact raised before anything checked whether the symbol existed. A client would
retry a typo forever. It now returns 404; the 243 genuinely quarantined symbols still get their
503. Fixed in `ohlc_provider.py` with two regression tests.

## Review cycle

A full `/review-cycle` on this diff (self-review → Codex tribunal → adversarial → simplicity →
cumulative re-read → assumption check) surfaced **13 more issues**, all fixed here. The theme is
the same one the PR is about — *a request that cannot succeed must not come back looking like
data*:

| Fixed | Was |
|---|---|
| Unknown symbol on `/indicators` and `/rates/../series` | `200` with zero rows — reads as "no signal fired" |
| Unknown `indicator` | `404 unknown_symbol` on a symbol that was fine |
| `/indicators` on `rates` | computed over a yield's null OHLC and returned numbers |
| `start` after `end` | `200` with zero rows |
| `listing=any` | always probed the **equity** partition, so fx ticker reuse read as unambiguous |
| Artifact probe | Bronze-only, so a Silver-only symbol with an empty window was a false `404` |
| Bad query value | named the symbol or livewire instead of the parameter (new `invalid_parameter`) |
| FastAPI's own 422 | a second, undocumented error shape (`{"detail": …}`) on the same surface |
| Any unhandled exception | untyped `500`; the lake is on an **external volume**, so DuckDB *will* raise (new `internal_error`, and it no longer echoes lake paths) |
| Coverage DuckDB reads | ran inline, stalling the event loop |
| `extra_bar_fields` | declared in the registry and never read — a 7th class would have been silently ignored |
| Malformed request with no provider | `503` "retry later" for a `4h` timeframe that will never exist |
| Null `first_date` on detail | ambiguous between "no coverage" and "catalog unreadable" (new `coverage_source`) |

Two Codex findings were **rejected**: it read "flat aliases are byte-identical" as backward
compatibility with 0.1.3, but the spec means identical *to the v1 route* and mandates dropping
`vwap` globally (CHANGELOG records the break); and it argued `adjustment_revision` should come
from the artifact rather than the revision watcher, which is what the spec explicitly specifies.

Gemini was unavailable (no license on this machine), so the tribunal was Codex-only.

`chart.py` crossed the 500-line budget during these fixes, so the request guards moved to
`_chart_guards.py` — the seam the spec named. 349 + 211 lines.

## Verification

| Claim | Evidence | Re-verify |
|---|---|---|
| Every `/v1` route works on real data | **73/73** e2e through the real ASGI app over the real lake | see below |
| All 6 asset classes serve real bars | equity, fx, volatility, cmdty, futures at their real ladders | " |
| Every error code is reachable | all 10 provoked against production, each returning its own code | " |
| The coverage catalog works when reachable | `/v1/instruments` served real rows; `q=BZ_` matched only real `BZ_` contracts (LIKE escaping) | " |
| A broken mount fails closed | catalog pointed at an empty **directory** → `503`, never an empty universe | " |
| Dual residency is real | `AACT` exists in both trees → `409`; same ticker at `1h` serves | " |
| Ladders are per-**symbol**, not just per-class | `AACT` has `1m/5m/30m/1h` and no `1d` in the live tree | " |
| Lake schemas match the frozen fixtures | 7/7 column sets + date ranges identical | `DESCRIBE SELECT * FROM read_parquet(...)` |
| Suite green | **2207 passed, 88 skipped** | `SKIP_NETWORK_TESTS=1 uv run pytest tests/unit/ tests/integration/ -q` |
| Types clean | no issues in 726 files | `make type-check` |
| Lint clean | exit 0 | `make lint` |
| No dead code / complexity regression | vulture silent, radon avg **A** | `make quality` |

The production check was read-only: branch source rsynced to `/tmp/apex-verify` on the mini, two
scripts run against the live lake, scratch files removed afterwards. No writes, no config changes.

`SKIP_NETWORK_TESTS=1` is required locally — two validation-runner tests hit Yahoo at runtime and
are correctly marked `@skip_network`, which keys on `CI=true` (set automatically in CI) or that
variable.
